### PR TITLE
add ownership changes to the editor tools (bug 712682)

### DIFF
--- a/apps/devhub/tests/test_views_ownership.py
+++ b/apps/devhub/tests/test_views_ownership.py
@@ -2,6 +2,8 @@
 from nose.tools import eq_
 from pyquery import PyQuery as pq
 
+from django.core import mail
+
 import amo
 import amo.tests
 from amo.tests import formset
@@ -223,6 +225,14 @@ class TestEditAuthor(TestOwnership):
         self.assertRedirects(r, self.url, 302)
         eq_(list(q.all()), [55021, 999])
 
+        # An email has been sent to the authors to warn them.
+        author_added = mail.outbox[0]
+        assert author_added.subject == ('An author has been added to your '
+                                        'add-on')
+        # Make sure all the authors are aware of the addition.
+        assert 'del@icio.us' in author_added.to  # The original author.
+        assert 'regular@mozilla.com' in author_added.to  # The new one.
+
     def test_success_edit_user(self):
         # Add an author b/c we can't edit anything about the current one.
         f = self.client.get(self.url).context['user_form'].initial_forms[0]
@@ -242,6 +252,32 @@ class TestEditAuthor(TestOwnership):
         self.assertRedirects(r, self.url, 302)
         eq_(AddonUser.objects.no_cache().get(addon=3615, user=999).listed,
             False)
+
+    def test_change_user_role(self):
+        # Add an author b/c we can't edit anything about the current one.
+        f = self.client.get(self.url).context['user_form'].initial_forms[0]
+        u = dict(user='regular@mozilla.com', listed=True,
+                 role=amo.AUTHOR_ROLE_DEV, position=1)
+        data = self.formset(f.initial, u, initial_count=1)
+        self.client.post(self.url, data)
+        eq_(AddonUser.objects.get(addon=3615, user=999).listed, True)
+
+        # Edit the user we just added.
+        user_form = self.client.get(self.url).context['user_form']
+        one, two = user_form.initial_forms
+        two.initial['role'] = amo.AUTHOR_ROLE_VIEWER
+        empty = dict(user='', listed=True, role=5, position=0)
+        data = self.formset(one.initial, two.initial, empty, initial_count=2)
+        r = self.client.post(self.url, data)
+        self.assertRedirects(r, self.url, 302)
+
+        # An email has been sent to the authors to warn them.
+        author_edit = mail.outbox[1]  # First mail was for the addition.
+        assert author_edit.subject == ('An author has a role changed on your '
+                                       'add-on')
+        # Make sure all the authors are aware of the addition.
+        assert 'del@icio.us' in author_edit.to  # The original author.
+        assert 'regular@mozilla.com' in author_edit.to  # The edited one.
 
     def test_add_user_twice(self):
         f = self.client.get(self.url).context['user_form'].initial_forms[0]
@@ -266,6 +302,14 @@ class TestEditAuthor(TestOwnership):
         r = self.client.post(self.url, data)
         eq_(r.status_code, 302)
         eq_(999, AddonUser.objects.get(addon=3615).user_id)
+
+        # An email has been sent to the authors to warn them.
+        author_delete = mail.outbox[1]  # First mail was for the addition.
+        assert author_delete.subject == ('An author has been removed from your'
+                                         ' add-on')
+        # Make sure all the authors are aware of the addition.
+        assert 'del@icio.us' in author_delete.to  # The original author.
+        assert 'regular@mozilla.com' in author_delete.to  # The removed one.
 
     def test_switch_owner(self):
         # See if we can transfer ownership in one POST.

--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -35,6 +35,18 @@
 
 {% include 'addons/details_box.html' %}
 
+{% if user_changes %}
+<div id="user-changes-history">
+  <h3>
+    {{ _('Add-on user change history') }}
+  </h3>
+  <ul id="user-changes">
+    {% for user_change in user_changes %}
+      <li>{{ user_change.activity_log.created }}: {{ user_change.activity_log }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
 <div id="review-files-header">
   <h3 id="history">
     {{ _('Add-on History') }}

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -22,7 +22,7 @@ from addons.models import Addon, Version
 from amo.decorators import json_view, post_required
 from amo.utils import paginate
 from amo.urlresolvers import reverse
-from devhub.models import ActivityLog, CommentLog
+from devhub.models import ActivityLog, AddonLog, CommentLog
 from editors import forms
 from editors.models import (AddonCannedResponse, EditorSubscription, EventLog,
                             PerformanceGraph, ReviewerScore,
@@ -540,13 +540,21 @@ def review(request, addon):
     except ViewQueue.DoesNotExist:
         flags = []
 
+    user_changes_actions = [
+        amo.LOG.ADD_USER_WITH_ROLE.id,
+        amo.LOG.CHANGE_USER_WITH_ROLE.id,
+        amo.LOG.REMOVE_USER_WITH_ROLE.id]
+    user_changes_log = AddonLog.objects.filter(
+        activity_log__action__in=user_changes_actions,
+        addon=addon).order_by('id')
     ctx = context(version=version, addon=addon,
                   pager=pager, num_pages=num_pages, count=count, flags=flags,
                   form=form, canned=canned, is_admin=is_admin,
                   show_diff=show_diff,
                   allow_unchecking_files=allow_unchecking_files,
                   actions=actions, actions_minimal=actions_minimal,
-                  whiteboard_form=forms.WhiteboardForm(instance=addon))
+                  whiteboard_form=forms.WhiteboardForm(instance=addon),
+                  user_changes=user_changes_log)
 
     return render(request, 'editors/review.html', ctx)
 

--- a/apps/users/templates/users/email/author_added.ltxt
+++ b/apps/users/templates/users/email/author_added.ltxt
@@ -1,0 +1,5 @@
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
+The following author has been added to your addon <a href="{{ addon_url }}">{{ addon_name }}</a>:
+
+<a href="{{ author_url }}">{{ author_name }}</a>: {{ author_role }}
+{% endblocktrans %}

--- a/apps/users/templates/users/email/author_changed.ltxt
+++ b/apps/users/templates/users/email/author_changed.ltxt
@@ -1,0 +1,5 @@
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
+The following author has been changed on your addon <a href="{{ addon_url }}">{{ addon_name }}</a>:
+
+<a href="{{ author_url }}">{{ author_name }}</a>: {{ author_role }}
+{% endblocktrans %}

--- a/apps/users/templates/users/email/author_removed.ltxt
+++ b/apps/users/templates/users/email/author_removed.ltxt
@@ -1,0 +1,6 @@
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
+The following author has been removed from addon <a href="{{ addon_url }}">{{ addon_name }}</a>:
+
+<a href="{{ author_url }}">{{ author_name }}</a>
+{% endblocktrans %}
+

--- a/apps/users/templates/users/email/confirm.ltxt
+++ b/apps/users/templates/users/email/confirm.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email.  Whitespace matters! #}{% blocktrans %}
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}
 Welcome to {{ domain }}.
 
 Before you can use your new account you must activate it - this ensures the e-mail address you used is valid and belongs to you.  To activate your account, click the link below or copy and paste the whole thing into your browser's location bar:

--- a/apps/users/templates/users/email/emailchange.ltxt
+++ b/apps/users/templates/users/email/emailchange.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email.  Whitespace matters! #}{% blocktrans %}
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}
 You requested a change to your email address at {{ domain }}.
 
 In order to confirm the new address, please click the link below or copy and paste the whole thing into your browser's location bar:

--- a/apps/users/templates/users/email/pwreset.ltxt
+++ b/apps/users/templates/users/email/pwreset.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email.  Whitespace matters! #}{% blocktrans %}
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}
 {{ domain }} Password Reset
 
 A request was received to reset the password for this account on

--- a/apps/users/templates/users/email/restricted.ltxt
+++ b/apps/users/templates/users/email/restricted.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email.  Whitespace matters! #}{% blocktrans %}
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}
 Your account has been restricted. You cannot create collections, post
 reviews for addons or apps, and your existing reviews and collections
 have been deleted.


### PR DESCRIPTION

Fixes [bug 712682](https://bugzilla.mozilla.org/show_bug.cgi?id=712682)

Misses tests:
- for the display of the user changes to the editor tools
- for the sending of emails to authors of the addon


![screen shot 2014-12-24 at 16 43 53](https://cloud.githubusercontent.com/assets/167767/5549635/f1a76c78-8b8d-11e4-86a1-f13045fe7896.png)