### PR TITLE
Remove files for the maemo platform from the db (bug 1119800)

### DIFF
--- a/migrations/802-remove-maemo-platform.sql
+++ b/migrations/802-remove-maemo-platform.sql
@@ -1,0 +1,2 @@
+-- Remove all files for the maemo platform.
+DELETE FROM files WHERE platform_id=8;


### PR DESCRIPTION
Fixes [bug 1119800](https://bugzilla.mozilla.org/show_bug.cgi?id=1119800)

This removes 95 files with the maemo platform at the time of the writing.