### PR TITLE
Add the file hash to its download url (bug 1155813)

### DIFF
--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -22,6 +22,7 @@ from access.models import Group, GroupUser
 from amo.helpers import user_media_url
 from amo.tests import addon_factory
 from amo.urlresolvers import reverse
+from amo.utils import urlparams
 from addons.models import Addon, CompatOverride, CompatOverrideRange
 from addons.tests.test_views import TestMobile
 from applications.models import AppVersion
@@ -635,7 +636,8 @@ class TestDownloadsBase(amo.tests.TestCase):
             file_ = self.file
         eq_(response.status_code, 302)
         eq_(response.url,
-            '%s%s/%s' % (host, self.addon.id, file_.filename))
+            urlparams('%s%s/%s' % (host, self.addon.id, file_.filename),
+                      filehash=file_.hash))
         eq_(response['X-Target-Digest'], file_.hash)
 
     def assert_served_internally(self, response):

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -102,7 +102,8 @@ def download_file(request, file_id, type=None):
 
     attachment = (type == 'attachment' or not request.APP.browser)
 
-    loc = file.get_mirror(addon, attachment=attachment)
+    loc = urlparams(file.get_mirror(addon, attachment=attachment),
+                    filehash=file.hash)
     response = http.HttpResponseRedirect(loc)
     response['X-Target-Digest'] = file.hash
     return response


### PR DESCRIPTION
Fixes [bug 1155813](https://bugzilla.mozilla.org/show_bug.cgi?id=1155813)