### PR TITLE
sign_addons command can sign all addons (bug 1123611)

### DIFF
--- a/apps/addons/management/commands/process_addons.py
+++ b/apps/addons/management/commands/process_addons.py
@@ -9,6 +9,7 @@ import amo
 from addons.models import Addon
 from amo.utils import chunked
 from devhub.tasks import convert_purified, flag_binary, get_preview_sizes
+from lib.crypto.tasks import sign_addons
 from reviews.tasks import addon_review_aggregates
 
 
@@ -26,6 +27,7 @@ tasks = {
     'get_preview_sizes': {'method': get_preview_sizes, 'qs': []},
     'convert_purified': {'method': convert_purified, 'qs': []},
     'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
+    'sign_addons': {'method': sign_addons, 'qs': []},
 }
 
 

--- a/lib/crypto/tasks.py
+++ b/lib/crypto/tasks.py
@@ -1,0 +1,18 @@
+import logging
+
+from celeryutils import task
+
+from versions.models import Version
+from lib.crypto.packaged import SigningError
+
+log = logging.getLogger('z.task')
+
+
+@task
+def sign_addons(addon_ids, **kw):
+    log.info('[%s] Signing addons.' % len(addon_ids))
+    for version in Version.objects.filter(addon_id__in=addon_ids):
+        try:
+            version.sign_files()
+        except SigningError as e:
+            log.warning('Failed signing version %s: %s.' % (version.pk, e))


### PR DESCRIPTION
Fixes [bug 1123611](https://bugzilla.mozilla.org/show_bug.cgi?id=1123611)

This is based on the PR #426

Instead of modifying the `sign_addons` management command to be able to sign all addons, I've added a task to be used with `process_addons --task sign_addons`