### PR TITLE
Change the download button CTA for non-Fx users. (bug 1170736)

### DIFF
--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -316,7 +316,6 @@ button[disabled],
     -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
     background-image:linear-gradient(to bottom,#43a6e2,#277ac1);
     color:#fff;
-    text-align:center;
     text-decoration:none;
     min-width:80px;
     border:0;
@@ -331,6 +330,10 @@ button[disabled],
     -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
     background-image:linear-gradient(to bottom,#81bc2e,#659324);
     cursor:pointer;
-    text-align:left;
-    border-radius:6px
+    text-align:center;
+    border-radius:6px;
+    font-size: 25px;
+    font-family: "Open Sans",X-LocaleSpecific,sans-serif;
+    font-weight: normal;
+    padding: 25px;
 }

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -305,35 +305,37 @@ button[disabled],
     pointer-events: none;
 }
 .button.CTA {
-    display:inline-block;
-    *display:inline;
-    *zoom:1;
-    border-radius:.25em;
-    box-shadow:0 1px 0 0 rgba(0,0,0,0.2),inset 0 -1px 0 0 rgba(0,0,0,0.3);
-    background-color:#43a6e2;
-    background-color:#277ac1;
-    background-image:-webkit-linear-gradient(top,#43a6e2,#277ac1);
-    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
-    background-image:linear-gradient(to bottom,#43a6e2,#277ac1);
-    color:#fff;
-    text-decoration:none;
-    min-width:80px;
-    border:0;
-    text-shadow:0 1px 0 rgba(0,0,0,0.25);
-    font-family:'Open Sans',X-LocaleSpecific,sans-serif;
-    -webkit-transition:all linear .25s;
-    transition:all linear .25s;
-    background-color:#81bc2e;
-    background-color:#659324;
-    background-repeat:repeat-x;
-    background-image:-webkit-linear-gradient(top,#81bc2e,#659324);
-    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
-    background-image:linear-gradient(to bottom,#81bc2e,#659324);
-    cursor:pointer;
-    text-align:center;
-    border-radius:6px;
-    font-size: 25px;
-    font-family: "Open Sans",X-LocaleSpecific,sans-serif;
-    font-weight: normal;
+    display: inline-block;
+    min-width: 80px;
     padding: 25px;
+    border: 0;
+    border-radius: 6px;
+    border-radius: .25em;
+    box-shadow: 0 1px 0 0 rgba(0,0,0,0.2), inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    color: #fff;
+    background-color: #43a6e2;
+    background-color: #277ac1;
+    background-color: #81bc2e;
+    background-color: #659324;
+    background-image: -webkit-linear-gradient(top, #43a6e2, #277ac1);
+    background-image: linear-gradient(to bottom, #43a6e2, #277ac1);
+    background-image: -webkit-linear-gradient(top, #81bc2e, #659324);
+    background-image: linear-gradient(to bottom, #81bc2e, #659324);
+    background-repeat: repeat-x;
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+    font-family: 'Open Sans',X-LocaleSpecific,sans-serif;
+    -webkit-transition: all linear .25s;
+    transition: all linear .25s;
+    text-align: center;
+    font-size: 25px;
+    font-family: "Open Sans", X-LocaleSpecific, sans-serif;
+    font-weight: normal;
+
+    /* IE7 and Below */
+    *display: inline;
+    *zoom: 1;
 }

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -304,3 +304,33 @@ button[disabled],
 .button.caution.concealed {
     pointer-events: none;
 }
+.button.CTA {
+    display:inline-block;
+    *display:inline;
+    *zoom:1;
+    border-radius:.25em;
+    box-shadow:0 1px 0 0 rgba(0,0,0,0.2),inset 0 -1px 0 0 rgba(0,0,0,0.3);
+    background-color:#43a6e2;
+    background-color:#277ac1;
+    background-image:-webkit-linear-gradient(top,#43a6e2,#277ac1);
+    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
+    background-image:linear-gradient(to bottom,#43a6e2,#277ac1);
+    color:#fff;
+    text-align:center;
+    text-decoration:none;
+    min-width:80px;
+    border:0;
+    text-shadow:0 1px 0 rgba(0,0,0,0.25);
+    font-family:'Open Sans',X-LocaleSpecific,sans-serif;
+    -webkit-transition:all linear .25s;
+    transition:all linear .25s;
+    background-color:#81bc2e;
+    background-color:#659324;
+    background-repeat:repeat-x;
+    background-image:-webkit-linear-gradient(top,#81bc2e,#659324);
+    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
+    background-image:linear-gradient(to bottom,#81bc2e,#659324);
+    cursor:pointer;
+    text-align:left;
+    border-radius:6px
+}

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -403,6 +403,8 @@ var installButton = function() {
         var opts = search ? {addPopup: false, addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
+        $button.addClass('concealed');
+        versionsAndPlatforms({addPopup: false});
         $button.addClass('CTA');
         $button.text('Only with Firefox -- Get Firefox Now!');
         $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2#download-fx');

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -407,7 +407,8 @@ var installButton = function() {
         versionsAndPlatforms({addPopup: false});
         $button.addClass('CTA');
         $button.text('Only with Firefox -- Get Firefox Now!');
-        $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2#download-fx');
+        $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2&utm_source=addons.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button#download-fx');
+        $('#site-nonfx').hide();
     } else if (z.app == 'thunderbird') {
         var msg = function() {
             return $(message('learn_more')()).html();

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -403,8 +403,9 @@ var installButton = function() {
         var opts = search ? {addPopup: false, addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
-        $button.addPopup(message('learn_more')).addClass('concealed');
-        versionsAndPlatforms({addPopup: false});
+        $button.addClass('CTA');
+        $button.text('Only with Firefox -- Get Firefox Now!');
+        $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2#download-fx');
     } else if (z.app == 'thunderbird') {
         var msg = function() {
             return $(message('learn_more')()).html();


### PR DESCRIPTION
I changed the button which is shown to link users to download Firefox directly rather than the 'learn more' popup CTA. This change is reflected by A/B testing done previously and documented by bug 1170736.

@magopian r?