### PR TITLE
Fix the breadcrumbs on the review page of unlisted addons (bug 1159710)

### DIFF
--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1831,6 +1831,17 @@ class TestReview(ReviewBase):
         ]
         self._test_breadcrumbs(expected)
 
+    def test_breadcrumbs_unlisted_addons(self):
+        self.addon.update(is_listed=False)
+        self.generate_files()
+        self.login_as_admin()
+        expected = [
+            ('Unlisted Pending Updates',
+             reverse('editors.unlisted_queue_pending')),
+            (unicode(self.addon.name), None),
+        ]
+        self._test_breadcrumbs(expected)
+
     def test_files_shown(self):
         r = self.client.get(self.url)
         eq_(r.status_code, 200)
@@ -2032,11 +2043,6 @@ class TestReview(ReviewBase):
         ]
         check_links(expected, pq(r.content)('#actions-addon a'), verify=False)
 
-    def test_action_links_unlisted_addon(self):
-        self.addon.update(is_listed=False)
-        r = self.client.get(self.url)
-        check_links([], pq(r.content)('#actions-addon a'), verify=False)
-
     def test_action_links_as_admin(self):
         self.login_as_admin()
         r = self.client.get(self.url)
@@ -2047,13 +2053,6 @@ class TestReview(ReviewBase):
              reverse('zadmin.addon_manage', args=[self.addon.id])),
         ]
         check_links(expected, pq(r.content)('#actions-addon a'), verify=False)
-
-    def test_unlisted_addon_action_links(self):
-        """No "View Listing" link for unlisted addons, no action links for
-        standard reviewers."""
-        self.addon.update(is_listed=False)
-        r = self.client.get(self.url)
-        check_links([], pq(r.content)('#actions-addon a'), verify=False)
 
     def test_unlisted_addon_action_links_as_admin(self):
         """No "View Listing" link for unlisted addons, "edit"/"manage" links

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -600,7 +600,8 @@ def review(request, addon):
                   allow_unchecking_files=allow_unchecking_files,
                   actions=actions, actions_minimal=actions_minimal,
                   whiteboard_form=forms.WhiteboardForm(instance=addon),
-                  user_changes=user_changes_log)
+                  user_changes=user_changes_log,
+                  unlisted=not addon.is_listed)
 
     return render(request, 'editors/review.html', ctx)
 


### PR DESCRIPTION
Fixes [bug 1159710](https://bugzilla.mozilla.org/show_bug.cgi?id=1159710)

![screen shot 2015-04-29 at 18 30 32](https://cloud.githubusercontent.com/assets/167767/7395955/dbdef55a-ee9d-11e4-826f-e001e1dbd679.png)
