### PR TITLE
Don't fail on missing or bad zipfile (bug 1155799)

### DIFF
--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -388,8 +388,11 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
         This is in no way a perfect or correct solution, it's just the way we
         do it until we decide to inspect/walk the certificates chain to
         validate it comes from Mozilla."""
-        with zipfile.ZipFile(self.file_path, mode='r') as zf:
-            filenames = set(zf.namelist())
+        try:
+            with zipfile.ZipFile(self.file_path, mode='r') as zf:
+                filenames = set(zf.namelist())
+        except (zipfile.BadZipfile, IOError):
+            filenames = set()
         return set(['META-INF/mozilla.rsa', 'META-INF/mozilla.sf',
                     'META-INF/manifest.mf']).issubset(filenames)
 

--- a/apps/files/tests/test_models.py
+++ b/apps/files/tests/test_models.py
@@ -299,6 +299,9 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
                 'apps/files/fixtures/files/new-addon-signature.xpi',
                 file_.file_path):
             assert file_.is_signed
+        # Make sure a bad zip file is not seen as signed.
+        with amo.tests.copy_file(__file__, file_.file_path):
+            assert not file_.is_signed
 
 
 class TestParseXpi(amo.tests.TestCase):

--- a/lib/crypto/tasks.py
+++ b/lib/crypto/tasks.py
@@ -47,7 +47,7 @@ def sign_addons(addon_ids, force=False, **kw):
                 sign_file(file_obj)
             # Now update the Version model.
             version.update(version='{0}.1'.format(version.version))
-        except (SigningError, zipfile.BadZipFile) as e:
+        except (SigningError, zipfile.BadZipfile, IOError) as e:
             log.warning(
                 'Failed signing version {0}: {1}.'.format(version.pk, e))
 

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -149,6 +149,15 @@ class TestTasks(amo.tests.TestCase):
             assert self.version.version == '1.3'
 
     @mock.patch('lib.crypto.tasks.sign_file')
+    def test_dont_sign_dont_bump_version_bad_zipfile(self, mock_sign_file):
+        with amo.tests.copy_file(__file__, self.file1.file_path):
+            assert self.version.version == '1.3'
+            tasks.sign_addons([self.addon.pk])
+            assert not mock_sign_file.called
+            self.version.reload()
+            assert self.version.version == '1.3'
+
+    @mock.patch('lib.crypto.tasks.sign_file')
     def test_resign_bump_version_in_model_if_force(self, mock_sign_file):
         with amo.tests.copy_file(
                 'apps/files/fixtures/files/new-addon-signature.xpi',


### PR DESCRIPTION
Fixes [bug 1155799](https://bugzilla.mozilla.org/show_bug.cgi?id=1155799)