### PR TITLE
Fix addon submission if unlisted-addons flag disabled (bug 1161536)

### DIFF
--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -2877,13 +2877,15 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, amo.tests.TestCase):
         assert log_items.filter(action=amo.LOG.CREATE_ADDON.id), (
             'New add-on creation never logged.')
 
-    def test_permission_denied_no_unlisted_addons_flag(self):
-        """Don't accept unlisted addons if the flag isn't set."""
+    def test_list_addon_no_unlisted_addons_flag(self):
+        """List an add-on if unlisted-addons flag isn't set."""
         self.upload = self.get_upload(
             'extension.xpi',
             validation=json.dumps(dict(errors=0, warnings=0, notices=2,
                                        metadata={}, messages=[])))
-        assert self.post(is_listed=False, status_code=403)
+        assert self.post(is_listed=False)  # Post as unlisted.
+        addon = Addon.with_unlisted.get()
+        assert addon.is_listed  # But add-on is still listed.
 
     @mock.patch('devhub.views.sign_file')
     def test_success_unlisted_no_automatic_validation_flag(self,

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1368,12 +1368,12 @@ def submit_addon(request, step):
 
             p = data.get('supported_platforms', [])
 
-            if (not data['is_listed'] and
-                    not waffle.flag_is_active(request, 'unlisted-addons')):
-                raise PermissionDenied
+            is_listed = data['is_listed']
+            if not waffle.flag_is_active(request, 'unlisted-addons'):
+                is_listed = True
 
             addon = Addon.from_upload(data['upload'], p, source=data['source'],
-                                      is_listed=data['is_listed'])
+                                      is_listed=is_listed)
             AddonUser(addon=addon, user=request.amo_user).save()
             check_validation_override(request, form, addon,
                                       addon.current_version)


### PR DESCRIPTION
Fixes (again) [bug 1161536](https://bugzilla.mozilla.org/show_bug.cgi?id=1161536)

No add-on could be submitted if the flag was disabled (oops...)