### PR TITLE
Raise log level to INFO for adi.updatecountsfromfile on production

### DIFF
--- a/sites/prod/settings_base.py
+++ b/sites/prod/settings_base.py
@@ -75,6 +75,7 @@ HERA = []
 LOG_LEVEL = logging.DEBUG
 
 LOGGING['loggers'].update({
+    'adi.updatecountsfromfile': {'level': logging.INFO},
     'amqp': {'level': logging.WARNING},
     'raven': {'level': logging.WARNING},
     'requests': {'level': logging.WARNING},


### PR DESCRIPTION
There's millions of lines of logs spit out by the update_counts_from_file
management command on production, slowing it down a lot, unnecessarily.