### PR TITLE
Remove files for the maemo platform from the db (bug 991290)

### DIFF
--- a/migrations/802-remove-maemo-platform.sql
+++ b/migrations/802-remove-maemo-platform.sql
@@ -1,0 +1,2 @@
+-- Remove all files for the maemo platform.
+DELETE FROM FILES WHERE platform_id=8;


### PR DESCRIPTION
Fixes (again) [bug 991290](https://bugzilla.mozilla.org/show_bug.cgi?id=991290)

This removes 95 files with the maemo platform at the time of the writing.