### PR TITLE
Don't display unlisted addons (bug 1121244)

### DIFF
--- a/apps/addons/tests/test_views.py
+++ b/apps/addons/tests/test_views.py
@@ -835,6 +835,11 @@ class TestDetailPage(amo.tests.TestCase):
         eq_(pq(response.content)('#more-webpage').attr('data-more-url'),
             self.addon.get_url_path(more=True))
 
+    def test_unlisted_addon_returns_404(self):
+        """Unlisted addons are not listed and return 404."""
+        self.addon.update(is_listed=False)
+        assert self.client.get(self.url).status_code == 404
+
 
 class TestImpalaDetailPage(amo.tests.TestCase):
     fixtures = ['base/addon_3615', 'base/addon_592', 'base/users']

--- a/apps/amo/tests/test_models.py
+++ b/apps/amo/tests/test_models.py
@@ -7,6 +7,7 @@ from amo.models import manual_order
 from amo.tests import TestCase
 from amo import models as context
 from addons.models import Addon
+from users.models import UserProfile
 
 
 pytestmark = pytest.mark.django_db
@@ -143,6 +144,10 @@ class TestModelBase(TestCase):
         # Reload. And it's magically now a persona.
         eq_(addon.reload().type, amo.ADDON_PERSONA)
         eq_(addon.type, amo.ADDON_PERSONA)
+
+    def test_get_unfiltered_manager(self):
+        Addon.get_unfiltered_manager() == Addon.unfiltered
+        UserProfile.get_unfiltered_manager() == UserProfile.objects
 
 
 def test_cache_key():

--- a/apps/devhub/decorators.py
+++ b/apps/devhub/decorators.py
@@ -5,7 +5,8 @@ from django.core.exceptions import PermissionDenied
 
 from amo.decorators import login_required
 from access import acl
-from addons.decorators import addon_view
+from addons.decorators import addon_view_factory
+from addons.models import Addon
 from devhub.models import SubmitStep
 
 
@@ -15,7 +16,7 @@ def dev_required(owner_for_post=False, allow_editors=False, theme=False):
     When allow_editors is True, an editor can view the page.
     """
     def decorator(f):
-        @addon_view
+        @addon_view_factory(qs=Addon.with_unlisted.all)
         @login_required
         @functools.wraps(f)
         def wrapper(request, addon, *args, **kw):

--- a/apps/devhub/models.py
+++ b/apps/devhub/models.py
@@ -293,11 +293,8 @@ class ActivityLog(amo.models.ModelBase):
             else:
                 (app_label, model_name) = model_name.split('.')
                 model = models.loading.get_model(app_label, model_name)
-                # Cope with soft deleted models.
-                if hasattr(model, 'with_deleted'):
-                    objs.extend(model.with_deleted.filter(pk=pk))
-                else:
-                    objs.extend(model.objects.filter(pk=pk))
+                # Cope with soft deleted models and unlisted addons.
+                objs.extend(model.get_unfiltered_manager().filter(pk=pk))
 
         return objs
 

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -2611,7 +2611,7 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, amo.tests.TestCase):
     def test_success_unlisted(self):
         eq_(Addon.objects.count(), 0)
         r = self.post(is_listed=False)
-        addon = Addon.objects.get()
+        addon = Addon.with_unlisted.get()
         assert not addon.is_listed
         # Skip from step 2 to step 6.
         self.assertRedirects(r, reverse('devhub.submit.6', args=[addon.slug]))

--- a/apps/editors/models.py
+++ b/apps/editors/models.py
@@ -677,7 +677,7 @@ class RereviewQueueTheme(amo.models.ModelBase):
 
     # The order of those managers is very important: please read the lengthy
     # comment above the Addon managers declaration/instanciation.
-    with_deleted = RereviewQueueThemeManager(include_deleted=True)
+    unfiltered = RereviewQueueThemeManager(include_deleted=True)
     objects = RereviewQueueThemeManager()
 
     class Meta:

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1117,7 +1117,7 @@ class TestModeratedQueue(QueueTest):
         # Make sure it was actually deleted.
         eq_(Review.objects.filter(addon=1865).count(), 1)
         # But make sure it wasn't *actually* deleted.
-        eq_(Review.with_deleted.filter(addon=1865).count(), 2)
+        eq_(Review.unfiltered.filter(addon=1865).count(), 2)
 
     def test_remove_fails_for_own_addon(self):
         """
@@ -1749,7 +1749,7 @@ class TestReview(ReviewBase):
 
     def test_needs_unlisted_reviewer_for_unlisted_addons(self):
         self.addon.update(is_listed=False)
-        assert self.client.head(self.url).status_code == 403
+        assert self.client.head(self.url).status_code == 404
         self.login_as_senior_editor()
         assert self.client.head(self.url).status_code == 200
 

--- a/apps/editors/tests/test_views_themes.py
+++ b/apps/editors/tests/test_views_themes.py
@@ -512,7 +512,7 @@ class TestThemeQueueRereview(ThemeReviewTestMixin, amo.tests.TestCase):
         eq_(r.status_code, 200)
         doc = pq(r.content)
         eq_(doc('.theme').length, 1)
-        eq_(RereviewQueueTheme.with_deleted.count(), 2)
+        eq_(RereviewQueueTheme.unfiltered.count(), 2)
 
     def test_rejected_addon_in_rqt(self):
         """Test rejected addons in RQT are not displayed in review lists."""

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -17,7 +17,7 @@ from tower import ugettext as _
 import amo
 from abuse.models import AbuseReport
 from access import acl
-from addons.decorators import addon_view
+from addons.decorators import addon_view, addon_view_factory
 from addons.models import Addon, Version
 from amo.decorators import json_view, post_required
 from amo.utils import paginate
@@ -482,12 +482,12 @@ def application_versions_json(request):
 
 
 @addons_reviewer_required
-@addon_view
+@addon_view_factory(qs=Addon.with_unlisted.all)
 def review(request, addon):
-    version = addon.latest_version
-
     if not addon.is_listed and not acl.check_unlisted_addons_reviewer(request):
-        raise PermissionDenied
+        raise http.Http404
+
+    version = addon.latest_version
 
     if not settings.ALLOW_SELF_REVIEWS and addon.has_author(request.amo_user):
         amo.messages.warning(request, _('Self-reviews are not allowed.'))

--- a/apps/editors/views_themes.py
+++ b/apps/editors/views_themes.py
@@ -448,8 +448,8 @@ def themes_logs(request):
 @admin_required(theme_reviewers=True)
 def deleted_themes(request):
     data = request.GET.copy()
-    deleted = Addon.with_deleted.filter(type=amo.ADDON_PERSONA,
-                                        status=amo.STATUS_DELETED)
+    deleted = Addon.unfiltered.filter(type=amo.ADDON_PERSONA,
+                                      status=amo.STATUS_DELETED)
 
     if not data.get('start') and not data.get('end'):
         today = datetime.date.today()

--- a/apps/files/tests/test_decorators.py
+++ b/apps/files/tests/test_decorators.py
@@ -1,6 +1,7 @@
 from django import http
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 
+import pytest
 from mock import Mock, patch
 
 import amo.tests
@@ -15,19 +16,65 @@ class AllowedTest(amo.tests.TestCase):
         self.request = Mock()
         self.file = Mock()
 
+    @patch.object(acl, 'check_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_addon_ownership',
+                  lambda request, addon, viewer, dev: True)
+    def test_owner_allowed(self):
+        self.assertTrue(allowed(self.request, self.file))
+
     @patch.object(acl, 'check_addons_reviewer', lambda x: True)
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
     def test_reviewer_allowed(self):
         self.assertTrue(allowed(self.request, self.file))
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: False)
-    def test_reviewer_unallowed(self):
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_addon_ownership',
+                  lambda request, addon, viewer, dev: False)
+    def test_viewer_unallowed(self):
         self.assertRaises(PermissionDenied, allowed, self.request, self.file)
 
-    @patch.object(acl, 'check_addons_reviewer', lambda x: False)
     def test_addon_not_found(self):
-        class MockVersion():
+        class MockVersion:
             @property
             def addon(self):
                 raise ObjectDoesNotExist
         self.file.version = MockVersion()
         self.assertRaises(http.Http404, allowed, self.request, self.file)
+
+    def get_unlisted_addon_file(self):
+        addon = amo.tests.addon_factory(is_listed=False)
+        return addon, addon.versions.get().files.get()
+
+    @patch.object(acl, 'check_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_addon_ownership',
+                  lambda request, addon, viewer, dev: False)
+    def test_unlisted_viewer_unallowed(self):
+        addon, file_ = self.get_unlisted_addon_file()
+        with pytest.raises(http.Http404):
+            allowed(self.request, file_)
+
+    @patch.object(acl, 'check_addons_reviewer', lambda x: True)
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_addon_ownership',
+                  lambda request, addon, viewer, dev: False)
+    def test_unlisted_reviewer_unallowed(self):
+        addon, file_ = self.get_unlisted_addon_file()
+        with pytest.raises(http.Http404):
+            allowed(self.request, file_)
+
+    @patch.object(acl, 'check_addons_reviewer', lambda x: True)
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: True)
+    def test_unlisted_admin_reviewer_allowed(self):
+        addon, file_ = self.get_unlisted_addon_file()
+        assert allowed(self.request, file_)
+
+    @patch.object(acl, 'check_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
+    @patch.object(acl, 'check_addon_ownership',
+                  lambda request, addon, viewer, dev: True)
+    def test_unlisted_owner_allowed(self):
+        addon, file_ = self.get_unlisted_addon_file()
+        assert allowed(self.request, file_)

--- a/apps/files/tests/test_views.py
+++ b/apps/files/tests/test_views.py
@@ -461,6 +461,11 @@ class TestFileViewer(FilesBase, amo.tests.TestCase):
             eq_(doc('#id_left option[value=%d]' % f.id).text(),
                 PLATFORM_NAME)
 
+    def test_files_for_unlisted_addon_returns_404(self):
+        """Files browsing isn't allowed for unlisted addons."""
+        self.addon.update(is_listed=False)
+        assert self.client.get(self.file_url()).status_code == 404
+
 
 class TestDiffViewer(FilesBase, amo.tests.TestCase):
     fixtures = ['base/addon_3615', 'base/users']

--- a/apps/reviews/models.py
+++ b/apps/reviews/models.py
@@ -79,7 +79,7 @@ class Review(amo.models.ModelBase):
 
     # The order of those managers is very important: please read the lengthy
     # comment above the Addon managers declaration/instanciation.
-    with_deleted = ReviewManager(include_deleted=True)
+    unfiltered = ReviewManager(include_deleted=True)
     objects = ReviewManager()
 
     class Meta:

--- a/apps/reviews/tests/test_models.py
+++ b/apps/reviews/tests/test_models.py
@@ -35,17 +35,17 @@ class TestReviewModel(amo.tests.TestCase):
 
     def test_soft_delete(self):
         eq_(Review.objects.count(), 2)
-        eq_(Review.with_deleted.count(), 2)
+        eq_(Review.unfiltered.count(), 2)
 
         Review.objects.get(id=1).delete()
 
         eq_(Review.objects.count(), 1)
-        eq_(Review.with_deleted.count(), 2)
+        eq_(Review.unfiltered.count(), 2)
 
         Review.objects.filter(id=2).delete()
 
         eq_(Review.objects.count(), 0)
-        eq_(Review.with_deleted.count(), 2)
+        eq_(Review.unfiltered.count(), 2)
 
     def test_filter_for_many_to_many(self):
         # Check https://bugzilla.mozilla.org/show_bug.cgi?id=1142035.

--- a/apps/reviews/tests/test_views.py
+++ b/apps/reviews/tests/test_views.py
@@ -137,6 +137,12 @@ class TestViews(ReviewTest):
         classes = sorted(c.get('class') for c in actions.find('li a'))
         eq_(classes, ['delete-review', 'review-edit'])
 
+    def test_cant_view_unlisted_addon_reviews(self):
+        """An unlisted addon doesn't have reviews."""
+        self.addon.update(is_listed=False)
+        assert self.client.get(helpers.url('addons.reviews.list',
+                                           self.addon.slug)).status_code == 404
+
 
 class TestFlag(ReviewTest):
 
@@ -370,6 +376,11 @@ class TestCreate(ReviewTest):
             eq_(ff[0].flag, True)
             eq_(ff[0].editorreview, True)
             eq_(rf[0].note, 'URLs')
+
+    def test_cant_review_unlisted_addon(self):
+        """Can't review an unlisted addon."""
+        self.addon.update(is_listed=False)
+        assert self.client.get(self.add).status_code == 404
 
 
 class TestEdit(ReviewTest):

--- a/apps/stats/views.py
+++ b/apps/stats/views.py
@@ -23,7 +23,7 @@ from product_details import product_details
 
 import amo
 from access import acl
-from addons.decorators import addon_view, addon_view_factory
+from addons.decorators import addon_view_factory
 from addons.models import Addon
 from amo.decorators import allow_cross_site_request, json_view, login_required
 from amo.urlresolvers import reverse
@@ -47,6 +47,9 @@ COLLECTION_SERIES = ('downloads', 'subscribers', 'ratings')
 GLOBAL_SERIES = ('addons_in_use', 'addons_updated', 'addons_downloaded',
                  'collections_created', 'reviews_created', 'addons_created',
                  'users_created', 'my_apps')
+
+
+addon_view_with_unlisted = addon_view_factory(qs=Addon.with_unlisted.all)
 
 
 def dashboard(request):
@@ -140,7 +143,7 @@ def extract(dicts):
     return extracted
 
 
-@addon_view
+@addon_view_with_unlisted
 def overview_series(request, addon, group, start, end, format):
     """Combines downloads_series and updates_series into one payload."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -185,7 +188,7 @@ def zip_overview(downloads, updates):
                'data': {'downloads': dl_count, 'updates': up_count}}
 
 
-@addon_view
+@addon_view_with_unlisted
 def downloads_series(request, addon, group, start, end, format):
     """Generate download counts grouped by ``group`` in ``format``."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -199,7 +202,7 @@ def downloads_series(request, addon, group, start, end, format):
         return render_json(request, addon, series)
 
 
-@addon_view
+@addon_view_with_unlisted
 def sources_series(request, addon, group, start, end, format):
     """Generate download source breakdown."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -216,7 +219,7 @@ def sources_series(request, addon, group, start, end, format):
         return render_json(request, addon, series)
 
 
-@addon_view
+@addon_view_with_unlisted
 def usage_series(request, addon, group, start, end, format):
     """Generate ADU counts grouped by ``group`` in ``format``."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -232,7 +235,7 @@ def usage_series(request, addon, group, start, end, format):
         return render_json(request, addon, series)
 
 
-@addon_view
+@addon_view_with_unlisted
 def usage_breakdown_series(request, addon, group,
                            start, end, format, field):
     """Generate ADU breakdown of ``field``."""
@@ -330,7 +333,7 @@ def check_stats_permission(request, addon, for_contributions=False):
     raise PermissionDenied
 
 
-@addon_view_factory(Addon.objects.valid)
+@addon_view_factory(qs=Addon.with_unlisted.valid)
 def stats_report(request, addon, report):
     check_stats_permission(request, addon,
                            for_contributions=(report == 'contributions'))
@@ -439,7 +442,7 @@ def site_event_format(request, events):
         }
 
 
-@addon_view
+@addon_view_with_unlisted
 def contributions_series(request, addon, group, start, end, format):
     """Generate summarized contributions grouped by ``group`` in ``format``."""
     date_range = check_series_params_or_404(group, start, end, format)

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -1275,6 +1275,42 @@ class TestProfileSections(amo.tests.TestCase):
         eq_(items('.install[data-addon=3615]').length, 1)
         eq_(items('.install[data-addon=5299]').length, 1)
 
+    def test_my_unlisted_addons(self):
+        """I can't see my own unlisted addons on my profile page."""
+        eq_(pq(self.client.get(self.url).content)('.num-addons a').length, 0)
+
+        AddonUser.objects.create(user=self.user, addon_id=3615)
+        Addon.objects.get(pk=5299).update(is_listed=False)
+        AddonUser.objects.create(user=self.user, addon_id=5299)
+
+        r = self.client.get(self.url)
+        assert list(r.context['addons'].object_list) == [
+            Addon.objects.get(pk=3615)]
+
+        doc = pq(r.content)
+        items = doc('#my-addons .item')
+        eq_(items.length, 1)
+        eq_(items('.install[data-addon=3615]').length, 1)
+
+    def test_not_my_unlisted_addons(self):
+        """I can't see others' unlisted addons on their profile pages."""
+        res = self.client.get('/user/999/', follow=True)
+        eq_(pq(res.content)('.num-addons a').length, 0)
+
+        user = UserProfile.objects.get(pk=999)
+        AddonUser.objects.create(user=user, addon_id=3615)
+        Addon.objects.get(pk=5299).update(is_listed=False)
+        AddonUser.objects.create(user=user, addon_id=5299)
+
+        r = self.client.get('/user/999/', follow=True)
+        assert list(r.context['addons'].object_list) == [
+            Addon.objects.get(pk=3615)]
+
+        doc = pq(r.content)
+        items = doc('#my-addons .item')
+        eq_(items.length, 1)
+        eq_(items('.install[data-addon=3615]').length, 1)
+
     def test_my_personas(self):
         eq_(pq(self.client.get(self.url).content)('.num-addons a').length, 0)
 

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -94,8 +94,10 @@ class Version(amo.models.OnChangeMixin, amo.models.ModelBase):
     source = models.FileField(
         upload_to=source_upload_path, null=True, blank=True)
 
+    # The order of those managers is very important: please read the lengthy
+    # comment above the Addon managers declaration/instanciation.
+    unfiltered = VersionManager(include_deleted=True)
     objects = VersionManager()
-    with_deleted = VersionManager(include_deleted=True)
 
     class Meta(amo.models.ModelBase.Meta):
         db_table = 'versions'

--- a/migrations/599-backfill-app-features.py
+++ b/migrations/599-backfill-app-features.py
@@ -1,23 +1,3 @@
 #!/usr/bin/env python
-from django.db.utils import IntegrityError
-
-from versions.models import Version
-from mkt.webapps.models import AppFeatures, Webapp
-
-
 def run():
-    for app in Webapp.with_deleted.all():
-        for ver in Version.with_deleted.filter(addon=app):
-            try:
-                ver.features
-            except AppFeatures.DoesNotExist:
-                try:
-                    AppFeatures.objects.create(version=ver)
-                except IntegrityError as e:
-                    print ('[Webapp:%s] IntegrityError while trying to create '
-                           'AppFeatures for version %s: %s' % (app.id, ver.id,
-                                                               e))
-                except Exception as e:
-                    print ('[Webapp:%s] Exception while trying to create '
-                           'AppFeatures for version %s: %s' % (app.id, ver.id,
-                                                               e))
+    pass  # Obsolete migration


### PR DESCRIPTION
Fixes [bug 1121244](https://bugzilla.mozilla.org/show_bug.cgi?id=1121244)

This bug "hides" the unlisted addons from everywhere. Sub-bugs will deal with displaying them in the places we want them (devhub/editor tools).

This bug is in particular about making sure that unlisted addons don't appear (unless when it's needed for owners/admins) in public pages:
- author profile
- addon pages
   - user reviews
   - statistics
   - versions page
   - browse files
   - download files
- searches