### PR TITLE
Skip steps 4 to 7 for unlisted addons submission (bug 1148447)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/describe.html
+++ b/apps/devhub/templates/devhub/addons/submit/describe.html
@@ -5,7 +5,7 @@
 
 {% block primary %}
   <h3>{{ _('Step 3. Describe') }}</h3>
-  <form method="post" id="submit-describe" class="item">
+  <form method="post" id="submit-describe" class="item{% if not addon.is_listed %} unlisted{% endif %}">
     {{ csrf() }}
     <div class="addon-submission-field">
       <label for="id_name">{{ _("Name and version:") }}</label>
@@ -16,7 +16,7 @@
              value="{{ version.version }}" size="6">
       {{ form.name.errors }}
     </div>
-    <div class="addon-submission-field">
+    <div class="addon-submission-field slug-edit">
       <label>{{ _("The detail page will be:") }}</label>
       <div id="slug_edit" class="edit_with_prefix edit_initially_hidden">
         <span>{{ settings.SITE_URL }}</span>{{ form.slug }}
@@ -35,31 +35,35 @@
       {{ form.summary }}
       {{ form.summary.errors }}
       <div class="edit-addon-details">
-        {% trans %}
-          This summary will be shown in listings and searches.
-        {% endtrans %}
+        {% if addon.is_listed %}
+          {% trans %}
+            This summary will be shown in listings and searches.
+          {% endtrans %}
+        {% endif %}
         <div class="char-count"
              data-for-startswith="{{ form.summary.auto_id }}_"
              data-maxlength="{{ form.summary.field.max_length }}"></div>
       </div>
     </div>
-    <div id="addon-categories-edit" class="addon-submission-field"
-         data-max-categories="{{ amo.MAX_CATEGORIES }}">
-      {{ cat_form.non_form_errors() }}
-      {{ cat_form.management_form }}
-      {% for form in cat_form.initial_forms %}
-        {{ select_cats(amo.MAX_CATEGORIES, form) }}
-      {% endfor %}
-    </div>
-    <div class="addon-submission-field">
-      <label>{{ _('Provide a more detailed description:') }}</label>
-      {{ form.description }}
-      {{ form.description.errors }}
-      <div class="edit-addon-details">
-        {{ _("The description will appear on the detail page.") }}
-        {{ some_html_tip() }}
+    {% if addon.is_listed %}
+      <div id="addon-categories-edit" class="addon-submission-field"
+           data-max-categories="{{ amo.MAX_CATEGORIES }}">
+        {{ cat_form.non_form_errors() }}
+        {{ cat_form.management_form }}
+        {% for form in cat_form.initial_forms %}
+          {{ select_cats(amo.MAX_CATEGORIES, form) }}
+        {% endfor %}
       </div>
-    </div>
+      <div class="addon-submission-field">
+        <label>{{ _('Provide a more detailed description:') }}</label>
+        {{ form.description }}
+        {{ form.description.errors }}
+        <div class="edit-addon-details">
+          {{ _("The description will appear on the detail page.") }}
+          {{ some_html_tip() }}
+        </div>
+      </div>
+    {% endif %}
     <div class="submission-buttons addon-submission-field">
       <button type="submit">
         {{ _('Continue') }}

--- a/apps/devhub/templates/devhub/addons/submit/sidebar.html
+++ b/apps/devhub/templates/devhub/addons/submit/sidebar.html
@@ -1,22 +1,25 @@
 {# Steps below HAS_ADDON don't have an addon associated.  Once we have an
    addon we can't go back below that line. #}
 {% set HAS_ADDON = 3 %}
-{% set NAV = (_('Getting Started'),
-              _('Upload your add-on'),
-              _('Describe your add-on'),
-              _('Add images'),
-              _('Select a license'),
-              _('Select a review process'),
-              _("You're done!")) %}
+{# List of steps: (text, class). A class of 'all' means the step is relevant
+   to listed or unlisted addons, a class of 'listed' means it's only relevant
+   to listed addons, not unlisted ones. #}
+{% set NAV = ((_('Getting Started'), 'all'),
+              (_('Upload your add-on'), 'all'),
+              (_('Describe your add-on'), 'all'),
+              (_('Add images'), 'listed'),
+              (_('Select a license'), 'listed'),
+              (_('Select a review process'), 'listed'),
+              (_("You're done!"), 'all')) %}
 {% set MAX = 7 %}
 {% set BASE = 'devhub.submit.%s' %}
 <div class="highlight">
   <hgroup>
     <h3>{{ _('Submission Process') }}</h3>
   </hgroup>
-  <ol class="submit-addon-progress">
-    {% for text in NAV %}
-      <li {% if step.current == loop.index %}class="current"{% endif %}>
+  <ol class="submit-addon-progress{% if addon and not addon.is_listed %} unlisted{% endif %}">
+    {% for text, class in NAV %}
+      <li class="{{ class }}{% if step.current == loop.index %} current{% endif %}">
         {% if step.current < HAS_ADDON %}
           {% if loop.index <= step.current %}
             <a href="{{ url(BASE % loop.index) }}">{{ text }}</a>
@@ -27,7 +30,7 @@
           {# 1. We have an addon, so don't link to non-addon steps.
              2. Don't link steps above the max step the addon has reached.
              3. If step.max == MAX the addon is done, so we only show the final page. #}
-          {% if loop.index < HAS_ADDON or loop.index > step.max or step.max == MAX or not addon.is_listed %}
+          {% if loop.index < HAS_ADDON or loop.index > step.max or step.max == MAX %}
             {{ text }}
           {% else %}
             <a href="{{ url(BASE % loop.index, addon.slug) }}">{{ text }}</a>

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1098,7 +1098,7 @@ class TestSubmitBase(amo.tests.TestCase):
         self.addon = self.get_addon()
 
     def get_addon(self):
-        return Addon.objects.no_cache().get(pk=3615)
+        return Addon.with_unlisted.no_cache().get(pk=3615)
 
     def get_version(self):
         return self.get_addon().versions.get()
@@ -1203,6 +1203,31 @@ class TestSubmitStep3(TestSubmitBase):
         eq_(addon.slug, 'testname')
         eq_(addon.description, 'desc')
         eq_(addon.summary, 'Hello!')
+        # Test add-on log activity.
+        log_items = ActivityLog.objects.for_addons(addon)
+        assert not log_items.filter(action=amo.LOG.EDIT_DESCRIPTIONS.id), (
+            "Creating a description needn't be logged.")
+
+    def test_submit_unlisted_addon(self):
+        self.addon.update(is_listed=False)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        # Post and be redirected.
+        response = self.client.post(self.url, {'name': 'unlisted addon',
+                                               'slug': 'unlisted-addon',
+                                               'summary': 'summary'})
+        assert response.status_code == 302
+        assert response.url.endswith(reverse('devhub.submit.7',
+                                             args=['unlisted-addon']))
+        # Unlisted addons don't need much info, and their queue is chosen
+        # automatically on step 2, so we skip steps 4, 5 and 6.
+        assert self.get_step().step == 7
+
+        addon = self.get_addon()
+        assert addon.name == 'unlisted addon'
+        assert addon.slug == 'unlisted-addon'
+        assert addon.summary == 'summary'
         # Test add-on log activity.
         log_items = ActivityLog.objects.for_addons(addon)
         assert not log_items.filter(action=amo.LOG.EDIT_DESCRIPTIONS.id), (
@@ -1851,21 +1876,25 @@ class TestSubmitSteps(amo.tests.TestCase):
         self.assert_linked(doc, [3, 4, 5, 6])
         self.assert_highlight(doc, 6)
 
-    def test_menu_step_6_unlisted(self):
-        SubmitStep.objects.create(addon_id=3615, step=6)
-        Addon.objects.get(pk=3615).update(is_listed=False)
-        url = reverse('devhub.submit.6', args=['a3615'])
-        doc = pq(self.client.get(url).content)
-        # Skipped from step 2 to 6, as unlisted add-ons don't need listing
-        # information. Thus none of the steps from 3 to 6 should be links.
-        self.assert_linked(doc, [])
-        self.assert_highlight(doc, 6)
-
     def test_menu_step_7(self):
         url = reverse('devhub.submit.7', args=['a3615'])
         doc = pq(self.client.get(url).content)
         self.assert_linked(doc, [])
         self.assert_highlight(doc, 7)
+
+    def test_menu_step_7_unlisted(self):
+        SubmitStep.objects.create(addon_id=3615, step=7)
+        Addon.objects.get(pk=3615).update(is_listed=False)
+        url = reverse('devhub.submit.7', args=['a3615'])
+        doc = pq(self.client.get(url).content)
+        self.assert_linked(doc, [])  # Last step: no previous step linked.
+        # Skipped from step 3 to 7, as unlisted add-ons don't need listing
+        # information. Thus none of the steps from 4 to 6 should be there.
+        # For reference, the steps that are with the "listed" class (instead of
+        # "all") aren't displayed.
+        assert len(doc('.submit-addon-progress li.all')) == 4
+        # The step 7 is thus the 4th visible in the list.
+        self.assert_highlight(doc, 7)  # Current step is still the 7th.
 
 
 class TestUpload(BaseUploadTest):
@@ -2779,51 +2808,36 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, amo.tests.TestCase):
 
     @mock.patch('devhub.views.sign_file')
     def test_success_unlisted(self, mock_sign_file):
-        eq_(Addon.objects.count(), 0)
+        eq_(Addon.with_unlisted.count(), 0)
         # No validation errors or warning.
         self.upload = self.get_upload(
             'extension.xpi',
             validation=json.dumps(dict(errors=0, warnings=0, notices=2,
                                        metadata={}, messages=[])))
-        r = self.post(is_listed=False)
+        self.post(is_listed=False)
         addon = Addon.with_unlisted.get()
         assert not addon.is_listed
         assert addon.status == amo.STATUS_LITE  # Automatic signing.
         assert mock_sign_file.called
-        # Skip from step 2 to step 6.
-        self.assertRedirects(r, reverse('devhub.submit.6', args=[addon.slug]))
-        log_items = ActivityLog.objects.for_addons(addon)
-        assert log_items.filter(action=amo.LOG.CREATE_ADDON.id), (
-            'New add-on creation never logged.')
 
     @mock.patch('lib.crypto.packaged.sign_file')
     def test_success_unlisted_fail_validation(self, mock_sign_file):
-        eq_(Addon.objects.count(), 0)
-        r = self.post(is_listed=False)
+        eq_(Addon.with_unlisted.count(), 0)
+        self.post(is_listed=False)
         addon = Addon.with_unlisted.get()
         assert not addon.is_listed
         assert addon.status == amo.STATUS_UNREVIEWED  # Prelim review.
         assert not mock_sign_file.called
-        # Skip from step 2 to step 6.
-        self.assertRedirects(r, reverse('devhub.submit.6', args=[addon.slug]))
-        log_items = ActivityLog.objects.for_addons(addon)
-        assert log_items.filter(action=amo.LOG.CREATE_ADDON.id), (
-            'New add-on creation never logged.')
 
     @mock.patch('lib.crypto.packaged.sign_file')
     def test_success_unlisted_sideload(self, mock_sign_file):
-        eq_(Addon.objects.count(), 0)
-        r = self.post(is_listed=False, is_sideload=True)
+        eq_(Addon.with_unlisted.count(), 0)
+        self.post(is_listed=False, is_sideload=True)
         addon = Addon.with_unlisted.get()
         assert not addon.is_listed
         # Full review for sideload addons.
         assert addon.status == amo.STATUS_NOMINATED
         assert not mock_sign_file.called
-        # Skip from step 2 to step 6.
-        self.assertRedirects(r, reverse('devhub.submit.6', args=[addon.slug]))
-        log_items = ActivityLog.objects.for_addons(addon)
-        assert log_items.filter(action=amo.LOG.CREATE_ADDON.id), (
-            'New add-on creation never logged.')
 
     def test_missing_platforms(self):
         r = self.client.post(self.url, dict(upload=self.upload.pk))

--- a/static/css/devhub/submission.less
+++ b/static/css/devhub/submission.less
@@ -54,6 +54,12 @@ ol.submit-addon-progress {
     }
 }
 
+ol.submit-addon-progress.unlisted {
+    li.listed {
+        text-decoration: line-through;
+    }
+}
+
 #agreement-extra-links {
     font-size: 90%;
     margin-bottom: 2em;

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -80,6 +80,10 @@ ul.refinements:last-child {
     width: 370px;
 }
 
+#submit-describe.unlisted .slug-edit {
+    display: none;
+}
+
 /*#id_homepage, #id_support_url, #id_support_email {*/
 #trans-support_email input,
 #trans-homepage input,

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -92,15 +92,19 @@ $(document).ready(function() {
     var $isListed = $('#id_is_listed');
     var $isSideloadLabel = $('label[for=id_is_sideload]');
     var $isSideload = $('#id_is_sideload');
+    var $submitAddonProgress = $('.submit-addon-progress');
     function updateListedStatus() {
-      if ($isListed.exists() &&
-          $isListed.is(':checked')) {
-        $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-listed'));
-        $isSideloadLabel.hide();
-        $isSideload.attr('checked', false);
-      } else {
-        $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-unlisted'));
-        $isSideloadLabel.show();
+      if ($isListed.exists()) {
+        if ($isListed.is(':checked')) {  // It's a listed add-on.
+          $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-listed'));
+          $isSideloadLabel.hide();
+          $isSideload.attr('checked', false);
+          $submitAddonProgress.removeClass('unlisted');
+        } else {  // It's an unlisted add-on.
+          $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-unlisted'));
+          $isSideloadLabel.show();
+          $submitAddonProgress.addClass('unlisted');
+        }
       }
       /* Don't allow submitting, need to reupload/revalidate the file. */
       $('.addon-upload-dependant').attr('disabled', true);


### PR DESCRIPTION
Fixes [bug 1148447](https://bugzilla.mozilla.org/show_bug.cgi?id=1148447)
Also fixes [bug 1148448](https://bugzilla.mozilla.org/show_bug.cgi?id=1148448)

Listed addon sidebar
![screen shot 2015-04-14 at 11 40 50](https://cloud.githubusercontent.com/assets/167767/7136057/125edad4-e2ad-11e4-9ea2-cc89f7f1fe77.png)

Unlisted addon sidebar
![screen shot 2015-04-14 at 11 41 02](https://cloud.githubusercontent.com/assets/167767/7136062/1e35f450-e2ad-11e4-8674-279d84819ac3.png)

Unlisted addon (shortened) step 3
![screen shot 2015-04-14 at 13 27 54](https://cloud.githubusercontent.com/assets/167767/7136068/2bfc5908-e2ad-11e4-88ad-ff59801aa36f.png)

Unlisted addon last step (7, which is numbered 4 in this case)
![screen shot 2015-04-14 at 13 27 22](https://cloud.githubusercontent.com/assets/167767/7136074/39ba487a-e2ad-11e4-9368-dcf1e2dea327.png)
