### PR TITLE
[DO NOT MERGE] Add a link to request a cert to sign own files (bug 1121161)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/start.html
+++ b/apps/devhub/templates/devhub/addons/submit/start.html
@@ -45,4 +45,8 @@
   {{ _('or <a href="{0}">Cancel</a>')|f(url('devhub.index')) }}
   </form>
 </div>
+<div class="no-upload">
+    {{ _('If you would like to have your add-on signed but cannot submit to AMO
+          please <a href="{0}">let us know</a>.')|f(settings.REQUEST_CERT_URL) }}
+</div>
 {% endblock %}

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1324,6 +1324,9 @@ SIGNING_SERVER = ''
 PRELIMINARY_SIGNING_SERVER = ''
 # And how long we'll give the server to respond.
 SIGNING_SERVER_TIMEOUT = 10
+# Where to redirect people who can't submit their add-on to AMO: they need to
+# request a cert to sign their own files.
+REQUEST_CERT_URL = 'https://bugzilla.mozilla.org/show_bug.cgi?id=1121159'
 
 # True when the Django app is running from the test suite.
 IN_TEST_SUITE = False


### PR DESCRIPTION
Fixes [bug 1121161](https://bugzilla.mozilla.org/show_bug.cgi?id=1121161)

This is how it looks like at the moment. @clouserw please let me know who I should ask for regarding styling the link.

![screen shot 2015-02-10 at 10 52 46](https://cloud.githubusercontent.com/assets/167767/6125179/bb6846b8-b113-11e4-8c68-e2e9fe14fb9a.png)

DON'T MERGE until we have the final link to the request cert form.