### PR TITLE
Fix the wording for unlisted add-ons in the devhub (bug 1159715)

### DIFF
--- a/apps/devhub/templates/devhub/addons/edit/basic.html
+++ b/apps/devhub/templates/devhub/addons/edit/basic.html
@@ -52,7 +52,7 @@
                        _("A short explanation of your add-on's basic
                           functionality that is displayed in search and browse
                           listings, as well as at the top of your add-on's
-                          details page.")) }}
+                          details page. It is only relevant for listed add-ons.")) }}
               </label>
             </th>
             <td>
@@ -72,7 +72,7 @@
               {{ tip(_("Categories"),
                      _("Categories are the primary way users browse through add-ons.
                         Choose any that fit your add-on's functionality for the most
-                        exposure.")) }}
+                        exposure. It is only relevant for listed add-ons.")) }}
             </th>
             <td id="addon-categories-edit"
                 data-max-categories="{{ amo.MAX_CATEGORIES }}">
@@ -118,7 +118,8 @@
               {{ tip(_("Tags"),
                      _("Tags help users find your add-on and should be short
                         descriptors such as tabs, toolbar, or twitter.  You
-                        may have a maximum of {0} tags.").format(amo.MAX_TAGS)) }}
+                        may have a maximum of {0} tags. It is only relevant
+                        for listed add-ons.").format(amo.MAX_TAGS)) }}
             </th>
             <td id="addon_tags_edit">
               {% if editable %}

--- a/apps/devhub/templates/devhub/addons/edit/details.html
+++ b/apps/devhub/templates/devhub/addons/edit/details.html
@@ -22,7 +22,7 @@
                        _("A longer explanation of features,
                           functionality, and other relevant information. This
                           field is only displayed on the add-on's details
-                          page.")) }}
+                          page. It is only relevant for listed add-ons.")) }}
               </label>
             </th>
             <td>
@@ -43,7 +43,8 @@
             <th>
               {{ tip(_("Default Locale"),
                      _("Information about your add-on is displayed in this locale
-                        unless you override it with a locale-specific translation.")) }}
+                        unless you override it with a locale-specific translation.
+                        It is only relevant for listed add-ons.")) }}
             </th>
             <td class="addon_edit_locale">
               {% if editable %}
@@ -62,7 +63,7 @@
                        _("If your add-on has another homepage, enter its
                           address here. If your website is localized into other
                           languages multiple translations of this field can be
-                          added.")) }}
+                          added. It is only relevant for listed add-ons.")) }}
               </label>
             </th>
             <td>

--- a/apps/devhub/templates/devhub/addons/edit/support.html
+++ b/apps/devhub/templates/devhub/addons/edit/support.html
@@ -22,7 +22,8 @@
                        _("If you wish to display an e-mail address for support
                           inquiries, enter it here. If you have different
                           addresses for each language multiple translations of
-                          this field can be added.")) }}
+                          this field can be added. It is only relevant for
+                          listed add-ons.")) }}
               </label>
             </th>
             <td>
@@ -44,7 +45,7 @@
                        _("If your add-on has a support website or forum, enter
                           its address here. If your website is localized into
                           other languages, multiple translations of this field can
-                          be added.")) }}
+                          be added. It is only relevant for listed add-ons.")) }}
               </label>
             </th>
             <td>

--- a/apps/devhub/templates/devhub/addons/edit/technical.html
+++ b/apps/devhub/templates/devhub/addons/edit/technical.html
@@ -24,7 +24,7 @@
                           necessarily applicable to the add-on summary or description.
                           Common uses include listing known major bugs, information on
                           how to report bugs, anticipated release date of a new version,
-                          etc.")) }}
+                          etc. It is only relevant for listed add-ons.")) }}
               </label>
             </th>
             <td>
@@ -66,7 +66,8 @@
           <tr>
             <th>
               {{ tip(_("Add-on Flags"),
-                     _("These flags are used to classify add-ons.")) }}
+                     _("These flags are used to classify add-ons. It is only
+                        relevant for listed add-ons.")) }}
             </th>
             <td>
               <div id="addon-flags">
@@ -87,7 +88,7 @@
             <th>
               {{ tip(_("View Source?"),
                      _("Whether the source of your add-on can be displayed in our
-                        online viewer.")) }}
+                        online viewer. It is only relevant for listed add-ons.")) }}
             </th>
             <td>
               {{ flags(_("This add-on's source code is publicly viewable."),
@@ -99,7 +100,8 @@
             <th>
               {{ tip(_("Public Stats?"),
                      _("Whether the download and usage stats of your add-on can
-                        be displayed in our online viewer.")) }}
+                        be displayed in our online viewer.
+                        It is only relevant for listed add-ons.")) }}
             </th>
             <td>
               {{ flags(_("This add-on's stats are publicly viewable."),
@@ -111,7 +113,9 @@
           <tr>
             <th>
               {{ tip(_('Upgrade SDK?'),
-                     _('If selected, we will try to automatically upgrade your add-on when a new version of the SDK is released.')) }}
+                     _('If selected, we will try to automatically upgrade your
+                        add-on when a new version of the SDK is released.
+                        It is only relevant for listed add-ons.')) }}
             </th>
             <td>
               {{ flags(_('This add-on will be automatically upgraded to new versions of the Add-on SDK.'),

--- a/apps/devhub/templates/devhub/addons/forms_shared/media.html
+++ b/apps/devhub/templates/devhub/addons/forms_shared/media.html
@@ -15,7 +15,8 @@
             {{ tip(_("Add-on icon"),
                    _("Upload an icon for your add-on or choose from one of ours. The
                       icon is displayed nearly everywhere your add-on is. Uploaded images
-                      must be one of the following image types: .png, .jpg")) }}
+                      must be one of the following image types: .png, .jpg.
+                      It is only relevant for listed add-ons.")) }}
           </th>
           {% endif %}
           <td>

--- a/apps/devhub/templates/devhub/includes/addon_details.html
+++ b/apps/devhub/templates/devhub/includes/addon_details.html
@@ -33,20 +33,28 @@
         {{ status_and_tip(addon,
                           _("You will receive an email when the review is complete. Until
                              then, your add-on is not listed in our gallery but can be
-                             accessed directly from its details page.")) }}
+                             accessed directly from its details page.")
+                          if addon.is_listed else
+                          _('You will receive an email when the review is
+                             complete and your add-on is signed.')) }}
       </a>
     {% elif addon.status == amo.STATUS_NOMINATED %}
       <a href="{{ addon.get_dev_url('versions') }}">
         {{ status_and_tip(addon,
                           _("You will receive an email when the review is complete. Until
                              then, your add-on is not listed in our gallery but can be
-                             accessed directly from its details page. ")) }}
+                             accessed directly from its details page. ")
+                          if addon.is_listed else
+                          _('You will receive an email when the review is
+                             complete and your add-on is signed.')) }}
       </a>
     {% elif addon.status == amo.STATUS_PUBLIC %}
       <a href="{{ addon.get_dev_url('versions') }}">
         {{ status_and_tip(addon,
                           _("Your add-on is displayed in our gallery and users are
-                             receiving automatic updates.")) }}
+                             receiving automatic updates.")
+                          if addon.is_listed else
+                          _("Your add-on has been signed and can be side-loaded.")) }}
       </a>
     {% elif addon.status == amo.STATUS_DISABLED %}
       <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload">
@@ -60,7 +68,9 @@
         {{ status_and_tip(addon,
                           _("Your add-on is displayed in our gallery as experimental
                              and users are receiving automatic updates. Some features
-                             are unavailable to your add-on.")) }}
+                             are unavailable to your add-on.")
+                          if addon.is_listed else
+                          _('Your add-on has been signed.')) }}
       </a>
     {% elif addon.status == amo.STATUS_LITE_AND_NOMINATED %}
       <a href="{{ addon.get_dev_url('versions') }}">
@@ -68,7 +78,10 @@
                           _("You will receive an email when the full review is complete.
                              Until then, your add-on is displayed in our gallery as
                              experimental and users are receiving automatic updates.
-                             Some features are unavailable to your add-on.")) }}
+                             Some features are unavailable to your add-on.")
+                          if addon.is_listed else
+                          _('You will receive an email when the full review is
+                             complete, making your add-on side-loadable.')) }}
       </a>
     {% elif addon.status == amo.STATUS_PURGATORY %}
       <a href="{{ addon.get_dev_url('versions') }}">
@@ -86,7 +99,8 @@
     {{ link_if_listed_else_text(addon.current_version, addon.current_version) }}
     <span class="tip tooltip" title="{{ _('This is the version of your add-on that will
                                            be installed if someone clicks the Install
-                                           button on addons.mozilla.org.') }}">?</span>
+                                           button on addons.mozilla.org. It is only
+                                           relevant for listed add-ons.') }}">?</span>
   </li>
 {% endif %}
 {% if sorting == 'created' %}

--- a/apps/devhub/templates/devhub/includes/license_form.html
+++ b/apps/devhub/templates/devhub/includes/license_form.html
@@ -3,7 +3,8 @@
 {% if version %}
   <tr>
     <th>{{ tip(_('License'),
-               _('Please choose a license appropriate for the rights you grant on your source code.')) }}</th>
+               _('Please choose a license appropriate for the rights you grant on your source code.
+                  It is only relevant for listed add-ons.')) }}</th>
     <td>
       {{ license_form.builtin.errors }}
       {{ license_form.builtin }}

--- a/apps/devhub/templates/devhub/includes/policy_form.html
+++ b/apps/devhub/templates/devhub/includes/policy_form.html
@@ -1,7 +1,8 @@
 {% from "devhub/includes/macros.html" import tip, some_html_tip %}
 <tr>
   <th>{{ tip(_('End-User License Agreement'),
-             _('Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.')) }}</th>
+             _('Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.
+                It is only relevant for listed add-ons.')) }}</th>
   <td>
     {{ policy_form.has_eula }}
     {{ policy_form.has_eula.label_tag() }}
@@ -17,7 +18,8 @@
 </tr>
 <tr>
   <th>{{ tip(_('Privacy Policy'),
-             _("If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.")) }}</th>
+             _("If your add-on transmits any data from the user's computer, a privacy policy is required that explains what data is sent and how it is used.
+                It is only relevant for listed add-ons.")) }}</th>
   <td>
     {{ policy_form.has_priv }}
     {{ policy_form.has_priv.label_tag() }}

--- a/apps/devhub/templates/devhub/payments/payments.html
+++ b/apps/devhub/templates/devhub/payments/payments.html
@@ -41,22 +41,30 @@
         <li>{{ _('Choose when and how users are asked to contribute') }}</li>
         <li>{{ _('Receive contributions in your PayPal account or send them to an organization of your choice') }}</li>
       </ul>
-      {% if not addon.has_full_profile() %}
-        <p class="error">
-        {% trans url=addon.get_dev_url('profile') %}
-          Contributions are only available for add-ons with a <a href="{{ url }}">completed developer profile</a>.
-        {% endtrans %}
-        </p>
-      {% elif addon.status != amo.STATUS_PUBLIC %}
+      {% if not addon.is_listed %}
         <p class="error">
         {% trans %}
-          Contributions are only available for fully reviewed add-ons.
+          Contributions are only available for listed add-ons.
         {% endtrans %}
         </p>
       {% else %}
-        <div class="button-wrapper">
-          <a href="#setup" id="do-setup" class="button prominent">{{ _('Set up Contributions') }}</a>
-        </div>
+        {% if not addon.has_full_profile() %}
+          <p class="error">
+          {% trans url=addon.get_dev_url('profile') %}
+            Contributions are only available for add-ons with a <a href="{{ url }}">completed developer profile</a>.
+          {% endtrans %}
+          </p>
+        {% elif addon.status != amo.STATUS_PUBLIC %}
+          <p class="error">
+          {% trans %}
+            Contributions are only available for fully reviewed add-ons.
+          {% endtrans %}
+          </p>
+        {% else %}
+          <div class="button-wrapper">
+            <a href="#setup" id="do-setup" class="button prominent">{{ _('Set up Contributions') }}</a>
+          </div>
+        {% endif %}
       {% endif %}
     </div>
   {% endif %}

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -618,6 +618,16 @@ class TestEditPayments(amo.tests.TestCase):
         eq_(doc('.intro').length, 1)
         eq_(doc('.intro.full-intro').length, 0)
 
+    def test_no_voluntary_contributions_for_unlisted_addons(self):
+        self.addon.update(is_listed=False)
+        r = self.client.get(self.url)
+        doc = pq(r.content)
+        assert doc('.intro').length == 1
+        assert doc('.intro.full-intro').length == 0
+        assert not doc('#do-setup')  # No way to setup the payment.
+        assert doc('.intro .error').text() == (
+            'Contributions are only available for listed add-ons.')
+
 
 class TestDisablePayments(amo.tests.TestCase):
     fixtures = ['base/users', 'base/addon_3615']


### PR DESCRIPTION
Fixes [bug 1159715](https://bugzilla.mozilla.org/show_bug.cgi?id=1159715)

I changed some of the wordings where necessary, and just added "It is only relevant for listed add-ons." on most of the tooltips for items that are not used for unlisted add-ons.

Example of changed wording:
![screen shot 2015-04-30 at 10 47 25](https://cloud.githubusercontent.com/assets/167767/7409882/4e657f5e-ef2a-11e4-8f7a-50727927ecff.png)

Example of addition of "only relevant...":
![screen shot 2015-04-30 at 10 49 25](https://cloud.githubusercontent.com/assets/167767/7409890/622f7c4c-ef2a-11e4-9e84-932e8021e408.png)

I also added an error to the payments page:
![screen shot 2015-04-30 at 11 12 32](https://cloud.githubusercontent.com/assets/167767/7409894/6b6408be-ef2a-11e4-8fa3-e5178e62d993.png)

