### PR TITLE
Get rid of bogus File.can_be_signed (bug 1141068)

### DIFF
--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -115,10 +115,6 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
                        not self.version.addon.disabled_by_user)
         return is_eligible
 
-    def can_be_signed(self):
-        """True only if extension is xpi"""
-        return os.path.splitext(self.filename)[1] == '.xpi'
-
     def get_mirror(self, addon, attachment=False):
         if attachment:
             host = posixpath.join(user_media_url('addons'), '_attachments')

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -482,8 +482,9 @@ class Version(amo.models.OnChangeMixin, amo.models.ModelBase):
             Version.objects.invalidate(self)
 
     def sign_files(self):
-        """Sign the files for this version."""
-        return packaged.sign(self)
+        """Sign the files for this version if it's an extension."""
+        if self.addon.type == amo.ADDON_EXTENSION:
+            packaged.sign(self)
 
 
 @Version.on_change

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -448,6 +448,21 @@ class TestVersion(amo.tests.TestCase):
                 self.version.addon.update(status=status)
                 assert self.version.current_queue == queue
 
+    @mock.patch('lib.crypto.packaged.sign')
+    def test_sign_files(self, sign_mock):
+        no_sign_types = [t for t in amo.ADDON_TYPE.keys()
+                         if t != amo.ADDON_EXTENSION]
+        # Don't sign for anything else than an extension.
+        for addon_type in no_sign_types:
+            self.version.addon.update(type=addon_type)
+            assert not sign_mock.called, (
+                'lib.crypto.packaged.sign called for addon type {0}'.format(
+                    addon_type))
+        # Sign files if it's an extension.
+        self.version.addon.update(type=amo.ADDON_EXTENSION)
+        self.version.sign_files()
+        assert sign_mock.called
+
 
 class TestViews(amo.tests.TestCase):
     fixtures = ['addons/eula+contrib-addon']

--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -78,7 +78,7 @@ def call_signing(file_obj):
         log.error(msg, exc_info=True)
         raise SigningError(msg)
     if response.status_code != 200:
-        msg = 'Posting to add-on signing failed %s' % response.reason
+        msg = 'Posting to add-on signing failed: %s' % response.reason
         log.error(msg)
         raise SigningError(msg)
 
@@ -95,11 +95,6 @@ def call_signing(file_obj):
 
 
 def sign_file(file_obj):
-    if not file_obj.can_be_signed():
-        msg = 'Attempt to sign a non-xpi file %s.' % file_obj.pk
-        log.error(msg)
-        raise SigningError(msg)
-
     try:
         cert_serial_num = call_signing(file_obj)  # Sign file.
         if cert_serial_num:
@@ -119,6 +114,6 @@ def sign(version):
 
     log.info('Signing version: %s' % version.pk)
 
-    for file_obj in [x for x in version.all_files if x.can_be_signed()]:
+    for file_obj in [x for x in version.all_files]:
         with statsd.timer('services.sign.addon'):
             sign_file(file_obj)


### PR DESCRIPTION
Fixes [bug 1141068](https://bugzilla.mozilla.org/show_bug.cgi?id=1141068)