### PR TITLE
Don't try to sign if file is missing (bug 1164390)

### DIFF
--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -457,6 +457,7 @@ class TestVersion(amo.tests.TestCase):
         # Don't sign for anything else than an extension.
         for addon_type in no_sign_types:
             self.version.addon.update(type=addon_type)
+            self.version.sign_files()
             assert not sign_mock.called, (
                 'lib.crypto.packaged.sign_file called for addon type {0}'
                 .format(addon_type))
@@ -464,6 +465,21 @@ class TestVersion(amo.tests.TestCase):
         self.version.addon.update(type=amo.ADDON_EXTENSION)
         self.version.sign_files()
         assert sign_mock.called
+
+    @mock.patch('lib.crypto.packaged.call_signing')
+    @mock.patch('lib.crypto.packaged.get_endpoint')
+    def test_sign_version_missing_files(self, get_endpoint, call_signing_mock):
+        """If one of the files is missing the others should still be signed."""
+        get_endpoint.return_value = 'endpoint'  # Fake an endpoint.
+        self.version.addon.update(type=amo.ADDON_EXTENSION)
+        # Current file doesn't have a file on disk. We create a file with one.
+        good_file = amo.tests.file_factory(version=self.version)
+        with amo.tests.copy_file('apps/files/fixtures/files/jetpack.xpi',
+                                 good_file.file_path):
+            self.version.sign_files()
+        # 'sign_file' got called twice, but only one was signed.
+        call_signing_mock.assert_called_once_with(
+            good_file.file_path, 'endpoint', good_file.version.addon.guid)
 
     def test_get_url_path(self):
         eq_(self.version.get_url_path(),

--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -83,6 +83,11 @@ def sign_file(file_obj):
             file_obj.pk))
         return
 
+    # No file? No signature.
+    if not os.path.exists(file_obj.file_path):
+        log.info(u'File {0} doesn\'t exist on disk'.format(file_obj.file_path))
+        return
+
     # Don't sign hotfixes.
     if file_obj.version.addon.guid in settings.HOTFIX_ADDON_GUIDS:
         log.info(u'Not signing file {0}: addon is a hotfix'.format(

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -126,6 +126,17 @@ class TestPackaged(amo.tests.TestCase):
         assert self.file_.hash
         assert packaged.is_signed(self.file_.file_path)
 
+    def test_no_sign_missing_file(self):
+        os.unlink(self.file_.file_path)
+        assert not self.file_.is_signed
+        assert not self.file_.cert_serial_num
+        assert not self.file_.hash
+        packaged.sign_file(self.file_)
+        assert not self.file_.is_signed
+        assert not self.file_.cert_serial_num
+        assert not self.file_.hash
+        assert not packaged.is_signed(self.file_.file_path)
+
     def test_no_sign_hotfix_addons(self):
         """Don't sign hotfix addons."""
         for hotfix_guid in settings.HOTFIX_ADDON_GUIDS:


### PR DESCRIPTION
Fixes [bug 1164390](https://bugzilla.mozilla.org/show_bug.cgi?id=1164390)