### PR TITLE
Add a waffle flag for automatic validation of unlisted addons (bug 1157215)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/upload.html
+++ b/apps/devhub/templates/devhub/addons/submit/upload.html
@@ -4,7 +4,8 @@
 
 {% block primary %}
 
-<form method="post" id="create-addon" class="item" enctype="multipart/form-data">
+<form method="post" id="create-addon" class="item" enctype="multipart/form-data"
+    data-automatic-validation="{% if waffle.flag('automatic-validation') %}true{% else %}false{% endif %}">
   {{ csrf() }}
   <h3>{{ _('Step 2. Upload Your Add-on') }}</h3>
   <p>

--- a/migrations/808-waffle-automatic-validation.sql
+++ b/migrations/808-waffle-automatic-validation.sql
@@ -1,0 +1,2 @@
+INSERT INTO waffle_flag (name, everyone, percent, testing, superusers, staff, authenticated, languages, rollout, note, created, modified)
+       VALUES ('automatic-validation', 0, NULL, 0, 0, 0, 0, '', 0, "Guards the automatic validation/review/signing or unlisted add-ons when they're submitted.", NOW(), NOW());

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -329,13 +329,18 @@
 
                     // Specific messages for unlisted addons.
                     var isListed = $('#id_is_listed').is(':checked'),
-                        isSideload = $('#id_is_sideload').is(':checked');
+                        isSideload = $('#id_is_sideload').is(':checked'),
+                        automaticValidation = $('#create-addon').data('automatic-validation');
                     if (!isListed) {
                       if (isSideload) {
                         $("<p>").text(gettext("Your submission will go through a manual review.")).appendTo(upload_results);
                       } else {
                         if (warnings === 0) {
-                          $("<p>").text(gettext("Your submission passed validation and will be automatically signed.")).appendTo(upload_results);
+                          if (automaticValidation) {  // Automatic validation is enabled.
+                            $("<p>").text(gettext("Your submission passed validation and will be automatically signed.")).appendTo(upload_results);
+                          } else {  // Automatic validation is not enabled.
+                            $("<p>").text(gettext("Your submission passed validation and will go through a manual review.")).appendTo(upload_results);
+                          }
                         } else {
                           $("<p>").text(gettext("Your submission didn't pass automatic validation and will go through a manual review.")).appendTo(upload_results);
                         }


### PR DESCRIPTION
Fixes [bug 1157215](https://bugzilla.mozilla.org/show_bug.cgi?id=1157215)

This puts the preliminary work done in #503 on automatically signing (non side-load) unlisted addons during their submission behind a waffle flag named `automatic-validation`.

If the flag is disabled and the unlisted addon passes validation, here's the message displayed:
![screen shot 2015-04-22 at 16 43 29](https://cloud.githubusercontent.com/assets/167767/7277347/d0d642a0-e90f-11e4-9000-bac77582380f.png)
