### PR TITLE
Always add the en-US locale fallback for translations (bug 988376)

### DIFF
--- a/apps/translations/tests/test_models.py
+++ b/apps/translations/tests/test_models.py
@@ -119,6 +119,26 @@ class TranslationTestCase(TestCase):
         finally:
             translation.deactivate()
 
+    @patch.object(TranslatedModel, 'get_fallback', create=True)
+    def test_fetch_translation_prioritized(self, get_fallback):
+        """Fallback locale in following order: asked/fallback/en-us/random."""
+        get_model = lambda: TranslatedModel.objects.no_cache().get(id=1)
+
+        # Asked for DE, which exists.
+        with translation.override('de'):
+            o = get_model()
+            trans_eq(o.name, 'German!! (unst unst)', 'de')
+
+        # Asked for FR (doesn't exist):
+        with translation.override('fr'):
+            # Use fallback (DE) instead.
+            get_fallback.return_value = 'de'
+            o = get_model()
+            trans_eq(o.name, 'German!! (unst unst)', 'de')
+
+            # Fallback doesn't exist, use EN-US instead.
+            trans_eq(o.description, 'some description', 'en-US')
+
     def test_create_translation(self):
         o = TranslatedModel.objects.create(name='english name')
         get_model = lambda: TranslatedModel.objects.get(id=o.id)
@@ -154,7 +174,6 @@ class TranslationTestCase(TestCase):
         english = get_model()
         trans_eq(english.name, 'english name', 'en-US')
         english.debug = True
-        eq_(english.description, None)
 
         english.description = 'english description'
         english.save()
@@ -256,7 +275,14 @@ class TranslationTestCase(TestCase):
     def test_sorting_mixed(self):
         translation.activate('de')
         q = TranslatedModel.objects.all()
-        expected = [1, 4, 3]
+        expected = [5, 1, 4, 3]
+
+        eq_(ids(order_by_translation(q, 'name')), expected)
+        eq_(ids(order_by_translation(q, '-name')), list(reversed(expected)))
+
+        translation.activate('fr')
+        q = TranslatedModel.objects.no_cache().all()
+        expected = [3, 4, 1]
 
         eq_(ids(order_by_translation(q, 'name')), expected)
         eq_(ids(order_by_translation(q, '-name')), list(reversed(expected)))
@@ -267,7 +293,7 @@ class TranslationTestCase(TestCase):
 
         translation.activate('de')
         q = TranslatedModel.objects.all()
-        expected = [3, 1, 4]
+        expected = [5, 3, 1, 4]
 
         eq_(ids(order_by_translation(q, 'name')), expected)
         eq_(ids(order_by_translation(q, '-name')), list(reversed(expected)))
@@ -353,7 +379,7 @@ class TranslationTestCase(TestCase):
             '.html</a> .')
         eq_(m.linkified.localized_string, s)
 
-    def test_require_locale(self):
+    def test_any_locale(self):
         obj = TranslatedModel.objects.get(id=1)
         eq_(unicode(obj.no_locale), 'blammo')
         eq_(obj.no_locale.locale, 'en-US')

--- a/apps/translations/tests/testapp/fixtures/testapp/test_models.json
+++ b/apps/translations/tests/testapp/fixtures/testapp/test_models.json
@@ -70,6 +70,17 @@
         }
     },
     {
+        "pk": 7,
+        "model": "translations.translation",
+        "fields": {
+            "id": 5,
+            "locale": "de",
+            "localized_string": "Deutsch name",
+            "created": "2007-03-05 16:06:55",
+            "modified": "2007-03-21 13:42:36"
+        }
+    },
+    {
         "pk": 10,
         "model": "translations.translation",
         "fields": {
@@ -133,6 +144,18 @@
         "fields": {
             "id": 4,
             "name": 4,
+            "description": null,
+            "default_locale": "en-US",
+            "created": "2007-03-05 16:06:55",
+            "modified": "2007-03-21 13:42:36"
+        }
+    },
+    {
+        "pk": 5,
+        "model": "testapp.translatedmodel",
+        "fields": {
+            "id": 5,
+            "name": 5,
             "description": null,
             "default_locale": "en-US",
             "created": "2007-03-05 16:06:55",

--- a/apps/translations/transformer.py
+++ b/apps/translations/transformer.py
@@ -1,57 +1,84 @@
-from django.conf import settings
-from django.db import connections, models, router
-from django.utils import translation
+from django.db import connections, router
 
-from translations.models import Translation
 from translations.fields import TranslatedField
+from translations.models import Translation
+from translations.query import get_locales
 
-isnull = """IF(!ISNULL({t1}.localized_string), {t1}.{col}, {t2}.{col})
-            AS {name}_{col}"""
-join = """LEFT OUTER JOIN translations {t}
-          ON ({t}.id={model}.{name} AND {t}.locale={locale})"""
-no_locale_join = """LEFT OUTER JOIN translations {t}
-                    ON {t}.id={model}.{name}"""
+
+isnull_tpl = """IF(!ISNULL({alias}.localized_string),
+                   {alias}.{col},
+                   {else_})"""
+join_tpl = """LEFT OUTER JOIN translations {alias}
+                   ON ({alias}.id={model}.{name} AND
+                       {alias}.locale={locale})"""
+no_locale_join_tpl = """LEFT OUTER JOIN translations {alias}
+                             ON {alias}.id={model}.{name}"""
 
 trans_fields = [f.name for f in Translation._meta.fields]
 
 
 def build_query(model, connection):
+    """Build the query to retrieve translations for a given model.
+
+    We will try to find a translation for locales in the following order:
+    1. The active language
+    2. The fallback locale if provided by the model via get_fallback()
+    3. settings.LANGUAGE_CODE
+
+    Only try a locale if it hasn't been tried before, to optimize the number of
+    joins.
+
+    Eg, if the active language is 'en-US' and there's no fallback locale for
+    the model (no ``get_fallback()`` method), then we're only doing one join
+    for 'en-US' (active language and settings.LANGUAGE_CODE).
+
+    This code is a bit like the one in translations.query.order_by_translation,
+    but uses a different API.
+
+    Fun(?) project: see if it's possible to factorize the code, and/or use the
+    same API for both.
+
+    """
     qn = connection.ops.quote_name
     selects, joins, params = [], [], []
 
-    # The model can define a fallback locale (which may be a Field).
-    if hasattr(model, 'get_fallback'):
-        fallback = model.get_fallback()
-    else:
-        fallback = settings.LANGUAGE_CODE
-
+    # Populate the model._meta.translated_fields if needed.
     if not hasattr(model._meta, 'translated_fields'):
         model._meta.translated_fields = [f for f in model._meta.fields
                                          if isinstance(f, TranslatedField)]
 
+    # Get the locales to try.
+    locale_strings, locale_params = get_locales(model, qn)
+
     # Add the selects and joins for each translated field on the model.
     for field in model._meta.translated_fields:
-        if isinstance(fallback, models.Field):
-            fallback_str = '%s.%s' % (qn(model._meta.db_table),
-                                      qn(fallback.column))
-        else:
-            fallback_str = '%s'
-
         name = field.column
-        d = {'t1': 't1_' + name, 't2': 't2_' + name,
-             'model': qn(model._meta.db_table), 'name': name}
+        d = {'model': qn(model._meta.db_table), 'name': name}
 
-        selects.extend(isnull.format(col=f, **d) for f in trans_fields)
+        # Add the selects and joins for each locale to try, for this field.
+        isnull = isnull_tpl
+        for i, locale in enumerate(locale_strings):
+            alias = 't{0}_{1}'.format(i, name)  # DB alias for the join.
+            # Inception: we need the "else" clause to be another "isnull"
+            # element. We replace {col} with itself, as we're not ready to fill
+            # that in yet, it'll be done when building the ``selects`` below.
+            isnull = isnull.format(alias=alias, else_=isnull_tpl, col='{col}')
 
-        joins.append(join.format(t=d['t1'], locale='%s', **d))
-        params.append(translation.get_language())
+            joins.append(join_tpl.format(alias=alias, locale=locale, **d))
+        # Append all the "locale params" for this run.
+        params.extend(locale_params)
 
-        if field.require_locale:
-            joins.append(join.format(t=d['t2'], locale=fallback_str, **d))
-            if not isinstance(fallback, models.Field):
-                params.append(fallback)
-        else:
-            joins.append(no_locale_join.format(t=d['t2'], **d))
+        # If the field has require_locale=False, return just any translation
+        # regardless of its locale.
+        if not field.require_locale:
+            alias = 't{0}_{1}'.format(i + 1, name)
+            joins.append(no_locale_join_tpl.format(alias=alias, **d))
+
+        # End of the "inception" here for the else clause.
+        else_ = '{alias}.{col}'.format(alias=alias, col='{col}')
+        isnull = isnull.format(alias=alias, else_=else_, col='{col}')
+
+        selects.extend(isnull.format(col=f) for f in trans_fields)
 
     # ids will be added later on.
     sql = """SELECT {model}.{pk}, {selects} FROM {model} {joins}
@@ -66,8 +93,8 @@ def get_trans(items):
         return
 
     model = items[0].__class__
-    # FIXME: if we knew which db the queryset we are transforming used, we could
-    # make sure we are re-using the same one.
+    # FIXME: if we knew which db the queryset we are transforming used,
+    # we could make sure we are re-using the same one.
     dbname = router.db_for_read(model)
     connection = connections[dbname]
     sql, params = build_query(model, connection)


### PR DESCRIPTION
fix [bug 988376](https://bugzilla.mozilla.org/show_bug.cgi?id=988376)

This is based on PR #18 which can't be merged because of the "last chance callback" requiring a too big performance hit because of the needed "group by".

In this PR, we still have most of the behavior described in #18, but without the "last chance fallback":

Check the following locales in order
  1. the active language
  2. the model fallback provided by the ```get_fallback()``` method (if it exists)
  3. ```settings.LANGUAGE_CODE```