### PR TITLE
Handle new beta versions with signing (bug 1160593)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -540,8 +540,9 @@ class NewVersionForm(NewAddonForm):
         })
     beta = forms.BooleanField(
         required=False,
-        help_text=_lazy(u'A file with a version ending with a|alpha|b|beta and'
-                        u' an optional number is detected as beta.'))
+        help_text=_lazy(u'A file with a version ending with '
+                        u'a|alpha|b|beta|pre|rc and an optional number is '
+                        u'detected as beta.'))
 
     def __init__(self, *args, **kw):
         self.addon = kw.pop('addon')

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -63,6 +63,9 @@
         </label>
       </div>
     {% endif %}
+    <div id="invalid-beta" class="hidden">
+        <p class="error">{{ _("Your version was detected as beta. It didn't pass automatic validation and thus can't be submitted. If you didn't mean to submit it as beta, please uncheck the beta channel option.") }}</p>
+    </div>
 
     <div class="upload-status-button-add">
       <button class="addon-upload-dependant button" id="upload-file-finish" disabled>{{ action_label }}</button>

--- a/apps/files/tests/test_utils_.py
+++ b/apps/files/tests/test_utils_.py
@@ -28,6 +28,23 @@ def test_is_beta():
     assert is_beta('1.2a-1')
     assert is_beta('1.2a-123')
 
+    assert is_beta('1.2alpha')
+    assert is_beta('1.2alpha')
+    assert is_beta('1.2alpha1')
+    assert is_beta('1.2alpha123')
+    assert is_beta('1.2alpha.1')
+    assert is_beta('1.2alpha.123')
+    assert is_beta('1.2alpha-1')
+    assert is_beta('1.2alpha-123')
+
+    assert is_beta('1.2b')
+    assert is_beta('1.2b1')
+    assert is_beta('1.2b123')
+    assert is_beta('1.2b.1')
+    assert is_beta('1.2b.123')
+    assert is_beta('1.2b-1')
+    assert is_beta('1.2b-123')
+
     assert is_beta('1.2beta')
     assert is_beta('1.2beta1')
     assert is_beta('1.2beta123')
@@ -35,6 +52,22 @@ def test_is_beta():
     assert is_beta('1.2beta.123')
     assert is_beta('1.2beta-1')
     assert is_beta('1.2beta-123')
+
+    assert is_beta('1.2pre')
+    assert is_beta('1.2pre1')
+    assert is_beta('1.2pre123')
+    assert is_beta('1.2pre.1')
+    assert is_beta('1.2pre.123')
+    assert is_beta('1.2pre-1')
+    assert is_beta('1.2pre-123')
+
+    assert is_beta('1.2rc')
+    assert is_beta('1.2rc1')
+    assert is_beta('1.2rc123')
+    assert is_beta('1.2rc.1')
+    assert is_beta('1.2rc.123')
+    assert is_beta('1.2rc-1')
+    assert is_beta('1.2rc-123')
 
 
 class TestFindJetpacks(amo.tests.TestCase):

--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -48,7 +48,8 @@ def supports_firefox(file_obj):
 def get_endpoint(file_obj):
     """Get the endpoint to sign the file, depending on its review status."""
     server = settings.SIGNING_SERVER
-    if file_obj.version.addon.status != amo.STATUS_PUBLIC:
+    if (file_obj.status == amo.STATUS_BETA or
+            file_obj.version.addon.status != amo.STATUS_PUBLIC):
         server = settings.PRELIMINARY_SIGNING_SERVER
     if not server:
         return
@@ -115,10 +116,10 @@ def sign_file(file_obj):
             file_obj.pk))
         return
 
-    # We only sign files that have been reviewed.
-    if file_obj.status not in amo.REVIEWED_STATUSES:
-        log.info(u'Not signing file {0}: it isn\'t reviewed'.format(
-            file_obj.pk))
+    # We only sign files that have been reviewed, or that are beta.
+    if file_obj.status not in amo.REVIEWED_STATUSES + (amo.STATUS_BETA,):
+        log.info(u'Not signing file {0}: it isn\'t reviewed and isn\t beta'
+                 .format(file_obj.pk))
         return
 
     # We only sign files that are compatible with Firefox.

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -784,6 +784,10 @@ pre.email_comment {
     margin-bottom: 1em;
 }
 
+#upload-file .admin-settings {
+    margin-top: 1em;
+}
+
 #upload-status-bar {
     background-color: #F2F2F2;
     -moz-border-radius: 5px;

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -278,10 +278,10 @@
                 }
 
                 // Validation results?  If not, fetch the json again.
-                if(! results.validation) {
+                if (! results.validation) {
                     upload_progress_outside.attr('class', 'progress-idle');
                     // Not loaded yet. Try again!
-                    setTimeout(function(){
+                    setTimeout(function() {
                         $.ajax({
                             url: results.url,
                             dataType: 'json',
@@ -298,7 +298,7 @@
                 } else {
                     var errors = getErrors(results),
                         v = results.validation;
-                    if(errors.length > 0) {
+                    if (errors.length > 0) {
                         $upload_field.trigger("upload_errors", [file, errors, results]);
                         return;
                     }
@@ -315,7 +315,7 @@
                     var message = "";
 
                     var warnings = v.warnings + v.notices;
-                    if(warnings > 0) {
+                    if (warnings > 0) {
                         message = format(ngettext(
                                     "Your add-on passed validation with no errors and {0} message.",
                                     "Your add-on passed validation with no errors and {0} messages.",
@@ -336,7 +336,7 @@
                     if ($new_form.data('unlisted-addons')) {
                       // Specific messages for unlisted addons.
                       var isSideload = $('#id_is_sideload').is(':checked') || $new_form.data('addon-is-sideload');
-                      var automaticValidation = $('#create-addon').data('automatic-validation');
+                      var automaticValidation = $('#create-addon').data('automatic-validation') || $new_form.data('automatic-validation');
                       if (!isListed) {
                         if (isSideload) {
                           $("<p>").text(gettext("Your submission will go through a manual review.")).appendTo(upload_results);
@@ -351,6 +351,13 @@
                             // If unlisted and not sideload and failed validation, disable submit until checkbox checked.
                             $('.addon-upload-dependant').attr('disabled', true);
                             $('#manual-review').show().removeClass('hidden');
+                          }
+                        }
+                      } else {  // This is a listed add-on.
+                        if (automaticValidation && results.beta) {
+                          if (warnings > 0) {
+                            $('#invalid-beta').show().removeClass('hidden');
+                            $('.addon-upload-dependant').attr('disabled', true);
                           }
                         }
                       }

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -124,6 +124,18 @@ $(document).ready(function() {
         $('.addon-upload-dependant').attr('disabled', !($(this).is(':checked')));
     });
 
+    $('#id_beta').bind('change', function() {
+        // User unchecked the beta checkbox, meaning they want this file to go
+        // through the usual review process.
+        if ($('#id_beta').is(':checked')) {
+            $('#invalid-beta').show();
+            $('.addon-upload-dependant').attr('disabled', true);
+        } else {
+            $('#invalid-beta').hide();
+            $('.addon-upload-dependant').attr('disabled', false);
+        }
+    });
+
     if ($(".add-file-modal").length) {
         $modalFile = $(".add-file-modal").modal(".version-upload", {
             width: '450px',


### PR DESCRIPTION
TODO:
* [x] Handle toggling of `is_beta` checkbox.
