### PR TITLE
rename signature files from zigbert to mozilla (bug 1152102)

### DIFF
--- a/apps/addons/management/commands/sign_addons.py
+++ b/apps/addons/management/commands/sign_addons.py
@@ -27,12 +27,12 @@ class Command(BaseCommand):
                 'Please provide at least one addon id to sign. If you want to '
                 'sign them all, use the "process_addons --task sign_addons" '
                 'management command.')
-        signing_server = options.get('signing_server', settings.SIGNING_SERVER)
-        preliminary_signing_server = options.get(
-            'preliminary_signing_server', settings.PRELIMINARY_SIGNING_SERVER)
+        full_server = options.get('signing_server') or settings.SIGNING_SERVER
+        prelim_server = (options.get('preliminary_signing_server') or
+                         settings.PRELIMINARY_SIGNING_SERVER)
 
         addon_ids = [int(addon_id) for addon_id in args]
         with override_settings(
-                SIGNING_SERVER=signing_server,
-                PRELIMINARY_SIGNING_SERVER=preliminary_signing_server):
+                SIGNING_SERVER=full_server,
+                PRELIMINARY_SIGNING_SERVER=prelim_server):
             sign_addons(addon_ids)

--- a/apps/addons/tests/test_commands.py
+++ b/apps/addons/tests/test_commands.py
@@ -1,0 +1,37 @@
+import mock
+
+from django.conf import settings
+from django.core.management import call_command
+
+
+@mock.patch('lib.crypto.tasks.sign_addons')
+def test_override_settings(mock_sign_addons):
+    """You can override the (PRELIMINARY_)SIGNING_SERVER settings."""
+    assert not settings.SIGNING_SERVER
+    assert not settings.PRELIMINARY_SIGNING_SERVER
+
+    # No endpoint defined in the test settings.
+    def no_endpoint(ids):
+        assert not settings.SIGNING_SERVER
+    mock_sign_addons.side_effect = no_endpoint
+    call_command('sign_addons', 123)
+    assert mock_sign_addons.called
+
+    mock_sign_addons.reset_mock()
+
+    # Override the SIGNING_SERVER setting.
+    def signing_server(ids):
+        assert settings.SIGNING_SERVER == 'http://example.com'
+    mock_sign_addons.side_effect = signing_server
+    call_command('sign_addons', 123, signing_server='http://example.com')
+    assert mock_sign_addons.called
+
+    mock_sign_addons.reset_mock()
+
+    # Override the PRELIMINARY_SIGNING_SERVER setting.
+    def preliminary_signing_server(ids):
+        assert settings.PRELIMINARY_SIGNING_SERVER == 'http://example.com'
+    mock_sign_addons.side_effect = preliminary_signing_server
+    call_command('sign_addons', 123,
+                 preliminary_signing_server='http://example.com')
+    assert mock_sign_addons.called

--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -64,7 +64,7 @@ def call_signing(file_obj):
         with statsd.timer('services.sign.addon'):
             response = requests.post(endpoint, timeout=timeout,
                                      data={'addon_id': addon_id},
-                                     files={'file': ('zigbert.sf',
+                                     files={'file': ('mozilla.sf',
                                                      str(jar.signatures))})
     except requests.exceptions.HTTPError as error:
         # Will occur when a 3xx or greater code is returned.
@@ -82,10 +82,10 @@ def call_signing(file_obj):
         log.error(msg)
         raise SigningError(msg)
 
-    pkcs7 = b64decode(json.loads(response.content)['zigbert.rsa'])
+    pkcs7 = b64decode(json.loads(response.content)['mozilla.rsa'])
     try:
         cert_serial_num = get_signature_serial_number(pkcs7)
-        jar.make_signed(pkcs7)
+        jar.make_signed(pkcs7, sigpath='mozilla')
     except:
         msg = 'Addon signing failed'
         log.error(msg, exc_info=True)

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -18,8 +18,8 @@ def is_signed(filename):
     """Return True if the file has been signed."""
     zf = zipfile.ZipFile(filename, mode='r')
     filenames = zf.namelist()
-    return ('META-INF/zigbert.rsa' in filenames and
-            'META-INF/zigbert.sf' in filenames and
+    return ('META-INF/mozilla.rsa' in filenames and
+            'META-INF/mozilla.sf' in filenames and
             'META-INF/manifest.mf' in filenames)
 
 
@@ -62,7 +62,7 @@ class TestPackaged(amo.tests.TestCase):
         """Fake a standard trunion response."""
         class FakeResponse:
             status_code = 200
-            content = '{"zigbert.rsa": ""}'
+            content = '{"mozilla.rsa": ""}'
 
         monkeypatch.setattr(
             'requests.post', lambda url, timeout, data, files: FakeResponse)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -84,7 +84,7 @@ receipts==0.2.9
 redis==2.8.0
 requests==2.6.0
 sasl==0.1.3
-signing_clients==0.1.10
+signing_clients==0.1.12
 six==1.4.1
 slumber==0.5.3
 SQLAlchemy==0.7.5


### PR DESCRIPTION
Fixes [bug 1152102](https://bugzilla.mozilla.org/show_bug.cgi?id=1152102)