### PR TITLE
Warn that unsigned file aren't installable on release versions of FF (bug 1161486)

### DIFF
--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -278,7 +278,9 @@
         <div class="install-beta" id="install-beta">
           <p>
             {% trans %}
-              <strong>Caution:</strong> Development versions of this add-on have not been reviewed by Mozilla.
+              <strong>Caution:</strong> Development versions of this add-on
+              have not been reviewed by Mozilla and can't be installed on
+              release versions of Firefox.
             {% endtrans %}
           </p>
           <dl>

--- a/apps/addons/templates/addons/popups.html
+++ b/apps/addons/templates/addons/popups.html
@@ -107,8 +107,9 @@
 {# js vars: url, msg #}
 <div class="install-note">
   <p class="msg m-unreviewed">{% trans %}
-    <strong>Caution:</strong> This add-on has not been reviewed by Mozilla.  Be
-    careful when installing third-party software that might harm your computer.
+    <strong>Caution:</strong> This add-on has not been reviewed by Mozilla and
+    can't be installed on release versions of Firefox.  Be careful when
+    installing third-party software that might harm your computer.
   {% endtrans %}</p>
   <p><a href="{url}" class="button installer">{msg}</a></p>
 </div>


### PR DESCRIPTION
Fixes [bug 1161486](https://bugzilla.mozilla.org/show_bug.cgi?id=1161486)