### PR TITLE
Fix addon total_reviews computation (bug 1121424)

### DIFF
--- a/apps/addons/management/commands/process_addons.py
+++ b/apps/addons/management/commands/process_addons.py
@@ -9,6 +9,7 @@ import amo
 from addons.models import Addon
 from amo.utils import chunked
 from devhub.tasks import convert_purified, flag_binary, get_preview_sizes
+from reviews.tasks import addon_review_aggregates
 
 
 tasks = {
@@ -24,6 +25,7 @@ tasks = {
     'flag_binary': {'method': flag_binary, 'qs': []},
     'get_preview_sizes': {'method': get_preview_sizes, 'qs': []},
     'convert_purified': {'method': convert_purified, 'qs': []},
+    'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
 }
 
 


### PR DESCRIPTION
Fixes [bug 1121424](https://bugzilla.mozilla.org/show_bug.cgi?id=1121424)

This happened because of this change: https://github.com/mozilla/olympia/commit/7c9c856873f2594b72993b2cfc66ad172de5e233#diff-8a597230c08354b4c86368c40eba461fL47

This change happened because depending on the python HASHSEED used, the order of the average rating and of the number of reviews could be reversed.

Example:

```
$ echo "from django.db.models import Avg, Count; Review.objects.filter(addon__in=[6, 7]).values_list('addon').annotate(Avg('rating'), Count('addon'))" | PYTHONHASHSEED=1 ./manage.py shell_plus

...
In [1]: Out[1]: [(7L, 2.0, 5), (6L, 3.75, 8)]
...
```

```
$ echo "from django.db.models import Avg, Count; Review.objects.filter(addon__in=[6, 7]).values_list('addon').annotate(Avg('rating'), Count('addon'))" | PYTHONHASHSEED=10000 ./manage.py shell_plus

...
In [1]: Out[1]: [(7L, 5, 2.0), (6L, 8, 3.75)]
...
```

However, the fix didn't work, as the query wasn't properly grouped by addon.

I'm thus reverting the change, and going with another fix: using `values` (which returns a dict) instead of `values_list` which returns a list that may be in the wrong order.