### PR TITLE
Don't display the 'unlist' option in the devhub unless the flag is active (bug 1168596)

### DIFF
--- a/apps/devhub/templates/devhub/versions/list.html
+++ b/apps/devhub/templates/devhub/versions/list.html
@@ -115,12 +115,14 @@
                     class="disable-addon">
              <strong>{{ _('Hidden:') }}</strong> {{ _('Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them.')|f(settings.SITE_URL) }}</label>
       <br><br>
+      {% if waffle.flag('unlisted-addons') %}
       <label><input name="addon-state" value="unlisted" type="radio"
                     {% if not owner or addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
                     {% if not addon.is_listed %}checked="checked"{% endif %}
                     class="unlist-addon">
              <strong>{{ _('Unlisted:') }}</strong> {{ _('Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own.')|f(settings.SITE_URL) }}</label>
       <br><br>
+      {% endif %}
       {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
         <a class="delete-button delete-addon" href="{{ addon.get_dev_url('versions') }}#delete-addon">{{ _('Delete Add-on') }}</a>
       {% endif %}

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -189,6 +189,7 @@ class TestVersion(amo.tests.TestCase):
 
     @mock.patch('devhub.views.unindex_addons')
     def test_user_can_unlist_addon(self, unindex):
+        self.create_flag('unlisted-addons')
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=False,
                           is_listed=True)
         res = self.client.post(self.unlist_url)
@@ -207,6 +208,7 @@ class TestVersion(amo.tests.TestCase):
 
     @mock.patch('devhub.views.unindex_addons')
     def test_user_can_unlist_hidden_addon(self, unindex):
+        self.create_flag('unlisted-addons')
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=True,
                           is_listed=True)
         res = self.client.post(self.unlist_url)
@@ -267,6 +269,7 @@ class TestVersion(amo.tests.TestCase):
 
     def test_non_owner_cant_change_status(self):
         """A non-owner can't use the radio buttons."""
+        self.create_flag('unlisted-addons')
         self.addon.update(disabled_by_user=False)
         addon_user = AddonUser.objects.get(addon=self.addon)
         addon_user.role = amo.AUTHOR_ROLE_VIEWER
@@ -312,6 +315,7 @@ class TestVersion(amo.tests.TestCase):
 
     def test_status_disabled_addon_radio(self):
         """Disabled by Mozilla addon: hidden selected, can't change status."""
+        self.create_flag('unlisted-addons')
         self.addon.update(status=amo.STATUS_DISABLED, disabled_by_user=False)
         res = self.client.get(self.url)
         doc = pq(res.content)
@@ -324,6 +328,7 @@ class TestVersion(amo.tests.TestCase):
 
     def test_unlisted_addon_cant_change_status(self):
         """Unlisted addon: can't change its status."""
+        self.create_flag('unlisted-addons')
         self.addon.update(disabled_by_user=False, is_listed=False)
         res = self.client.get(self.url)
         doc = pq(res.content)

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -394,6 +394,8 @@ def disable(request, addon_id, addon):
 @dev_required
 @post_required
 def unlist(request, addon_id, addon):
+    if not waffle.flag_is_active(request, 'unlisted-addons'):
+        raise PermissionDenied
     addon.update(is_listed=False, disabled_by_user=False)
     amo.log(amo.LOG.ADDON_UNLISTED, addon)
     unindex_addons.delay([addon.id])


### PR DESCRIPTION
Fixes [bug 1168596](https://bugzilla.mozilla.org/show_bug.cgi?id=1168596)