### PR TITLE
Find XPIs that have a META-INF/MANIFEST.MF file (bug 1169574)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -84,7 +84,7 @@ receipts==0.2.9
 redis==2.8.0
 requests==2.6.0
 sasl==0.1.3
-signing_clients==0.1.13
+signing_clients==0.1.14
 six==1.4.1
 slumber==0.5.3
 SQLAlchemy==0.7.5

--- a/scripts/find-MANIFEST-files-in-xpi.py
+++ b/scripts/find-MANIFEST-files-in-xpi.py
@@ -1,0 +1,39 @@
+import logging
+import os
+import site
+import zipfile
+
+# Add the parent dir to the python path so we can import manage.
+parent_dir = os.path.dirname(__file__)
+site.addsitedir(os.path.abspath(os.path.join(parent_dir, '../')))
+
+# manage adds /apps and /lib to the Python path.
+import manage  # noqa: we need this so it's a standalone script.
+
+import amo  # noqa
+from files.models import File  # noqa
+from files.utils import parse_addon  # noqa
+
+
+log = logging.getLogger('find-MANIFEST-files-in-xpi')
+
+
+"""Walk all the XPI files to find those that have META-INF/MANIFEST.mf file.
+
+This file with was not removed by the signing_clients<=0.1.13 on signing, and
+thus would result in a "signature not recognizable" error. See bug
+https://bugzilla.mozilla.org/show_bug.cgi?id=1169574.
+"""
+addons = set()
+# Only (complete) themes and addons can have XPI files.
+for file_ in File.objects.filter(
+        version__addon__type__in=[amo.ADDON_EXTENSION, amo.ADDON_THEME],
+        is_signed=True):
+    try:
+        with zipfile.ZipFile(file_.file_path, mode='r') as zf:
+            filenames = zf.namelist()
+            if u'META-INF/MANIFEST.MF' in filenames:
+                addons.add(file_.version.addon.pk)
+    except (zipfile.BadZipfile, IOError):
+        pass
+print ' '.join((str(addon_id) for addon_id in addons))


### PR DESCRIPTION
Fixes [bug 1169574](https://bugzilla.mozilla.org/show_bug.cgi?id=1169574)

This needs the new signing_clients==0.1.14 once it's released, to make sure
future signatures will be correct.

The find-MANIFEST-files-in-xpi.py will return a list of addons that have such a
bogus META-INF/MANIFEST.MF file, that list could be fed to the "unsign_addons"
script, and then to the "sign_addons" script again.