### PR TITLE
Add a checkbox to unlisted addon submission step 2 for side-loading (bug 1148446)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -507,6 +507,14 @@ class NewAddonForm(AddonUploadForm):
         help_text=_(
             u'Uncheck this option if you intend to distribute your add-on on '
             u'your own and only need it to be signed by Mozilla.'))
+    is_sideload = forms.BooleanField(
+        initial=False,
+        required=False,
+        label=_lazy(u'This add-on will be side-loaded via application '
+                    u'installers.'),
+        help_text=_(u'Add-ons that are side-loaded will be code reviewed by '
+                    u'Mozilla before they are signed and are held to a higher '
+                    u'quality standard.'))
 
     def clean(self):
         if not self.errors:

--- a/apps/devhub/templates/devhub/addons/submit/upload.html
+++ b/apps/devhub/templates/devhub/addons/submit/upload.html
@@ -28,6 +28,12 @@
         <span class="tip tooltip"
               title="{{ new_addon_form.is_listed.help_text }}">?</span>
       </label>
+      <label for="{{ new_addon_form.is_sideload.auto_id }}">
+        {{ new_addon_form.is_sideload }}
+        {{ new_addon_form.is_sideload.label }}
+        <span class="tip tooltip"
+              title="{{ new_addon_form.is_sideload.help_text }}">?</span>
+      </label>
     </div>
   </div>
   <input type="file" id="upload-addon"

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1157,7 +1157,9 @@ class TestSubmitStep2(amo.tests.TestCase):
         response = self.client.get(reverse('devhub.submit.2'))
         eq_(response.status_code, 200)
         doc = pq(response.content)
-        assert doc('.list-addon input[type=checkbox]')
+        assert doc('.list-addon input#id_is_listed[type=checkbox]')
+        # There also is a checkbox to select full review (side-load) or prelim.
+        assert doc('.list-addon input#id_is_sideload[type=checkbox]')
 
 
 class TestSubmitStep3(TestSubmitBase):
@@ -2622,10 +2624,10 @@ class TestVersionXSS(UploadTest):
 class UploadAddon(object):
 
     def post(self, supported_platforms=[amo.PLATFORM_ALL], expect_errors=False,
-             source=None, is_listed=True):
+             source=None, is_listed=True, is_sideload=False):
         d = dict(upload=self.upload.pk, source=source,
                  supported_platforms=[p.id for p in supported_platforms],
-                 is_listed=is_listed)
+                 is_listed=is_listed, is_sideload=is_sideload)
         r = self.client.post(self.url, d, follow=True)
         eq_(r.status_code, 200)
         if not expect_errors:
@@ -2670,6 +2672,20 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, amo.tests.TestCase):
         r = self.post(is_listed=False)
         addon = Addon.with_unlisted.get()
         assert not addon.is_listed
+        assert addon.status == amo.STATUS_UNREVIEWED  # Prelim review.
+        # Skip from step 2 to step 6.
+        self.assertRedirects(r, reverse('devhub.submit.6', args=[addon.slug]))
+        log_items = ActivityLog.objects.for_addons(addon)
+        assert log_items.filter(action=amo.LOG.CREATE_ADDON.id), (
+            'New add-on creation never logged.')
+
+    def test_success_unlisted_sideload(self):
+        eq_(Addon.objects.count(), 0)
+        r = self.post(is_listed=False, is_sideload=True)
+        addon = Addon.with_unlisted.get()
+        assert not addon.is_listed
+        # Full review for sideload addons.
+        assert addon.status == amo.STATUS_NOMINATED
         # Skip from step 2 to step 6.
         self.assertRedirects(r, reverse('devhub.submit.6', args=[addon.slug]))
         log_items = ActivityLog.objects.for_addons(addon)

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1336,6 +1336,10 @@ def submit_addon(request, step):
                                       addon.current_version)
             next_step = 3
             if not addon.is_listed:  # Not listed? Skip straight to step 6.
+                if data.get('is_sideload'):  # Full review needed.
+                    addon.update(status=amo.STATUS_NOMINATED)
+                else:  # Otherwise, simply do a prelim review.
+                    addon.update(status=amo.STATUS_UNREVIEWED)
                 next_step = 6
                 messages.info(
                     request,

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -399,6 +399,10 @@ form .char-count b {
     display: block;
     padding-bottom: 3px;
 }
+.addon-submission-process form label[for=id_is_sideload] {
+    display: none;
+    margin-left: 20px;
+}
 .submit-license input[type=checkbox] + label {
     display: inline;
     padding-bottom: 0;

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -90,12 +90,17 @@ $(document).ready(function() {
     // it'll run the validator with the "listed=False"
     // parameter.
     var $isListed = $('#id_is_listed');
-    function switchUploadUrl() {
+    var $isSideloadLabel = $('label[for=id_is_sideload]');
+    var $isSideload = $('#id_is_sideload');
+    function updateListedStatus() {
       if ($isListed.exists() &&
           $isListed.is(':checked')) {
         $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-listed'));
+        $isSideloadLabel.hide();
+        $isSideload.attr('checked', false);
       } else {
         $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-unlisted'));
+        $isSideloadLabel.show();
       }
       /* Don't allow submitting, need to reupload/revalidate the file. */
       $('.addon-upload-dependant').attr('disabled', true);
@@ -103,8 +108,9 @@ $(document).ready(function() {
                                                  'checked': false});
       $('.upload-status').remove();
     }
-    $isListed.bind('change', switchUploadUrl);
-    switchUploadUrl();
+    $isListed.bind('change', updateListedStatus);
+    $isSideload.bind('change', updateListedStatus);
+    updateListedStatus();
 
     if ($(".add-file-modal").length) {
         $modalFile = $(".add-file-modal").modal(".version-upload", {


### PR DESCRIPTION
Fixes [bug 1148446](https://bugzilla.mozilla.org/show_bug.cgi?id=1148446)

"Distribute on AMO" selected:
![screen shot 2015-04-09 at 17 46 45](https://cloud.githubusercontent.com/assets/167767/7070656/8fed786e-dee0-11e4-8fe2-b77be5c50730.png)

"Distribute on AMO" not selected:
![screen shot 2015-04-09 at 17 47 31](https://cloud.githubusercontent.com/assets/167767/7070661/984fc016-dee0-11e4-96b9-021984a57493.png)
