### PR TITLE
pass addon id to trunion (bug 1110468)

### DIFF
--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -105,7 +105,7 @@ class TestPackaged(amo.tests.TestCase):
     def test_non_xpi(self):
         self.file1.update(filename='foo.txt')
         packaged._sign_file(
-            self.version.pk, self.addon,
+            self.version.pk, self.addon, 'addon_id',
             self.file1, False, False)
 
     @mock.patch('lib.crypto.packaged.sign_addon')
@@ -126,7 +126,7 @@ class TestPackaged(amo.tests.TestCase):
     def test_sign_consumer(self, sign_addon):
         file_list = packaged.sign(self.version.pk)
         assert sign_addon.called
-        ids = json.loads(sign_addon.call_args[0][2])
+        ids = json.loads(sign_addon.call_args[0][3])
         eq_(ids['id'], self.addon.guid)
         eq_(ids['version'], self.version.pk)
 
@@ -138,7 +138,7 @@ class TestPackaged(amo.tests.TestCase):
     def test_sign_reviewer(self, sign_addon):
         file_list = packaged.sign(self.version.pk, reviewer=True)
         assert sign_addon.called
-        ids = json.loads(sign_addon.call_args[0][2])
+        ids = json.loads(sign_addon.call_args[0][3])
         eq_(ids['id'], 'reviewer-{guid}-{version_id}'.format(
             guid=self.addon.guid, version_id=self.version.pk))
         eq_(ids['version'], self.version.pk)


### PR DESCRIPTION
Fixes [bug 1110468](https://bugzilla.mozilla.org/show_bug.cgi?id=1110468)

@rtilder explained that we were not providing the addon_id when sending the
request to trunion. This is needed here:
https://github.com/mozilla/trunion/blob/rtilder/addon-signing/trunion/views.py#L63