### PR TITLE
Update installation.rst to reflect changes due to swig

### DIFF
--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -36,8 +36,8 @@ if you're running a recent version, you can `install them automatically
 
     sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev memcached libssl-dev swig openssl curl libjpeg-dev zlib1g-dev libsasl2-dev
 
-Note: 
------
+###### Note:
+ 
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
 
 .. _osx-packages:
@@ -50,8 +50,8 @@ The following packages will get you set for olympia::
 
     brew install python libxml2 mysql libmemcached openssl swig jpeg
 
-Note:
------
+###### Note:
+
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4.
 
 

--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -36,6 +36,9 @@ if you're running a recent version, you can `install them automatically
 
     sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev memcached libssl-dev swig openssl curl libjpeg-dev zlib1g-dev libsasl2-dev
 
+Note: 
+-----
+As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
 
 .. _osx-packages:
 
@@ -46,6 +49,11 @@ The best solution for installing UNIX tools on OS X is Homebrew_.
 The following packages will get you set for olympia::
 
     brew install python libxml2 mysql libmemcached openssl swig jpeg
+
+Note:
+-----
+As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4.
+
 
 MySQL
 ~~~~~

--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -36,7 +36,7 @@ if you're running a recent version, you can `install them automatically
 
     sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev memcached libssl-dev swig openssl curl libjpeg-dev zlib1g-dev libsasl2-dev
 
-**Note**: 
+.. Note:: 
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
 
 .. _osx-packages:
@@ -49,7 +49,7 @@ The following packages will get you set for olympia::
 
     brew install python libxml2 mysql libmemcached openssl swig jpeg
 
-**Note**:
+.. Note::
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4.
 
 

--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -36,8 +36,8 @@ if you're running a recent version, you can `install them automatically
 
     sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev memcached libssl-dev swig openssl curl libjpeg-dev zlib1g-dev libsasl2-dev
 
-.. note:: 
-As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
+.. note:: As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running 
+          ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
 
 .. _osx-packages:
 
@@ -49,8 +49,8 @@ The following packages will get you set for olympia::
 
     brew install python libxml2 mysql libmemcached openssl swig jpeg
 
-.. note::
-As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4.
+.. note:: As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running
+          ``make full_init``, you might have to downgrade swig to version <=3.0.4.
 
 
 MySQL

--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -36,8 +36,7 @@ if you're running a recent version, you can `install them automatically
 
     sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev memcached libssl-dev swig openssl curl libjpeg-dev zlib1g-dev libsasl2-dev
 
-###### Note:
- 
+**Note**: 
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
 
 .. _osx-packages:
@@ -50,8 +49,7 @@ The following packages will get you set for olympia::
 
     brew install python libxml2 mysql libmemcached openssl swig jpeg
 
-###### Note:
-
+**Note**:
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4.
 
 

--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -36,7 +36,7 @@ if you're running a recent version, you can `install them automatically
 
     sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev memcached libssl-dev swig openssl curl libjpeg-dev zlib1g-dev libsasl2-dev
 
-.. Note:: 
+.. note:: 
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4. 
 
 .. _osx-packages:
@@ -49,7 +49,7 @@ The following packages will get you set for olympia::
 
     brew install python libxml2 mysql libmemcached openssl swig jpeg
 
-.. Note::
+.. note::
 As of writing, M2Crypto is only compatible with swig <=3.0.4 version's. So, if you encounter a libssl exception while running ``make full_init``, you might have to downgrade swig to version <=3.0.4.
 
 


### PR DESCRIPTION
Currently, M2Crypto is only compatible with swig <=3.0.4 and thus upgraded versions cause ``make full_init`` to fail. This Patch mention's this exception in the installation.rst file, so that users can account and react to the exception accordingly.  