### PR TITLE
remove useless Config memoization (bug 1132402)

### DIFF
--- a/apps/amo/tests/test_middleware.py
+++ b/apps/amo/tests/test_middleware.py
@@ -12,7 +12,7 @@ from pyquery import PyQuery as pq
 import amo.tests
 from amo.middleware import NoAddonsMiddleware, NoVarySessionMiddleware
 from amo.urlresolvers import reverse
-from zadmin.models import Config, _config_cache
+from zadmin.models import Config
 
 
 pytestmark = pytest.mark.django_db
@@ -72,21 +72,13 @@ def test_trailing_slash_middleware():
 class AdminMessageTest(amo.tests.TestCase):
 
     def test_message(self):
-        c = Config()
-        c.key = 'site_notice'
-        c.value = 'ET Sighted.'
-        c.save()
-
-        if ('site_notice',) in _config_cache:
-            del _config_cache[('site_notice',)]
+        c = Config.objects.create(key='site_notice', value='ET Sighted.')
 
         r = self.client.get(reverse('home'), follow=True)
         doc = pq(r.content)
         eq_(doc('#site-notice').text(), 'ET Sighted.')
 
         c.delete()
-
-        del _config_cache[('site_notice',)]
 
         r = self.client.get(reverse('home'), follow=True)
         doc = pq(r.content)

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -309,7 +309,8 @@ def _performance_by_month(user_id, months=12, end_month=None, end_year=None):
 def motd(request):
     form = None
     if acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit'):
-        form = forms.MOTDForm()
+        form = forms.MOTDForm(
+            initial={'motd': get_config('editors_review_motd')})
     data = context(form=form)
     return render(request, 'editors/motd.html', data)
 


### PR DESCRIPTION
Fixes [bug 1132402](https://bugzilla.mozilla.org/show_bug.cgi?id=1132402)

Replacing the memoization by the cache, while a bit less efficient (I'm pretty sure the efficiency isn't that important here), will avoid strange display issues (with different processes displaying different things).