### PR TITLE
Use mkt's centos base images for our docker installs (bug 1162462)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,15 +16,20 @@ web:
     - MEMCACHE_LOCATION=memcached:11211
     - ELASTICSEARCH_LOCATION=elasticsearch:9200
     - REDIS_LOCATION=redis:6379
+    - MYSQL_ROOT_PASSWORD='docker'
+    - MYSQL_DATABASE='olympia'
 
 memcached:
-  build: dockerfiles/memcached
+  image: memcached
 
 mysqld:
-  image: dockerfile/mysql
+  image: mysql
+  environment:
+    - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    - MYSQL_DATABASE='olympia'
 
 elasticsearch:
-  image: dockerfile/elasticsearch
+  image: elasticsearch:1.3
 
 redis:
   image: redis

--- a/docker-mysql.repo
+++ b/docker-mysql.repo
@@ -1,0 +1,5 @@
+[mysql-community-releases]
+name=Mysql Community Packages
+baseurl=http://repo.mysql.com/yum/mysql-community/el/6/$basearch/
+gpgcheck=0
+enabled=1

--- a/dockerfiles/memcached/Dockerfile
+++ b/dockerfiles/memcached/Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu
-
-RUN apt-get update
-RUN apt-get install -y memcached
-
-EXPOSE 11211
-
-CMD /usr/bin/memcached -u root


### PR DESCRIPTION
Fixes [bug 1162462](https://bugzilla.mozilla.org/show_bug.cgi?id=1162462)

To start from a clean slate, you can drop all your docker images/containers with the following command:

```
docker rmi -f `docker images -aq` && docker rm -f `docker ps -aq`
```