### PR TITLE
Add the 'Addons:ReviewUnlisted' permission to the 'Senior Add-On Reviewers' group (bug 1121239)

### DIFF
--- a/apps/access/fixtures/initial.json
+++ b/apps/access/fixtures/initial.json
@@ -28,5 +28,15 @@
         "created": "2010-09-08 07:06:05",
         "modified": "2010-09-08 07:06:05"
     }
+  },
+  {
+    "pk": 4,
+    "model": "access.group",
+    "fields": {
+        "name": "Senior Add-on Reviewers",
+        "rules": "Addons:Review,Reviews:Edit,CollectionStats:View,Addons:Edit,Spam:Flag,ReviewerAdminTools:View,Addons:ReviewUnlisted",
+        "created": "2010-09-08 07:06:05",
+        "modified": "2010-09-08 07:06:05"
+    }
   }
 ]

--- a/migrations/806-perms-addons-reviewunlisted.sql
+++ b/migrations/806-perms-addons-reviewunlisted.sql
@@ -1,0 +1,3 @@
+UPDATE groups
+SET rules=CONCAT(rules, ',Addons:ReviewUnlisted')
+WHERE groups.name='Senior Add-on Reviewers';


### PR DESCRIPTION
Fixes [bug 1121239](https://bugzilla.mozilla.org/show_bug.cgi?id=1121239)