### PR TITLE
pin dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,11 +1,8 @@
 -r compiled.txt
 -r test.txt
 -r docs.txt
+-r flake8.txt
 
 django-debug-toolbar==1.2
 django-fixture-magic==0.0.4
-flake8
-mccabe
-pep8
-pyflakes
-sqlparse
+sqlparse==0.1.14

--- a/requirements/flake8.txt
+++ b/requirements/flake8.txt
@@ -1,0 +1,4 @@
+flake8==2.3.0
+mccabe==0.3
+pep8==1.5.7
+pyflakes==0.8.1

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,7 @@ commands =
 
 [testenv:flake8]
 deps =
-    flake8
-    mccabe
-    pep8
-    pyflakes
+    -rrequirements/flake8.txt
 commands = make flake8
 
 [testenv:docs]


### PR DESCRIPTION
This fixes the travis failures lately: a new version of [pep8](https://pypi.python.org/pypi/pep8/1.6.1#id2) was released, which is stricter than it used to be. Until we fix the new warnings, we simply pin the requirement versions (as we should have done from the beginning).