### PR TITLE
Don't review a file if its signing failed (bug 1156333)

### DIFF
--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1220,8 +1220,8 @@ def version_add(request, addon_id, addon):
                     and not file_.validation.errors
                     and not file_.validation.warnings):
                 # Passed validation: sign automatically without manual review.
+                sign_file(file_, settings.PRELIMINARY_SIGNING_SERVER)
                 file_.update(status=amo.STATUS_LITE)
-                sign_file(file_)
 
         return dict(url=url)
     else:
@@ -1257,8 +1257,8 @@ def version_add_file(request, addon_id, addon, version_id):
                 and not new_file.validation.errors
                 and not new_file.validation.warnings):
             # Passed validation: sign automatically without manual review.
+            sign_file(new_file, settings.PRELIMINARY_SIGNING_SERVER)
             new_file.update(status=amo.STATUS_LITE)
-            sign_file(new_file)
 
     return render(request, 'devhub/includes/version_file.html',
                   {'form': form[0], 'addon': addon})
@@ -1386,8 +1386,9 @@ def submit_addon(request, step):
                             and not validation.errors
                             and not validation.warnings):
                         # Passed validation: sign automatically without review.
+                        sign_file(addon_file,
+                                  settings.PRELIMINARY_SIGNING_SERVER)
                         addon.update(status=amo.STATUS_LITE)
-                        sign_file(addon_file)
                     else:
                         addon.update(status=amo.STATUS_UNREVIEWED)
             SubmitStep.objects.create(addon=addon, step=3)

--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -647,6 +647,9 @@ class ReviewAddon(ReviewBase):
         if self.review_type == 'preliminary':
             raise AssertionError('Preliminary addons cannot be made public.')
 
+        # Sign addon first. If it fails, it'll halt the process.
+        self.version.sign_files(settings.SIGNING_SERVER)
+
         # Hold onto the status before we change it.
         status = self.addon.status
 
@@ -656,9 +659,6 @@ class ReviewAddon(ReviewBase):
                        copy_to_mirror=True)
         self.set_addon(highest_status=amo.STATUS_PUBLIC,
                        status=amo.STATUS_PUBLIC)
-
-        # Sign addon.
-        self.version.sign_files()
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         self.notify_email('%s_to_public' % self.review_type,
@@ -698,6 +698,9 @@ class ReviewAddon(ReviewBase):
 
     def process_preliminary(self):
         """Set an addon to preliminary."""
+        # Sign addon first. If it fails, it'll halt the process.
+        self.version.sign_files(settings.PRELIMINARY_SIGNING_SERVER)
+
         # Hold onto the status before we change it.
         status = self.addon.status
 
@@ -714,9 +717,6 @@ class ReviewAddon(ReviewBase):
         self.set_addon(**changes)
         self.set_files(amo.STATUS_LITE, self.version.files.all(),
                        copy_to_mirror=True)
-
-        # Sign addon.
-        self.version.sign_files()
 
         self.log_action(amo.LOG.PRELIMINARY_VERSION)
         self.notify_email(template,
@@ -747,14 +747,14 @@ class ReviewFiles(ReviewBase):
         if self.review_type == 'preliminary':
             raise AssertionError('Preliminary addons cannot be made public.')
 
+        # Sign addon first. If it fails, it'll halt the process.
+        self.version.sign_files(settings.SIGNING_SERVER)
+
         # Hold onto the status before we change it.
         status = self.addon.status
 
         self.set_files(amo.STATUS_PUBLIC, self.data['addon_files'],
                        copy_to_mirror=True)
-
-        # Sign addon.
-        self.version.sign_files()
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         self.notify_email('%s_to_public' % self.review_type,
@@ -790,14 +790,14 @@ class ReviewFiles(ReviewBase):
 
     def process_preliminary(self):
         """Set an addons files to preliminary."""
+        # Sign addon first. If it fails, it'll halt the process.
+        self.version.sign_files(settings.PRELIMINARY_SIGNING_SERVER)
+
         # Hold onto the status before we change it.
         status = self.addon.status
 
         self.set_files(amo.STATUS_LITE, self.data['addon_files'],
                        copy_to_mirror=True)
-
-        # Sign addon.
-        self.version.sign_files()
 
         self.log_action(amo.LOG.PRELIMINARY_VERSION)
         self.notify_email('%s_to_preliminary' % self.review_type,

--- a/apps/editors/tests/test_helpers.py
+++ b/apps/editors/tests/test_helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.core import mail
 from django.core.files.storage import default_storage as storage
 
@@ -417,7 +418,7 @@ class TestReviewHelper(amo.tests.TestCase):
             eq_(len(mail.outbox), 1)
             eq_(mail.outbox[0].subject, '%s Fully Reviewed' % self.preamble)
 
-            sign_mock.assert_called_with(self.file)
+            sign_mock.assert_called_with(self.file, settings.SIGNING_SERVER)
             assert storage.exists(self.file.mirror_file_path)
 
             eq_(self.check_log_count(amo.LOG.APPROVE_VERSION.id), 1)
@@ -440,7 +441,8 @@ class TestReviewHelper(amo.tests.TestCase):
             eq_(mail.outbox[0].subject,
                 '%s Preliminary Reviewed' % self.preamble)
 
-            sign_mock.assert_called_with(self.file)
+            sign_mock.assert_called_with(self.file,
+                                         settings.PRELIMINARY_SIGNING_SERVER)
             assert storage.exists(self.file.mirror_file_path)
 
             eq_(self.check_log_count(amo.LOG.PRELIMINARY_VERSION.id), 1)

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -485,11 +485,11 @@ class Version(amo.models.OnChangeMixin, amo.models.ModelBase):
             # But we need the cache to be flushed.
             Version.objects.invalidate(self)
 
-    def sign_files(self):
+    def sign_files(self, server):
         """Sign the files for this version if it's an extension."""
         if self.addon.type == amo.ADDON_EXTENSION:
             for file_obj in self.files.all():
-                packaged.sign_file(file_obj)
+                packaged.sign_file(file_obj, server)
 
     @property
     def is_listed(self):

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -457,12 +457,13 @@ class TestVersion(amo.tests.TestCase):
         # Don't sign for anything else than an extension.
         for addon_type in no_sign_types:
             self.version.addon.update(type=addon_type)
+            self.version.sign_files(settings.SIGNING_SERVER)
             assert not sign_mock.called, (
                 'lib.crypto.packaged.sign_file called for addon type {0}'
                 .format(addon_type))
         # Sign files if it's an extension.
         self.version.addon.update(type=amo.ADDON_EXTENSION)
-        self.version.sign_files()
+        self.version.sign_files(settings.SIGNING_SERVER)
         assert sign_mock.called
 
     def test_get_url_path(self):

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -61,19 +61,17 @@ class TestPackaged(amo.tests.TestCase):
     def test_get_endpoint(self):
         assert self.addon.status == amo.STATUS_PUBLIC
         with self.settings(PRELIMINARY_SIGNING_SERVER=''):
-            assert packaged.get_endpoint(self.file_).startswith('http://full')
+            assert packaged.get_endpoint(
+                settings.SIGNING_SERVER).startswith('http://full')
         self.addon.update(status=amo.STATUS_LITE)
         with self.settings(SIGNING_SERVER=''):
-            assert packaged.get_endpoint(self.file_).startswith(
-                'http://prelim')
-        self.addon.update(status=amo.STATUS_LITE_AND_NOMINATED)
-        with self.settings(SIGNING_SERVER=''):
-            assert packaged.get_endpoint(self.file_).startswith(
-                'http://prelim')
+            assert packaged.get_endpoint(
+                settings.PRELIMINARY_SIGNING_SERVER).startswith(
+                    'http://prelim')
 
     def test_no_server_full(self):
         with self.settings(SIGNING_SERVER=''):
-            packaged.sign_file(self.file_)
+            packaged.sign_file(self.file_, settings.SIGNING_SERVER)
         # Make sure the file wasn't signed.
         assert not self.file_.is_signed
         assert not self.file_.cert_serial_num
@@ -81,23 +79,25 @@ class TestPackaged(amo.tests.TestCase):
     def test_no_server_prelim(self):
         self.file_.update(status=amo.STATUS_LITE)
         with self.settings(PRELIMINARY_SIGNING_SERVER=''):
-            packaged.sign_file(self.file_)
+            packaged.sign_file(self.file_, settings.PRELIMINARY_SIGNING_SERVER)
         # Make sure the file wasn't signed.
         assert not self.file_.is_signed
         assert not self.file_.cert_serial_num
 
-        self.file_.update(status=amo.STATUS_LITE_AND_NOMINATED)
-        with self.settings(PRELIMINARY_SIGNING_SERVER=''):
-            packaged.sign_file(self.file_)
-        # Make sure the file wasn't signed.
-        assert not self.file_.is_signed
-        assert not self.file_.cert_serial_num
-
-    def test_sign_file(self):
+    def test_sign_file_full(self):
         assert not self.file_.is_signed
         assert not self.file_.cert_serial_num
         assert not self.file_.hash
-        packaged.sign_file(self.file_)
+        packaged.sign_file(self.file_, settings.SIGNING_SERVER)
+        assert self.file_.is_signed
+        assert self.file_.cert_serial_num
+        assert self.file_.hash
+
+    def test_sign_file_prelim(self):
+        assert not self.file_.is_signed
+        assert not self.file_.cert_serial_num
+        assert not self.file_.hash
+        packaged.sign_file(self.file_, settings.PRELIMINARY_SIGNING_SERVER)
         assert self.file_.is_signed
         assert self.file_.cert_serial_num
         assert self.file_.hash
@@ -106,23 +106,10 @@ class TestPackaged(amo.tests.TestCase):
         """Don't sign hotfix addons."""
         for hotfix_guid in settings.HOTFIX_ADDON_GUIDS:
             self.addon.update(guid=hotfix_guid)
-            packaged.sign_file(self.file_)
+            packaged.sign_file(self.file_, settings.SIGNING_SERVER)
             assert not self.file_.is_signed
             assert not self.file_.cert_serial_num
             assert not self.file_.hash
-
-    def test_no_sign_unreviewed(self):
-        """Don't sign unreviewed files."""
-        self.file_.update(status=amo.STATUS_UNREVIEWED)
-        packaged.sign_file(self.file_)
-        assert not self.file_.is_signed
-        assert not self.file_.cert_serial_num
-        assert not self.file_.hash
-        self.file_.update(status=amo.STATUS_NOMINATED)
-        packaged.sign_file(self.file_)
-        assert not self.file_.is_signed
-        assert not self.file_.cert_serial_num
-        assert not self.file_.hash
 
 
 class TestTasks(amo.tests.TestCase):
@@ -150,13 +137,13 @@ class TestTasks(amo.tests.TestCase):
         self.max_appversion.update(version=version,
                                    version_int=version_int(version))
 
-    def assert_backup(self):
-        """Make sure there's a backup file."""
-        assert os.path.exists(self.backup_file_path)
-
-    def assert_no_backup(self):
-        """Make sure there's no backup file."""
-        assert not os.path.exists(self.backup_file_path)
+    def assert_signed(self, mock_sign_file, is_signed=True,
+                      sign_file_called=True):
+        assert mock_sign_file.called is sign_file_called
+        self.version.reload()
+        assert self.version.version == '1.3.1-signed' if is_signed else '1.3'
+        assert (self.file_hash != self.file_.generate_hash()) is is_signed
+        assert os.path.exists(self.backup_file_path) is is_signed
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_bump_version_in_model(self, mock_sign_file):
@@ -182,45 +169,55 @@ class TestTasks(amo.tests.TestCase):
                         '1.3.1-signed')
                     assert file_hash != self.file_.generate_hash()
                     assert file2_hash != self.file2.generate_hash()
-                    self.assert_backup()
+                    assert os.path.exists(self.backup_file_path)
                     assert os.path.exists(backup_file2_path)
         finally:
             if os.path.exists(backup_file2_path):
                 os.unlink(backup_file2_path)
 
     @mock.patch('lib.crypto.tasks.sign_file')
-    def test_dont_sign_dont_bump_old_versions(self, mock_sign_file):
-        """Don't sign files which are too old, or not default to compatible."""
-        def not_signed():
-            assert not mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3'
-            assert self.version.version_int == version_int('1.3')
-            assert file_hash == self.file_.generate_hash()
-            self.assert_no_backup()
-
+    def test_dont_sign_dont_bump_unreviewed(self, mock_sign_file):
+        """Don't sign unreviewed files."""
         with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',
                                  self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
+
+            for status in [s for s in amo.VALID_STATUSES
+                           if s not in amo.REVIEWED_STATUSES]:
+                self.file_.update(status=status)
+                assert self.version.version == '1.3'
+                tasks.sign_addons([self.addon.pk])
+                self.assert_signed(mock_sign_file, is_signed=False,
+                                   sign_file_called=False)
+
+    @mock.patch('lib.crypto.tasks.sign_file')
+    def test_dont_sign_dont_bump_old_versions(self, mock_sign_file):
+        """Don't sign files which are too old, or not default to compatible."""
+        with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',
+                                 self.file_.file_path):
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
 
             # Too old, don't sign.
             self.set_max_appversion('1')  # Very very old.
             tasks.sign_addons([self.addon.pk])
-            not_signed()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=False)
 
             # MIN_D2C_VERSION, but strict compat: don't sign.
             self.set_max_appversion(tasks.MIN_D2C_VERSION)
             self.file_.update(strict_compatibility=True)
             tasks.sign_addons([self.addon.pk])
-            not_signed()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=False)
 
             # MIN_D2C_VERSION, but binary component: don't sign.
             self.file_.update(strict_compatibility=False,
                               binary_components=True)
             tasks.sign_addons([self.addon.pk])
-            not_signed()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=False)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_sign_bump_old_versions_default_compat(self, mock_sign_file):
@@ -228,17 +225,13 @@ class TestTasks(amo.tests.TestCase):
         with amo.tests.copy_file(
                 'apps/files/fixtures/files/new-addon-signature.xpi',
                 self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             self.set_max_appversion(tasks.MIN_D2C_VERSION)
             tasks.sign_addons([self.addon.pk], force=True)
-            assert mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3.1-signed'
-            assert self.version.version_int == version_int('1.3.1-signed')
-            assert file_hash != self.file_.generate_hash()
-            self.assert_backup()
+            self.assert_signed(mock_sign_file, is_signed=True,
+                               sign_file_called=True)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_sign_bump_new_versions_not_default_compat(self, mock_sign_file):
@@ -246,96 +239,72 @@ class TestTasks(amo.tests.TestCase):
         with amo.tests.copy_file(
                 'apps/files/fixtures/files/new-addon-signature.xpi',
                 self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             self.file_.update(binary_components=True,
                               strict_compatibility=True)
             tasks.sign_addons([self.addon.pk], force=True)
-            assert mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3.1-signed'
-            assert self.version.version_int == version_int('1.3.1-signed')
-            assert file_hash != self.file_.generate_hash()
-            self.assert_backup()
+            self.assert_signed(mock_sign_file, is_signed=True,
+                               sign_file_called=True)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_dont_resign_dont_bump_version_in_model(self, mock_sign_file):
         with amo.tests.copy_file(
                 'apps/files/fixtures/files/new-addon-signature.xpi',
                 self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             tasks.sign_addons([self.addon.pk])
-            assert not mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3'
-            assert self.version.version_int == version_int('1.3')
-            assert file_hash == self.file_.generate_hash()
-            self.assert_no_backup()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=False)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_dont_sign_dont_bump_version_bad_zipfile(self, mock_sign_file):
         with amo.tests.copy_file(__file__, self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             tasks.sign_addons([self.addon.pk])
-            assert not mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3'
-            assert self.version.version_int == version_int('1.3')
-            assert file_hash == self.file_.generate_hash()
-            self.assert_no_backup()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=False)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_dont_sign_dont_bump_sign_error(self, mock_sign_file):
         mock_sign_file.side_effect = IOError()
         with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',
                                  self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             tasks.sign_addons([self.addon.pk])
-            assert mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3'
-            assert self.version.version_int == version_int('1.3')
-            assert file_hash == self.file_.generate_hash()
-            self.assert_no_backup()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=True)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_dont_bump_not_signed(self, mock_sign_file):
         mock_sign_file.return_value = None  # Pretend we didn't sign.
         with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',
                                  self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             tasks.sign_addons([self.addon.pk])
-            assert mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3'
-            assert self.version.version_int == version_int('1.3')
-            assert file_hash == self.file_.generate_hash()
-            self.assert_no_backup()
+            self.assert_signed(mock_sign_file, is_signed=False,
+                               sign_file_called=True)
 
     @mock.patch('lib.crypto.tasks.sign_file')
     def test_resign_bump_version_in_model_if_force(self, mock_sign_file):
         with amo.tests.copy_file(
                 'apps/files/fixtures/files/new-addon-signature.xpi',
                 self.file_.file_path):
-            file_hash = self.file_.generate_hash()
+            self.file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
             tasks.sign_addons([self.addon.pk], force=True)
-            assert mock_sign_file.called
-            self.version.reload()
-            assert self.version.version == '1.3.1-signed'
-            assert self.version.version_int == version_int('1.3.1-signed')
-            assert file_hash != self.file_.generate_hash()
-            self.assert_backup()
+            self.assert_signed(mock_sign_file, is_signed=True,
+                               sign_file_called=True)
 
     def test_bump_version_in_install_rdf(self):
         with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',


### PR DESCRIPTION
Fixes [bug 1156333](https://bugzilla.mozilla.org/show_bug.cgi?id=1156333)

The current iteration simply makes sure that if there's any failure while signing, it bubbles up to the user (as a "OOPS" page). The important point here is that the addon/version/file isn't reviewed if the signing failed, giving the opportunity to re-review it (and have it signed) at a later point if the signing is fixed.