### PR TITLE
Add two newlines at the end of the mozilla.sf file (bug 1158938)

### DIFF
--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -40,7 +40,8 @@ def call_signing(file_obj, endpoint):
     # Extract jar signature.
     jar = JarExtractor(path=storage.open(file_obj.file_path),
                        outpath=temp_filename,
-                       omit_signature_sections=True)
+                       omit_signature_sections=True,
+                       extra_newlines=True)
 
     log.debug('File signature contents: {0}'.format(jar.signatures))
 

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -101,6 +101,11 @@ class TestPackaged(amo.tests.TestCase):
         assert self.file_.is_signed
         assert self.file_.cert_serial_num
         assert self.file_.hash
+        # Make sure there's two newlines at the end of the mozilla.sf file (see
+        # bug 1158938).
+        with zipfile.ZipFile(self.file_.file_path, mode='r') as zf:
+            with zf.open('META-INF/mozilla.sf', 'r') as mozillasf:
+                assert mozillasf.read().endswith('\n\n')
 
     def test_no_sign_hotfix_addons(self):
         """Don't sign hotfix addons."""

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -84,7 +84,7 @@ receipts==0.2.9
 redis==2.8.0
 requests==2.6.0
 sasl==0.1.3
-signing_clients==0.1.12
+signing_clients==0.1.13
 six==1.4.1
 slumber==0.5.3
 SQLAlchemy==0.7.5


### PR DESCRIPTION
This should fix Firefox crashes when installing signed add-ons on versions 28
and below.

Fixes [bug 1158938](https://bugzilla.mozilla.org/show_bug.cgi?id=1158938)