### PR TITLE
No prelim review available for unlisted sideload addons (bug 1159708)

### DIFF
--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -450,12 +450,20 @@ class ReviewHelper:
         if not addon.admin_review or acl.action_allowed(
                 request, 'ReviewerAdminTools', 'View'):
             if self.review_type != 'preliminary':
+                if addon.is_listed:
+                    label = _lazy('Push to public')
+                else:
+                    label = _lazy('Grant full review')
                 actions['public'] = {'method': self.handler.process_public,
                                      'minimal': False,
-                                     'label': _lazy('Push to public')}
-            actions['prelim'] = {'method': self.handler.process_preliminary,
-                                 'label': labels['prelim'],
-                                 'minimal': False}
+                                     'label': label}
+            # An unlisted sideload add-on, which requests a full review, cannot
+            # be granted a preliminary review.
+            if addon.is_listed or self.review_type == 'preliminary':
+                actions['prelim'] = {
+                    'method': self.handler.process_preliminary,
+                    'label': labels['prelim'],
+                    'minimal': False}
             actions['reject'] = {'method': self.handler.process_sandbox,
                                  'label': _lazy('Reject'),
                                  'minimal': False}

--- a/apps/editors/tests/test_forms.py
+++ b/apps/editors/tests/test_forms.py
@@ -47,6 +47,12 @@ class TestReviewActions(amo.tests.TestCase):
                 eq_(force_unicode(self.set_status(status)['prelim']['label']),
                     'Grant preliminary review')
 
+    def test_nominated_unlisted_addon_no_prelim(self):
+        self.addon.update(is_listed=False)
+        actions = self.set_status(amo.STATUS_NOMINATED)
+        assert 'prelim' not in actions
+        assert actions['public']['label'] == 'Grant full review'
+
     def test_reject(self):
         reject = self.set_status(amo.STATUS_UNREVIEWED)['reject']['details']
         assert force_unicode(reject).startswith('This will reject the add-on')


### PR DESCRIPTION
Fixes [bug 1159708](https://bugzilla.mozilla.org/show_bug.cgi?id=1159708)

![screen shot 2015-04-29 at 17 55 46](https://cloud.githubusercontent.com/assets/167767/7395238/fda10f02-ee98-11e4-85eb-16fbcd362a66.png)
