### PR TITLE
Bump version to .1-signed instead of .1 when bulk signing (bug 1156217)

### DIFF
--- a/lib/crypto/tasks.py
+++ b/lib/crypto/tasks.py
@@ -46,14 +46,14 @@ def sign_addons(addon_ids, force=False, **kw):
                 bump_version_number(file_obj)
                 sign_file(file_obj)
             # Now update the Version model.
-            version.update(version='{0}.1'.format(version.version))
+            version.update(version=_dot_one(version.version))
         except (SigningError, zipfile.BadZipfile, IOError) as e:
             log.warning(
                 'Failed signing version {0}: {1}.'.format(version.pk, e))
 
 
 def bump_version_number(file_obj):
-    """Add a .1 to the version number in the install.rdf or package.json."""
+    """Add a '.1-signed' to the version number."""
     # Create a new xpi with the bumped version.
     bumped = '{0}.bumped'.format(file_obj.file_path)
     # Copy the original XPI, with the updated install.rdf or package.json.
@@ -72,12 +72,12 @@ def bump_version_number(file_obj):
 
 
 def _dot_one(version):
-    """Returns the version with an appended .1 on it."""
-    return '{0}.1'.format(version)
+    """Returns the version with an appended '.1-signed' on it."""
+    return '{0}.1-signed'.format(version)
 
 
 def _bump_version_in_install_rdf(content):
-    """Add a '.1' to the version number in the install.rdf provided."""
+    """Add a '.1-signed' to the version number in the install.rdf provided."""
     # We need to use an XML parser, and not a RDF parser, because our
     # install.rdf files aren't really standard (they use default namespaces,
     # don't namespace the "about" attribute... rdflib can parse them, and can
@@ -103,7 +103,7 @@ def _bump_version_in_install_rdf(content):
 
 
 def _bump_version_in_package_json(content):
-    """Add a '.1' to the version number in the package.json provided."""
+    """Add a '.1-signed' to the version number in the package.json provided."""
     bumped = json.loads(content)
     if 'version' in bumped:
         bumped['version'] = _dot_one(bumped['version'])

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -148,7 +148,7 @@ class TestTasks(amo.tests.TestCase):
             tasks.sign_addons([self.addon.pk])
             assert mock_sign_file.called
             self.version.reload()
-            assert self.version.version == '1.3.1'
+            assert self.version.version == '1.3.1-signed'
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_dont_resign_dont_bump_version_in_model(self, mock_sign_file):
@@ -179,21 +179,21 @@ class TestTasks(amo.tests.TestCase):
             tasks.sign_addons([self.addon.pk], force=True)
             assert mock_sign_file.called
             self.version.reload()
-            assert self.version.version == '1.3.1'
+            assert self.version.version == '1.3.1-signed'
 
     def test_bump_version_in_install_rdf(self):
         with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',
                                  self.file1.file_path):
             tasks.bump_version_number(self.file1)
             parsed = parse_xpi(self.file1.file_path)
-            assert parsed['version'] == '1.3.1'
+            assert parsed['version'] == '1.3.1-signed'
 
     def test_bump_version_in_alt_install_rdf(self):
         with amo.tests.copy_file('apps/files/fixtures/files/alt-rdf.xpi',
                                  self.file1.file_path):
             tasks.bump_version_number(self.file1)
             parsed = parse_xpi(self.file1.file_path)
-            assert parsed['version'] == '2.1.106.1'
+            assert parsed['version'] == '2.1.106.1-signed'
 
     def test_bump_version_in_package_json(self):
         with amo.tests.copy_file(
@@ -201,4 +201,4 @@ class TestTasks(amo.tests.TestCase):
                 self.file1.file_path):
             tasks.bump_version_number(self.file1)
             parsed = parse_xpi(self.file1.file_path)
-            assert parsed['version'] == '0.0.1.1'
+            assert parsed['version'] == '0.0.1.1-signed'


### PR DESCRIPTION
Fixes [bug 1156217](https://bugzilla.mozilla.org/show_bug.cgi?id=1156217)