### PR TITLE
Always serve signed packages (bug 1107842)

### DIFF
--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -117,13 +117,13 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
         """True only if extension is xpi"""
         return os.path.splitext(self.filename)[1] == '.xpi'
 
-    def get_mirror(self, addon, attachment=False):
+    def get_mirror(self, addon, attachment=False, media_root='addons'):
         if attachment:
-            host = posixpath.join(user_media_url('addons'), '_attachments')
+            host = posixpath.join(user_media_url(media_root), '_attachments')
         elif addon.is_disabled or self.status == amo.STATUS_DISABLED:
             host = settings.PRIVATE_MIRROR_URL
         else:
-            host = user_media_url('addons')
+            host = user_media_url(media_root)
 
         return posixpath.join(*map(smart_str, [host, addon.id, self.filename]))
 

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -2,6 +2,7 @@ import os
 import posixpath
 
 from django import http
+from django.core.files.storage import default_storage as storage
 from django.shortcuts import get_object_or_404, redirect, render
 
 import caching.base as caching
@@ -94,6 +95,12 @@ def download_file(request, file_id, type=None):
     attachment = (type == 'attachment' or not request.APP.browser)
 
     loc = file.get_mirror(addon, attachment=attachment)
+    signed_loc = file.get_mirror(addon, attachment=attachment,
+                                 media_root='signed_addons')
+
+    if storage.exists(file.signed_file_path):
+        loc = signed_loc
+
     response = http.HttpResponseRedirect(loc)
     response['X-Target-Digest'] = file.hash
     return response


### PR DESCRIPTION
Fixes [1107842](https://bugzilla.mozilla.org/show_bug.cgi?id=1107842)

Supersedes #386

I've simplified the tests, we only want to test the case where the signed
version exist, and in that case, that we serve it.