### PR TITLE
Store the signature certificate serial number (bug 1070190)

### DIFF
--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -78,6 +78,8 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
     # amo-validator when it finds "binary-components" in the chrome manifest
     # file, used for default to compatible.
     binary_components = models.BooleanField(default=False, db_index=True)
+    # Serial number of the certificate use for the signature.
+    cert_serial_num = models.CharField(max_length=255, blank=True)
 
     class Meta(amo.models.ModelBase.Meta):
         db_table = 'files'

--- a/migrations/803-file-add-cert_serial_num.sql
+++ b/migrations/803-file-add-cert_serial_num.sql
@@ -1,0 +1,1 @@
+ALTER TABLE files ADD COLUMN cert_serial_num varchar(255) NOT NULL;


### PR DESCRIPTION
Fixes [bug 1070190](https://bugzilla.mozilla.org/show_bug.cgi?id=1070190)

Based on PR #426