### PR TITLE
Addon owner notification emails are only text (bug 712682)

### DIFF
--- a/apps/amo/mail.py
+++ b/apps/amo/mail.py
@@ -39,7 +39,7 @@ class DevEmailBackend(BaseEmailBackend):
                     # We don't want to send real emails to people if
                     # they happen to also be in the recipients together
                     # with white-listed emails
-                    msg.to = qa_emails
+                    msg.to = list(qa_emails)
                 qa_messages.append(msg)
         if qa_messages:
             log.debug('Sending real mail messages to QA.')

--- a/apps/amo/tests/test_send_mail.py
+++ b/apps/amo/tests/test_send_mail.py
@@ -171,7 +171,7 @@ class TestSendMail(BaseTestCase):
                          recipient_list=['nobody@mozilla.org', 'b@example.fr'],
                          fail_silently=False)
         eq_(len(mail.outbox), 1)
-        eq_(mail.outbox[0].to, set(['nobody@mozilla.org']))
+        eq_(mail.outbox[0].to, ['nobody@mozilla.org'])
         eq_(FakeEmail.objects.count(), 1)
 
     @mock.patch('amo.utils.Context')

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -412,7 +412,8 @@ def ownership(request, addon_id, addon):
         t = loader.get_template(
             'users/email/{part}.ltxt'.format(part=template_part))
         send_mail(title,
-                  t.render(Context({'author': author, 'addon': addon})),
+                  t.render(Context({'author': author, 'addon': addon,
+                                    'site_url': settings.SITE_URL})),
                   None, recipients, use_blacklist=False, real_email=True)
 
     if request.method == 'POST' and all([form.is_valid() for form in fs]):

--- a/apps/users/templates/users/email/author_added.ltxt
+++ b/apps/users/templates/users/email/author_added.ltxt
@@ -1,5 +1,5 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
-The following author has been added to your addon <a href="{{ addon_url }}">{{ addon_name }}</a>:
+The following author has been added to your addon {{ addon_name }} ({{ site_url }}{{ addon_url }}):
 
-<a href="{{ author_url }}">{{ author_name }}</a>: {{ author_role }}
+{{ author_name }} ({{ site_url }}{{ author_url }}): {{ author_role }}
 {% endblocktrans %}

--- a/apps/users/templates/users/email/author_changed.ltxt
+++ b/apps/users/templates/users/email/author_changed.ltxt
@@ -1,5 +1,5 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
-The following author has been changed on your addon <a href="{{ addon_url }}">{{ addon_name }}</a>:
+The following author has been changed on your addon {{ addon_name }} ({{ site_url }}{{ addon_url }}):
 
-<a href="{{ author_url }}">{{ author_name }}</a>: {{ author_role }}
+{{ author_name }} ({{ site_url }}{{ author_url }}): {{ author_role }}
 {% endblocktrans %}

--- a/apps/users/templates/users/email/author_removed.ltxt
+++ b/apps/users/templates/users/email/author_removed.ltxt
@@ -1,6 +1,5 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
-The following author has been removed from addon <a href="{{ addon_url }}">{{ addon_name }}</a>:
+The following author has been removed from addon {{ addon_name }} ({{ site_url }}{{ addon_url }}):
 
-<a href="{{ author_url }}">{{ author_name }}</a>
+{{ author_name }} ({{ site_url }}{{ author_url }})
 {% endblocktrans %}
-

--- a/settings.py
+++ b/settings.py
@@ -66,7 +66,7 @@ UGLIFY_BIN = path('node_modules/uglify-js/bin/uglifyjs')
 # replicas to zero.
 ES_DEFAULT_NUM_REPLICAS = 0
 
-SITE_URL = 'http://localhost:8000/'
+SITE_URL = 'http://localhost:8000'
 SERVICES_DOMAIN = 'localhost:8000'
 SERVICES_URL = 'http://%s' % SERVICES_DOMAIN
 


### PR DESCRIPTION
Fixes [bug 712682](https://bugzilla.mozilla.org/show_bug.cgi?id=712682)
The emails are only text, so don't use html in them.

This is a follow-up to #405