### PR TITLE
don't link submission steps 3 to 6 for unlisted addons (bug 1121241)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/sidebar.html
+++ b/apps/devhub/templates/devhub/addons/submit/sidebar.html
@@ -27,7 +27,7 @@
           {# 1. We have an addon, so don't link to non-addon steps.
              2. Don't link steps above the max step the addon has reached.
              3. If step.max == MAX the addon is done, so we only show the final page. #}
-          {% if loop.index < HAS_ADDON or loop.index > step.max or step.max == MAX %}
+          {% if loop.index < HAS_ADDON or loop.index > step.max or step.max == MAX or not addon.is_listed %}
             {{ text }}
           {% else %}
             <a href="{{ url(BASE % loop.index, addon.slug) }}">{{ text }}</a>

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1770,6 +1770,16 @@ class TestSubmitSteps(amo.tests.TestCase):
         self.assert_linked(doc, [3, 4, 5, 6])
         self.assert_highlight(doc, 6)
 
+    def test_menu_step_6_unlisted(self):
+        SubmitStep.objects.create(addon_id=3615, step=6)
+        Addon.objects.get(pk=3615).update(is_listed=False)
+        url = reverse('devhub.submit.6', args=['a3615'])
+        doc = pq(self.client.get(url).content)
+        # Skipped from step 2 to 6, as unlisted add-ons don't need listing
+        # information. Thus none of the steps from 3 to 6 should be links.
+        self.assert_linked(doc, [])
+        self.assert_highlight(doc, 6)
+
     def test_menu_step_7(self):
         url = reverse('devhub.submit.7', args=['a3615'])
         doc = pq(self.client.get(url).content)


### PR DESCRIPTION
Fixes [bug 1121241](https://bugzilla.mozilla.org/show_bug.cgi?id=1121241)