### PR TITLE
Display/edit unlisted addons through the devhub (bug 1144676)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -538,6 +538,8 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
         return urls
 
     def get_url_path(self, more=False, add_prefix=True):
+        if not self.is_listed:  # Not listed? Doesn't have a public page.
+            return ''
         # If more=True you get the link to the ajax'd middle chunk of the
         # detail page.
         view = 'addons.detail_more' if more else 'addons.detail'

--- a/apps/addons/views.py
+++ b/apps/addons/views.py
@@ -244,59 +244,52 @@ class BaseFilter(object):
 
     def filter(self, field):
         """Get the queryset for the given field."""
-        filter = self._filter(field) & self.base_queryset
-        order = getattr(self, 'order_%s' % field, None)
-        if order:
-            return order(filter)
-        return filter
-
-    def _filter(self, field):
-        return getattr(self, 'filter_%s' % field)()
+        return getattr(self, 'filter_{0}'.format(field))()
 
     def filter_featured(self):
         ids = self.model.featured_random(self.request.APP, self.request.LANG)
-        return manual_order(self.model.objects, ids, 'addons.id')
+        return manual_order(self.base_queryset, ids, 'addons.id')
 
     def filter_free(self):
         if self.model == Addon:
-            return self.model.objects.top_free(self.request.APP, listed=False)
+            return self.base_queryset.top_free(self.request.APP, listed=False)
         else:
-            return self.model.objects.top_free(listed=False)
+            return self.base_queryset.top_free(listed=False)
 
     def filter_paid(self):
         if self.model == Addon:
-            return self.model.objects.top_paid(self.request.APP, listed=False)
+            return self.base_queryset.top_paid(self.request.APP, listed=False)
         else:
-            return self.model.objects.top_paid(listed=False)
+            return self.base_queryset.top_paid(listed=False)
 
     def filter_popular(self):
-        return (self.model.objects.order_by('-weekly_downloads')
+        return (self.base_queryset.order_by('-weekly_downloads')
                 .with_index(addons='downloads_type_idx'))
 
     def filter_downloads(self):
         return self.filter_popular()
 
     def filter_users(self):
-        return (self.model.objects.order_by('-average_daily_users')
+        return (self.base_queryset.order_by('-average_daily_users')
                 .with_index(addons='adus_type_idx'))
 
     def filter_created(self):
-        return (self.model.objects.order_by('-created')
+        return (self.base_queryset.order_by('-created')
                 .with_index(addons='created_type_idx'))
 
     def filter_updated(self):
-        return (self.model.objects.order_by('-last_updated')
+        return (self.base_queryset.order_by('-last_updated')
                 .with_index(addons='last_updated_type_idx'))
 
     def filter_rating(self):
-        return (self.model.objects.order_by('-bayesian_rating')
+        return (self.base_queryset.order_by('-bayesian_rating')
                 .with_index(addons='rating_type_idx'))
 
     def filter_hotness(self):
-        return self.model.objects.order_by('-hotness')
+        return self.base_queryset.order_by('-hotness')
 
     def filter_name(self):
-        return order_by_translation(self.model.objects.all(), 'name')
+        return order_by_translation(self.base_queryset.all(), 'name')
 
 
 class ESBaseFilter(BaseFilter):

--- a/apps/browse/views.py
+++ b/apps/browse/views.py
@@ -240,11 +240,8 @@ class CategoryLandingFilter(BaseFilter):
                                                     default)
 
     def filter_featured(self):
-        # Never fear this will get & with manual order and the base.
-        return Addon.objects.all()
-
-    def order_featured(self, filter):
-        return manual_order(filter, self.ids, pk_name='addons.id')
+        qs = self.base_queryset.all()
+        return manual_order(qs, self.ids, pk_name='addons.id')
 
 
 def category_landing(request, category, addon_type=amo.ADDON_EXTENSION,
@@ -278,27 +275,27 @@ class PersonasFilter(BaseFilter):
             ('popular', _lazy(u'Most Popular')),
             ('rating', _lazy(u'Top Rated')))
 
-    def _filter(self, field):
+    def filter(self, field):
         # Special case with dashes.
         if field == 'up-and-coming':
             # See bug 944096 related to the popularity.
-            return (self.model.objects.filter(persona__popularity__gte=100)
+            return (self.base_queryset.filter(persona__popularity__gte=100)
                     .order_by('-persona__movers'))
         else:
-            return super(PersonasFilter, self)._filter(field)
+            return super(PersonasFilter, self).filter(field)
 
     def filter_created(self):
-        return self.model.objects.order_by('-created')
+        return self.base_queryset.order_by('-created')
 
     def filter_popular(self):
-        return self.model.objects.order_by('-persona__popularity')
+        return self.base_queryset.order_by('-persona__popularity')
 
     def filter_rating(self):
-        return self.model.objects.order_by('-bayesian_rating')
+        return self.base_queryset.order_by('-bayesian_rating')
 
 
 def personas_listing(request, category_slug=None):
-    # Common pieces using by browse and search.
+    # Common pieces used by browse and search.
     TYPE = amo.ADDON_PERSONA
     q = Category.objects.filter(type=TYPE)
     categories = order_by_translation(q, 'name')

--- a/apps/devhub/templates/devhub/addons/edit/basic.html
+++ b/apps/devhub/templates/devhub/addons/edit/basic.html
@@ -40,7 +40,7 @@
                 {{ form.slug.errors }}
               {% else %}
                 {{ settings.SITE_URL }}/&hellip;/{{ addon.slug }}
-                <a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a>
+                {% if addon.is_listed %}<a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a>{% endif %}
               {% endif %}
             </td>
           </tr>

--- a/apps/devhub/templates/devhub/addons/listing/item_actions.html
+++ b/apps/devhub/templates/devhub/addons/listing/item_actions.html
@@ -59,12 +59,9 @@
           <li><a href="{{ url }}">{{ title }}</a></li>
         {% endfor %}
       </ul>
-      {% set view_urls = ((addon.get_url_path(), _('View Add-on Listing')),
-                          (url('devhub.feed', addon.slug), _('View Recent Changes'))) %}
       <ul>
-        {% for url, title in view_urls %}
-          <li><a href="{{ url }}">{{ title }}</a></li>
-        {% endfor %}
+        {% if addon.is_listed %}<li><a href="{{ addon.get_url_path() }}">{{ _('View Add-on Listing') }}</a></li>{% endif %}
+        <li><a href="{{ url('devhub.feed', addon.slug) }}">{{ _('View Recent Changes') }}</a></li>
       </ul>
     </div>
   </li>

--- a/apps/devhub/templates/devhub/includes/addon_details.html
+++ b/apps/devhub/templates/devhub/includes/addon_details.html
@@ -1,4 +1,5 @@
 {% from "includes/forms.html" import tip %}
+{% from "devhub/includes/macros.html" import link_if_listed_else_text %}
 
 {% macro status_and_tip(addon, tip) %}
   {% if addon.status != amo.STATUS_DISABLED and addon.disabled_by_user %}
@@ -82,12 +83,10 @@
 {% if addon.current_version %}
   <li>
     <strong>{{ _('Current Version:') }}</strong>
-    <a href="{{ addon.current_version.get_url_path() }}">
-      {{ addon.current_version }}
-      <span class="tip tooltip" title="{{ _('This is the version of your add-on that will
-                                             be installed if someone clicks the Install
-                                             button on addons.mozilla.org.') }}">?</span>
-    </a>
+    {{ link_if_listed_else_text(addon.current_version, addon.current_version) }}
+    <span class="tip tooltip" title="{{ _('This is the version of your add-on that will
+                                           be installed if someone clicks the Install
+                                           button on addons.mozilla.org.') }}">?</span>
   </li>
 {% endif %}
 {% if sorting == 'created' %}
@@ -106,11 +105,9 @@
 {% if addon.latest_version and addon.latest_version != addon.current_version %}
   <li>
     <strong>{{ _('Next Version:') }}</strong>
-    <a href="{{ addon.latest_version.get_url_path() }}">
-      {{ addon.latest_version.version }}
-      <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however
-                                             it isn’t live on the site yet.') }}">?</span>
-    </a>
+    {{ link_if_listed_else_text(addon.latest_version, addon.latest_version.version) }}
+    <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however
+                                           it isn’t live on the site yet.') }}">?</span>
   </li>
 {% endif %}
 {% with position = get_position(addon) %}

--- a/apps/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/apps/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -43,8 +43,8 @@
       </li>
     </ul>
     <ul class="refinements">
-      <li><a href="{{ addon.get_url_path() }}">
-        {{ _('View Listing') }}</a></li>
+      {% if addon.is_listed %}<li><a href="{{ addon.get_url_path() }}">
+        {{ _('View Listing') }}</a></li>{% endif %}
       <li><a href="{{ url('devhub.feed', addon.slug) }}">
         {{ _('View Recent Changes') }}</a></li>
       {% if not theme %}

--- a/apps/devhub/templates/devhub/includes/macros.html
+++ b/apps/devhub/templates/devhub/includes/macros.html
@@ -76,3 +76,11 @@
     {{ form.categories.errors }}
   </div>
 {% endmacro %}
+
+{% macro link_if_listed_else_text(addon_or_version, text) %}
+  {% if addon_or_version.is_listed %}
+    <a href="{{ addon_or_version.get_url_path() }}">{{ text }}</a>
+  {% else %}
+    {{ text }}
+  {% endif %}
+{% endmacro %}

--- a/apps/devhub/templates/devhub/index.html
+++ b/apps/devhub/templates/devhub/index.html
@@ -1,4 +1,5 @@
 {% extends "devhub/base_impala.html" %}
+{% from "devhub/includes/macros.html" import link_if_listed_else_text %}
 
 {% macro docs_ul(docs) %}
   <ul class="listing-list">
@@ -88,9 +89,8 @@
                     {% if item.addon.current_version %}
                       <p>
                         <strong>{{ _('Latest Version:') }}</strong>
-                        <a href="{{ item.addon.current_version.get_url_path() }}">
-                          {{ item.addon.current_version.version }}
-                        </a>
+                        {{ link_if_listed_else_text(item.addon.current_version,
+                                         item.addon.current_version.version) }}
                       </p>
                     {% endif %}
                     {% with position = item.position %}

--- a/apps/devhub/templates/devhub/nav.html
+++ b/apps/devhub/templates/devhub/nav.html
@@ -13,7 +13,7 @@
         <a href="{{ url('devhub.addons') }}" class="controller">
             {{ _('My Add-ons') }}</a>
         <ul>
-          {% set my_addons = request.amo_user.my_addons() %}
+          {% set my_addons = request.amo_user.my_addons(with_unlisted=True) %}
           {% for addon in my_addons %}
             {% if loop.index == 8 %}
               <li><a href="{{ url('devhub.addons') }}">

--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -274,7 +274,7 @@
 
   <strong>{{ _('Actions') }}</strong>
   <ul id="actions-addon">
-    <li><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></li>
+    {% if addon.is_listed %}<li><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></li>{% endif %}
     {% if is_admin %}
     <li><a href="{{ addon.get_dev_url() }}">{{ _('Edit') }}</a> <em>{{ _('(admin)') }}</em></li>
     <li><a href="{{ url('zadmin.addon_manage', addon.id) }}">{{ _('Admin Page') }}</a> <em>{{ _('(admin)') }}</em></li>

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -2030,11 +2030,27 @@ class TestReview(ReviewBase):
         ]
         check_links(expected, pq(r.content)('#actions-addon a'), verify=False)
 
+    def test_action_links_unlisted_addon(self):
+        self.addon.update(is_listed=False)
+        r = self.client.get(self.url)
+        check_links([], pq(r.content)('#actions-addon a'), verify=False)
+
     def test_action_links_as_admin(self):
         self.login_as_admin()
         r = self.client.get(self.url)
         expected = [
             ('View Listing', self.addon.get_url_path()),
+            ('Edit', self.addon.get_dev_url()),
+            ('Admin Page',
+             reverse('zadmin.addon_manage', args=[self.addon.id])),
+        ]
+        check_links(expected, pq(r.content)('#actions-addon a'), verify=False)
+
+    def test_action_links_as_admin_unlisted_addon(self):
+        self.addon.update(is_listed=False)
+        self.login_as_admin()
+        r = self.client.get(self.url)
+        expected = [
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page',
              reverse('zadmin.addon_manage', args=[self.addon.id])),

--- a/apps/files/tests/test_decorators.py
+++ b/apps/files/tests/test_decorators.py
@@ -18,8 +18,7 @@ class AllowedTest(amo.tests.TestCase):
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: False)
     @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
-    @patch.object(acl, 'check_addon_ownership',
-                  lambda request, addon, viewer, dev: True)
+    @patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: True)
     def test_owner_allowed(self):
         self.assertTrue(allowed(self.request, self.file))
 
@@ -30,8 +29,7 @@ class AllowedTest(amo.tests.TestCase):
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: False)
     @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
-    @patch.object(acl, 'check_addon_ownership',
-                  lambda request, addon, viewer, dev: False)
+    @patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_viewer_unallowed(self):
         self.assertRaises(PermissionDenied, allowed, self.request, self.file)
 
@@ -49,8 +47,7 @@ class AllowedTest(amo.tests.TestCase):
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: False)
     @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
-    @patch.object(acl, 'check_addon_ownership',
-                  lambda request, addon, viewer, dev: False)
+    @patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_unlisted_viewer_unallowed(self):
         addon, file_ = self.get_unlisted_addon_file()
         with pytest.raises(http.Http404):
@@ -58,8 +55,7 @@ class AllowedTest(amo.tests.TestCase):
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: True)
     @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
-    @patch.object(acl, 'check_addon_ownership',
-                  lambda request, addon, viewer, dev: False)
+    @patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_unlisted_reviewer_unallowed(self):
         addon, file_ = self.get_unlisted_addon_file()
         with pytest.raises(http.Http404):
@@ -73,8 +69,7 @@ class AllowedTest(amo.tests.TestCase):
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: False)
     @patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
-    @patch.object(acl, 'check_addon_ownership',
-                  lambda request, addon, viewer, dev: True)
+    @patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: True)
     def test_unlisted_owner_allowed(self):
         addon, file_ = self.get_unlisted_addon_file()
         assert allowed(self.request, file_)

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -269,9 +269,12 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase,
         return self.addons.reviewed().filter(
             addonuser__user=self, addonuser__listed=True).count()
 
-    def my_addons(self, n=8):
+    def my_addons(self, n=8, with_unlisted=False):
         """Returns n addons"""
-        qs = order_by_translation(self.addons, 'name')
+        addons = self.addons
+        if with_unlisted:
+            addons = self.addons.model.with_unlisted.filter(authors=self)
+        qs = order_by_translation(addons, 'name')
         return qs[:n]
 
     @property

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -156,6 +156,16 @@ class TestUserProfile(amo.tests.TestCase):
         addons = UserProfile.objects.get(id=2519).my_addons()
         eq_(sorted(a.name for a in addons), [addon1.name, addon2.name])
 
+    def test_my_addons_with_unlisted_addons(self):
+        """Test helper method can return unlisted addons."""
+        addon1 = Addon.objects.create(name='test-1', type=amo.ADDON_EXTENSION)
+        AddonUser.objects.create(addon_id=addon1.id, user_id=2519, listed=True)
+        addon2 = Addon.objects.create(name='test-2', type=amo.ADDON_EXTENSION,
+                                      is_listed=False)
+        AddonUser.objects.create(addon_id=addon2.id, user_id=2519, listed=True)
+        addons = UserProfile.objects.get(id=2519).my_addons(with_unlisted=True)
+        eq_(sorted(a.name for a in addons), [addon1.name, addon2.name])
+
     def test_mobile_collection(self):
         u = UserProfile.objects.get(id='4043307')
         assert not Collection.objects.filter(author=u)

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -214,6 +214,8 @@ class Version(amo.models.OnChangeMixin, amo.models.ModelBase):
         return self.addon.flush_urls()
 
     def get_url_path(self):
+        if not self.addon.is_listed:  # Not listed? Doesn't have a public page.
+            return ''
         return reverse('addons.versions', args=[self.addon.slug, self.version])
 
     def delete(self):
@@ -487,6 +489,10 @@ class Version(amo.models.OnChangeMixin, amo.models.ModelBase):
         """Sign the files for this version if it's an extension."""
         if self.addon.type == amo.ADDON_EXTENSION:
             packaged.sign(self)
+
+    @property
+    def is_listed(self):
+        return self.addon.is_listed
 
 
 @Version.on_change


### PR DESCRIPTION
Fixes [bug 1144676](https://bugzilla.mozilla.org/show_bug.cgi?id=1144676)

This PR is based on PR #479, only the last commit is relevant to this bug