### PR TITLE
Change wording for unlisted addons submission step 7 (bug 1148440)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/done.html
+++ b/apps/devhub/templates/devhub/addons/submit/done.html
@@ -6,14 +6,14 @@
 
 {% block primary %}
 <h3>{{ _("You're done!") }}</h3>
-<p>
-{% if addon.status == amo.STATUS_UNREVIEWED %}
-  {{ _('Your add-on has been submitted to the Preliminary Review queue.') }}
-{% elif addon.status == amo.STATUS_NOMINATED %}
-  {{ _('Your add-on has been submitted to the Full Review queue.') }}
-{% endif %}
-</p>
 {% if addon.is_listed %}
+  <p>
+  {% if addon.status == amo.STATUS_UNREVIEWED %}
+    {{ _('Your add-on has been submitted to the Preliminary Review queue.') }}
+  {% elif addon.status == amo.STATUS_NOMINATED %}
+    {{ _('Your add-on has been submitted to the Full Review queue.') }}
+  {% endif %}
+  </p>
   <p>
     {{ _('You\'ll receive an email once it has been reviewed by an editor. In
           the meantime, you and your friends can install it directly from its
@@ -40,6 +40,7 @@
 
   <div id="editor-pitch" class="action-needed">
   <h3>{{ _('Get Ahead in the Review Queue!') }}</h3>
+
   <p>
     {{ _('Become an AMO Reviewer today and get your add-ons reviewed faster.') }}
     <a class="button learn-more" href="https://wiki.mozilla.org/AMO:Editors">
@@ -47,12 +48,44 @@
   </p>
   </div>
 {% else %}
+  {% set signed = addon.status in [amo.STATUS_PUBLIC, amo.STATUS_LITE] %}
+  {% if signed %}
+    <p>
+      {{ _('Your add-on has been signed and it\'s ready to use. You can download it here:') }}
+    </p>
+    <p>
+      {% set version_url = url('devhub.versions.edit', addon.slug, addon.current_version.id) %}
+      <a id="download-addon-url" href="{{ version_url }}">
+        {{ version_url|absolutify|display_url }}</a>
+    </p>
+  {% else %}
+    <p>
+    {% if addon.status == amo.STATUS_UNREVIEWED %}
+      {{ _('Your add-on has been submitted to the Unlisted Preliminary Review queue.') }}
+    {% elif addon.status == amo.STATUS_NOMINATED %}
+      {{ _('Your add-on has been submitted to the Unlisted Full Review queue.') }}
+    {% endif %}
+    </p>
+    <p>
+      {{ _('You\'ll receive an email once it has been reviewed by an editor and signed.') }}
+    </p>
+  {% endif %}
   <p>
-    {{ _('You\'ll receive an email once it has been reviewed by an editor.') }}
-    <strong>{{ _('Your add-on will not be publicly available on AMO.') }}</strong>
+    <strong>{{ _('Your add-on will not be publicly available on this website.') }}</strong>
   </p>
-  <p>
-    {{ _('If you need to adjust any details of your add-on please <a href="{0}">edit the listing</a>.')|f(addon.get_dev_url()) }}
-  </p>
+  <div class="done-next-steps">
+    <p><strong>{{ _('Next steps:') }}</strong></p>
+    <ul>
+      {% if is_platform_specific %}
+        {% set files_url = url('devhub.versions.edit',
+                                addon.slug, addon.current_version.id) %}
+        <li>{{ _('<a href="{0}">Upload</a> another platform-specific file to this version.')|f(files_url) }}</li>
+      {% endif %}
+      <li>{{ _('You can upload new versions of your add-on in the <a href="{0}">add-on\'s developer page</a>.')|f(addon.get_dev_url()) }}</li>
+      {% if not signed %}
+        <li>{{ _('View approximate review queue <a href="{0}">wait times</a>.')|f('https://forums.addons.mozilla.org/viewforum.php?f=21') }}</li>
+      {% endif %}
+    </ul>
+  </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes [bug 1148440](https://bugzilla.mozilla.org/show_bug.cgi?id=1148440)

Unlisted addon, queued:
![screen shot 2015-04-09 at 16 06 59](https://cloud.githubusercontent.com/assets/167767/7068439/ab7ac4d2-ded2-11e4-8bb2-3ff7d28383e8.png)

Unlisted addon, signed:
![screen shot 2015-04-09 at 16 08 03](https://cloud.githubusercontent.com/assets/167767/7068440/b1c87492-ded2-11e4-9ded-68f9e5c957e2.png)
