### PR TITLE
fix JS extraction; upgrade Tower

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -160,9 +160,7 @@ RTL_LANGUAGES = ('ar', 'fa', 'fa-IR', 'he')
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
 
 # Tower / L10n
-LOCALE_PATHS = (path('locale'),)
-TEXT_DOMAIN = 'messages'
-STANDALONE_DOMAINS = [TEXT_DOMAIN, 'javascript']
+STANDALONE_DOMAINS = ['messages', 'javascript']
 TOWER_KEYWORDS = {
     '_lazy': None,
 }
@@ -438,11 +436,11 @@ DOMAIN_METHODS = {
         # We can't say **.js because that would dive into mochikit and timeplot
         # and all the other baggage we're carrying.  Timeplot, in particular,
         # crashes the extractor with bad unicode data.
-        ('media/js/*.js', 'javascript'),
-        ('media/js/amo2009/**.js', 'javascript'),
-        ('media/js/common/**.js', 'javascript'),
-        ('media/js/impala/**.js', 'javascript'),
-        ('media/js/zamboni/**.js', 'javascript'),
+        ('static/js/*.js', 'javascript'),
+        ('static/js/amo2009/**.js', 'javascript'),
+        ('static/js/common/**.js', 'javascript'),
+        ('static/js/impala/**.js', 'javascript'),
+        ('static/js/zamboni/**.js', 'javascript'),
     ],
 }
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -94,6 +94,7 @@ SQLAlchemy==0.7.5
 statsd==2.0.3
 suds==0.4
 thrift==0.9.1
+tower==0.4.1
 urllib3==1.9
 
 ## Not on pypi.
@@ -119,7 +120,6 @@ urllib3==1.9
 
 ## Out of date or not sure on pypi.
 -e git+https://github.com/jbalogh/django-mobility.git@e2b60a1f96e4c4aed736395c01bf707e969d8e83#egg=django-mobility
--e git+https://github.com/clouserw/tower.git@ce2eba049a5146918fa5239d827bdde9e36eadb7#egg=tower-dev
 
 # Fix bug 963188. Once a version above 1.3.0 is available, move back to a PyPI release.
 -e git+https://github.com/nose-devs/nose.git@79102e33fda8a67292e7c79aafea85ea74334288#egg=nose-dev


### PR DESCRIPTION
Our [javascript.pot file](https://github.com/mozilla/olympia/blob/master/locale/templates/LC_MESSAGES/javascript.pot) has been empty for a long time and this was on my list to investigate.  Looks like it got left out of the media -> static move.  Upgraded Tower while I was in there.