### PR TITLE
disable travis cache (too slow)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,3 @@ notifications:
       - "irc.mozilla.org#amo-bots"
     on_success: change
     on_failure: always
-cache:
-  directories:
-    - /tmp/elasticsearch
-    - /tmp/pip-cache

--- a/scripts/travis_es.sh
+++ b/scripts/travis_es.sh
@@ -4,7 +4,8 @@ TARGET="/tmp/elasticsearch"
 
 if [ ! -f "$TARGET/elasticsearch-1.2.4/bin/elasticsearch" ]; then
     echo "$TARGET not found. Building..."
-    pushd $TARGET
+    mkdir -p $TARGET
+    cd $TARGET
     wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.2.tar.gz
     tar xvf elasticsearch-1.3.2.tar.gz
 else


### PR DESCRIPTION
Not sure exactly why, but the cache seems very slow on travis (at least on the new docker architecture).

Proof:
- without caching, 40mn total: https://travis-ci.org/mozilla/olympia/builds/47632018
- with caching, 1h19mn total: https://travis-ci.org/mozilla/olympia/builds/47625543

@clouserw thoughts?