### PR TITLE
Adapt submission step 7 for unlisted addons (bug 1121242)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/done.html
+++ b/apps/devhub/templates/devhub/addons/submit/done.html
@@ -8,51 +8,51 @@
 <h3>{{ _("You're done!") }}</h3>
 <p>
 {% if addon.status == amo.STATUS_UNREVIEWED %}
-  {% trans %}
-    Your add-on has been submitted to the Preliminary Review queue.
-  {% endtrans %}
+  {{ _('Your add-on has been submitted to the Preliminary Review queue.') }}
 {% elif addon.status == amo.STATUS_NOMINATED %}
-  {% trans %}
-    Your add-on has been submitted to the Full Review queue.
-  {% endtrans %}
+  {{ _('Your add-on has been submitted to the Full Review queue.') }}
 {% endif %}
 </p>
-<p>
-{% trans %}
-  You'll receive an email once it has been reviewed by an editor. In
-  the meantime, you and your friends can install it directly from its
-  details page:
-{% endtrans %}
-</p>
-<p>
-  <a id="submitted-addon-url" href="{{ addon.get_url_path() }}">
-    {{ addon.get_url_path()|absolutify|display_url }}</a>
-</p>
-<div class="done-next-steps">
-  <p><strong>{{ _('Next steps:') }}</strong></p>
-  <ul>
-    {% if is_platform_specific %}
-      {% set files_url = url('devhub.versions.edit',
-                              addon.slug, addon.current_version.id) %}
-      <li>{{ _('<a href="{0}">Upload</a> another platform-specific file to this version.')|f(files_url) }}</li>
-    {% endif %}
-    {% set edit_url = addon.get_dev_url() %}
-    <li>{{ _('Provide more details by <a href="{0}">editing its listing</a>.')|f(edit_url) }}</li>
-    {% set profile_url = addon.get_dev_url('profile') %}
-    <li>{{ _('Tell your users why you created this in your <a href="{0}">Developer Profile</a>.')|f(profile_url) }}</li>
-    {% set feed_url = url('devhub.feed', addon.slug) %}
-    <li>{{ _('View and subscribe to your add-on\'s <a href="{0}">activity feed</a> to stay updated on reviews, collections, and more.')|f(feed_url) }}</li>
-    <li>{{ _('View approximate review queue <a href="{0}">wait times</a>.')|f('https://forums.addons.mozilla.org/viewforum.php?f=21') }}</li>
-  </ul>
-</div>
+{% if addon.is_listed %}
+  <p>
+    {{ _('You\'ll receive an email once it has been reviewed by an editor. In
+          the meantime, you and your friends can install it directly from its
+          details page:') }}
+  </p>
+  <p>
+    <a id="submitted-addon-url" href="{{ addon.get_url_path() }}">
+      {{ addon.get_url_path()|absolutify|display_url }}</a>
+  </p>
+  <div class="done-next-steps">
+    <p><strong>{{ _('Next steps:') }}</strong></p>
+    <ul>
+      {% if is_platform_specific %}
+        {% set files_url = url('devhub.versions.edit',
+                                addon.slug, addon.current_version.id) %}
+        <li>{{ _('<a href="{0}">Upload</a> another platform-specific file to this version.')|f(files_url) }}</li>
+      {% endif %}
+      <li>{{ _('Provide more details by <a href="{0}">editing its listing</a>.')|f(addon.get_dev_url()) }}</li>
+      <li>{{ _('Tell your users why you created this in your <a href="{0}">Developer Profile</a>.')|f(addon.get_dev_url('profile')) }}</li>
+      <li>{{ _('View and subscribe to your add-on\'s <a href="{0}">activity feed</a> to stay updated on reviews, collections, and more.')|f(url('devhub.feed', addon.slug)) }}</li>
+      <li>{{ _('View approximate review queue <a href="{0}">wait times</a>.')|f('https://forums.addons.mozilla.org/viewforum.php?f=21') }}</li>
+    </ul>
+  </div>
 
-<div id="editor-pitch" class="action-needed">
-<h3>{{ _('Get Ahead in the Review Queue!') }}</h3>
-<p>
-  {{ _('Become an AMO Reviewer today and get your add-ons reviewed faster.') }}
-  <a class="button learn-more" href="https://wiki.mozilla.org/AMO:Editors">
-    {{ _('Learn More') }}</a>
-</p>
-</div>
-
+  <div id="editor-pitch" class="action-needed">
+  <h3>{{ _('Get Ahead in the Review Queue!') }}</h3>
+  <p>
+    {{ _('Become an AMO Reviewer today and get your add-ons reviewed faster.') }}
+    <a class="button learn-more" href="https://wiki.mozilla.org/AMO:Editors">
+      {{ _('Learn More') }}</a>
+  </p>
+  </div>
+{% else %}
+  <p>
+    {{ _('You\'ll receive an email once it has been reviewed by an editor.') }}
+    <strong>{{ _('Your add-on will not be publicly available on AMO.') }}</strong>
+  </p>
+  <p>
+    {{ _('If you need to adjust any details of your add-on please <a href="{0}">edit the listing</a>.')|f(addon.get_dev_url()) }}
+  </p>
+{% endif %}
 {% endblock %}

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1583,6 +1583,20 @@ class TestSubmitStep7(TestSubmitBase):
         eq_(next_steps.eq(1).attr('href'), self.addon.get_dev_url('profile'))
 
     @mock.patch('devhub.tasks.send_welcome_email.delay', new=mock.Mock)
+    def test_finish_submitting_unlisted_addon(self):
+        eq_(self.addon.current_version.supported_platforms, [amo.PLATFORM_ALL])
+        self.addon.update(is_listed=False)
+
+        r = self.client.get(self.url)
+        eq_(r.status_code, 200)
+        doc = pq(r.content)
+
+        # For unlisted add-ons, there's only the devhub page link displayed.
+        content = doc('.addon-submission-process')
+        assert len(content('a')) == 1
+        assert content('a').attr('href') == self.addon.get_dev_url()
+
+    @mock.patch('devhub.tasks.send_welcome_email.delay', new=mock.Mock)
     def test_finish_submitting_platform_specific_addon(self):
         # mac-only Add-on:
         addon = Addon.objects.get(name__localized_string='Cooliris')


### PR DESCRIPTION
Fixes [bug 1121242](https://bugzilla.mozilla.org/show_bug.cgi?id=1121242)

This is how the new page looks like for unlisted addons (for listed addons, there's no change):

![screen shot 2015-02-11 at 14 28 07](https://cloud.githubusercontent.com/assets/167767/6148189/9c86cfa2-b1ff-11e4-9850-3c42e2de4809.png)
