### PR TITLE
Unlisted addons can be reviewed in the editor tools (bug 1144708)

### DIFF
--- a/apps/addons/templates/addons/details_box.html
+++ b/apps/addons/templates/addons/details_box.html
@@ -100,8 +100,9 @@
               <tr class="meta-abuse">
                 <th>{{ _('Abuse Reports') }}</th>
                 <td>
-                  <a href="{{ url('editors.abuse_reports', addon.slug) }}">
-                    <strong>{{ addon.abuse_reports.count()|numberfmt }}</strong></a>
+                  {% if addon.is_listed %}<a href="{{ url('editors.abuse_reports', addon.slug) }}">{% endif %}
+                    <strong>{{ addon.abuse_reports.count()|numberfmt }}</strong>
+                  {% if addon.is_listed %}</a>{% endif %}
                 </td>
               </tr>
               {% if not show_actions %}

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -1439,6 +1439,11 @@ class TestAddonManagement(amo.tests.TestCase):
         self.url = reverse('zadmin.addon_manage', args=[self.addon.slug])
         self.client.login(username='admin@mozilla.com', password='password')
 
+    def test_can_manage_unlisted_addons(self):
+        """Unlisted addons can be managed too."""
+        self.addon.update(is_listed=False)
+        assert self.client.get(self.url).status_code == 200
+
     def _form_data(self, data=None):
         initial_data = {
             'status': '4',

--- a/apps/zadmin/views.py
+++ b/apps/zadmin/views.py
@@ -22,7 +22,7 @@ from hera.contrib.django_utils import get_hera, flush_urls
 
 import amo
 import amo.search
-from addons.decorators import addon_view
+from addons.decorators import addon_view_factory
 from addons.models import Addon, AddonUser, CompatOverride
 from addons.search import get_mappings as get_addons_mappings
 from amo import messages, get_user
@@ -662,9 +662,8 @@ def general_search(request, app_id, model_id):
 
 
 @admin_required(reviewers=True)
-@addon_view
+@addon_view_factory(qs=Addon.with_unlisted.all)
 def addon_manage(request, addon):
-
     form = AddonStatusForm(request.POST or None, instance=addon)
     pager = amo.utils.paginate(request, addon.versions.all(), 30)
     # A list coercion so this doesn't result in a subquery with a LIMIT which


### PR DESCRIPTION
Fixes [bug 1144708](https://bugzilla.mozilla.org/show_bug.cgi?id=1144708)

This PR is based on PR #489, which is based on PR #487, which is based on PR #484, which is based on #479, only the last commit is relevant to this bug