### PR TITLE
Warn if a review is needed for unlisted addons after validation (bug 1148449)

### DIFF
--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -24,7 +24,7 @@ class SigningError(Exception):
 def get_endpoint(file_obj):
     """Get the endpoint to sign the file, depending on its review status."""
     server = settings.SIGNING_SERVER
-    if file_obj.status != amo.STATUS_PUBLIC:
+    if file_obj.version.addon.status != amo.STATUS_PUBLIC:
         server = settings.PRELIMINARY_SIGNING_SERVER
     if not server:
         return

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -64,14 +64,13 @@ class TestPackaged(amo.tests.TestCase):
                             lambda pkcs7: 'serial number')
 
     def test_get_endpoint(self):
-        # self.file1 is fully reviewed, self.file2 is preliminary reviewed.
-        self.file2.update(status=amo.STATUS_LITE)
+        assert self.addon.status == amo.STATUS_PUBLIC
         with self.settings(PRELIMINARY_SIGNING_SERVER=''):
-            assert packaged.get_endpoint(self.file1)
-            assert not packaged.get_endpoint(self.file2)
+            assert packaged.get_endpoint(self.file1).startswith('http://full')
+        self.addon.update(status=amo.STATUS_LITE)
         with self.settings(SIGNING_SERVER=''):
-            assert not packaged.get_endpoint(self.file1)
-            assert packaged.get_endpoint(self.file2)
+            assert packaged.get_endpoint(self.file1).startswith(
+                'http://prelim')
 
     def test_no_file(self):
         [f.delete() for f in self.addon.current_version.all_files]

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -327,12 +327,28 @@
 
                     $("<strong>").text(message).appendTo(upload_results);
 
+                    // Specific messages for unlisted addons.
+                    var isListed = $('#id_is_listed').is(':checked'),
+                        isSideload = $('#id_is_sideload').is(':checked');
+                    if (!isListed) {
+                      if (isSideload) {
+                        $("<p>").text(gettext("Your submission will go through a manual review.")).appendTo(upload_results);
+                      } else {
+                        if (warnings === 0) {
+                          $("<p>").text(gettext("Your submission passed validation and will be automatically signed.")).appendTo(upload_results);
+                        } else {
+                          $("<p>").text(gettext("Your submission didn't pass automatic validation and will go through a manual review.")).appendTo(upload_results);
+                        }
+                      }
+                    }
+
                     if (warnings > 0) {
                         // Validation checklist
                         var checklist_box = $('<div>').attr('class', 'submission-checklist').appendTo(upload_results),
                             checklist = [
                                 gettext("Include detailed version notes (this can be done in the next step)."),
                                 gettext("If your add-on requires an account to a website in order to be fully tested, include a test username and password in the Notes to Reviewer (this can be done in the next step)."),
+                                gettext("If your add-on is intended for a limited audience you should choose Preliminary Review instead of Full Review."),
                             ],
                             warnings_id = [
                                 'set_innerHTML',
@@ -345,10 +361,6 @@
                               return this.hasOwnProperty('id') && _.contains(this.id, id);
                             };
 
-                        if (!upload_results.parents('.add-file-modal').length) {
-                            // We are uploading a file for an existing addon.
-                            checklist.push(gettext("If your add-on is intended for a limited audience, you should choose Preliminary Review instead of Full Review."));
-                        }
                         $('<h5>').text(gettext("Add-on submission checklist")).appendTo(checklist_box);
                         $('<p>').text(gettext("Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:")).appendTo(checklist_box);
                         if (results.validation.metadata.contains_binary_extension) {


### PR DESCRIPTION
Fixes [bug 1148449](https://bugzilla.mozilla.org/show_bug.cgi?id=1148449)

Only a text message is displayed, instead of a popup/prompt.

At the moment, we only do an automatic (preliminary) review and signing for submissions that result in 0 messages/errors from the validator. The implementation of the real behavior will happen with [bug 1153231](https://bugzilla.mozilla.org/show_bug.cgi?id=1153231)

I've tried doing the status changes and file signing at the `Addon.from_upload` and `File.from_upload` level, but because of all the automatic status changing done via signals and stuff it didn't quite work out. It would have made the code (that is at the moment in three places in the `apps/devhub/views.py` file) more factorized, but I'm afraid of unknown consequences if I start digging/modifying the signals.

Sideload addon:
![screen shot 2015-04-10 at 14 51 00](https://cloud.githubusercontent.com/assets/167767/7088315/f6cd7f68-df92-11e4-8f9f-d3ed02e8fc23.png)

Unlisted addon with warnings:
![screen shot 2015-04-10 at 14 50 24](https://cloud.githubusercontent.com/assets/167767/7088324/00d4cea8-df93-11e4-8f19-ccfebe541d5a.png)

Unlisted addon without warnings:
![screen shot 2015-04-10 at 15 00 47](https://cloud.githubusercontent.com/assets/167767/7088333/06a1491a-df93-11e4-892c-62e4b1207f79.png)

