### PR TITLE
Adjust metrics related crontab entries to ensure enough time for queries + transfer.

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -49,21 +49,21 @@ HOME=/tmp
 50 10 * * * %(z_cron)s update_google_analytics
 
 # Update ADI metrics from HIVE.
-# Once per day after 1000 UTC (after hive queries + transfert is done)
-30 10 * * * %(django)s update_counts_from_file
-00 11 * * * %(django)s download_counts_from_file
-05 11 * * * %(django)s theme_update_counts_from_hive
-30 11 * * * %(django)s theme_update_counts_from_file
-30 12 * * * %(django)s update_theme_popularity_movers
+# Once per day after 1000 UTC (after hive queries + transfer is done)
+30 11 * * * %(django)s update_counts_from_file
+00 12 * * * %(django)s download_counts_from_file
+05 12 * * * %(django)s theme_update_counts_from_hive
+30 12 * * * %(django)s theme_update_counts_from_file
+30 13 * * * %(django)s update_theme_popularity_movers
 
 # Once per day after metrics is done (see above)
-35 11 * * * %(z_cron)s update_addon_download_totals
-40 11 * * * %(z_cron)s weekly_downloads
-35 12 * * * %(z_cron)s update_global_totals
-40 12 * * * %(z_cron)s update_addon_average_daily_users
-30 13 * * * %(z_cron)s index_latest_stats
-45 13 * * * %(z_cron)s update_addons_collections_downloads
-50 13 * * * %(z_cron)s update_daily_theme_user_counts
+35 12 * * * %(z_cron)s update_addon_download_totals
+40 12 * * * %(z_cron)s weekly_downloads
+35 13 * * * %(z_cron)s update_global_totals
+40 13 * * * %(z_cron)s update_addon_average_daily_users
+30 14 * * * %(z_cron)s index_latest_stats
+45 14 * * * %(z_cron)s update_addons_collections_downloads
+50 14 * * * %(z_cron)s update_daily_theme_user_counts
 
 # Once per week
 45 7 * * 4 %(z_cron)s unconfirmed


### PR DESCRIPTION
At times update_counts_from_file will run before all the files have been transferred over. I've adjusted the cron run time by 1 hour to give it some additional time before attempting to process.

r? @magopian 