### PR TITLE
Don't configure signing endpoints by default for tests

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -109,6 +109,10 @@ DEBUG_PROPAGATE_EXCEPTIONS = False
 # Set to True if we're allowed to use X-SENDFILE.
 XSENDFILE = True
 
+# Don't enable the signing by default in tests, many would fail trying to sign
+# empty or bad zip files, or try posting to the endpoints. We don't want that.
+SIGNING_SERVER = ''
+PRELIMINARY_SIGNING_SERVER = ''
 
 ###############################################################################
 # Only if running on a CI server.


### PR DESCRIPTION
This allows tests to still pass even if you have signing endpoints defined locally.