### PR TITLE
Don't fail on warnings truncation on the addon validation page (bug 1139674)

### DIFF
--- a/apps/devhub/utils.py
+++ b/apps/devhub/utils.py
@@ -54,6 +54,8 @@ def limit_validation_results(validation, is_compatibility=False):
             validation['messages'].append({
                 'tier': 1,
                 'type': msgtype,
+                # To respect the message structure, see bug 1139674.
+                'id': ['validation', 'messages', 'truncated'],
                 'message': (_('Validation generated too many errors/'
                               'warnings so %s messages were truncated. '
                               'After addressing the visible messages, '

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -341,7 +341,9 @@
                             ], current, matched, messages = [],
                             // this.id is in the form ["testcases_javascript_instanceactions", "_call_expression", "createelement_variable"],
                             // we usually only match one of the elements.
-                            matchId = function (id) {return _.contains(this.id, id);};
+                            matchId = function (id) {
+                              return this.hasOwnProperty('id') && _.contains(this.id, id);
+                            };
 
                         if (!upload_results.parents('.add-file-modal').length) {
                             // We are uploading a file for an existing addon.


### PR DESCRIPTION
Fixes [bug 1139674](https://bugzilla.mozilla.org/show_bug.cgi?id=1139674)