### PR TITLE
unlisted addons submissions and beta files validation are in beta status (bug 1173064)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -503,12 +503,12 @@ class NewAddonForm(AddonUploadForm):
         coerce=int,
         error_messages={'required': 'Need at least one platform.'}
     )
-    is_listed = forms.BooleanField(
-        initial=True,
+    is_unlisted = forms.BooleanField(
+        initial=False,
         required=False,
-        label=_lazy(u'Yes, distribute my add-on on this site.'),
+        label=_lazy(u'Do not list my add-on on this site (beta)'),
         help_text=_lazy(
-            u'Uncheck this option if you intend to distribute your add-on on '
+            u'Check this option if you intend to distribute your add-on on '
             u'your own and only need it to be signed by Mozilla.'))
     is_sideload = forms.BooleanField(
         initial=False,

--- a/apps/devhub/templates/devhub/addons/submit/upload.html
+++ b/apps/devhub/templates/devhub/addons/submit/upload.html
@@ -25,11 +25,19 @@
     <div class="list-addon">
       <label>{{ _('Do you want your add-on to be distributed on this site?') }}</label>
       <div>
-        <label for="{{ new_addon_form.is_listed.auto_id }}">
-          {{ new_addon_form.is_listed }}
-          {{ new_addon_form.is_listed.label }}
+        <label for="{{ new_addon_form.is_unlisted.auto_id }}">
+          {{ new_addon_form.is_unlisted }}
+          {{ new_addon_form.is_unlisted.label }}
           <span class="tip tooltip"
-                title="{{ new_addon_form.is_listed.help_text }}">?</span>
+                title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
+          <span class="beta-warning"><br /><em>{{ _('Warning:') }}</em>
+            {% trans bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
+              Submission of unlisted add-ons for signing is currently in an
+              open beta. Manual review may still be required for a large
+              number of add-ons. Please
+              <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+            {% endtrans %}
+          </span>
         </label>
         <label for="{{ new_addon_form.is_sideload.auto_id }}">
           {{ new_addon_form.is_sideload }}

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -12,6 +12,16 @@
           will be available for download.
         {% endtrans %}
       </p>
+      {% if not addon.is_listed %}
+        <p class="beta-warning"><em>{{ _('Warning:') }}</em>
+          {% trans bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
+            Submission of updates to unlisted add-ons for signing is currently
+            in an open beta. Manual review may still be required for a large
+            number of add-ons. Please
+            <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+          {% endtrans %}
+        </p>
+      {% endif %}
       {{ csrf() }}
 
       <div class="hidden">
@@ -46,6 +56,15 @@
       <div class="beta-status hide">
         <label>{{ new_file_form.beta }} {{ _('Only publish this version to my beta channel.') }}</label>
         <span class="tip tooltip" title="{{ new_file_form.beta.help_text }}">?</span>
+        <p class="beta-warning"><em>{{ _('Warning:') }}</em>
+          {% trans addon_signing_url='https://wiki.mozilla.org/Addons/Extension_Signing', bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
+            The behavior of the beta channel has changed to accommodate
+            <a href="{{ addon_signing_url }}">mandatory add-on signing</a>. The
+            new process is currently in an open beta, and may change
+            significantly in the near future. Please
+            <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+          {% endtrans %}
+        </p>
       </div>
       {% if is_admin %}
       <div class="admin-settings">

--- a/apps/devhub/templates/devhub/versions/list.html
+++ b/apps/devhub/templates/devhub/versions/list.html
@@ -120,7 +120,7 @@
                     {% if not owner or addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
                     {% if not addon.is_listed %}checked="checked"{% endif %}
                     class="unlist-addon">
-             <strong>{{ _('Unlisted:') }}</strong> {{ _('Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own.')|f(settings.SITE_URL) }}</label>
+             <strong>{{ _('Unlisted:') }}</strong> {{ _('Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own. (beta)')|f(settings.SITE_URL) }}</label>
       <br><br>
       {% endif %}
       {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
@@ -294,6 +294,12 @@
           users.  It is recommended for unlisted add-ons to provide a custom
           <a href="{{ update_url }}" target="_blank">updateURL</a> in their
           install.rdf file for automatic updates.
+        {% endtrans %}
+      </p>
+      <p class="beta-warning"><br /><em>{{ _('Warning:') }}</em>
+        {% trans bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
+          Switching add-ons to unlisted is currently in an open beta. Please
+          <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
         {% endtrans %}
       </p>
       <p>

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1171,7 +1171,7 @@ class TestSubmitStep2(amo.tests.TestCase):
         response = self.client.get(reverse('devhub.submit.2'))
         eq_(response.status_code, 200)
         doc = pq(response.content)
-        assert doc('.list-addon input#id_is_listed[type=checkbox]')
+        assert doc('.list-addon input#id_is_unlisted[type=checkbox]')
         # There also is a checkbox to select full review (side-load) or prelim.
         assert doc('.list-addon input#id_is_sideload[type=checkbox]')
 
@@ -2953,7 +2953,7 @@ class UploadAddon(object):
              source=None, is_listed=True, is_sideload=False, status_code=200):
         d = dict(upload=self.upload.pk, source=source,
                  supported_platforms=[p.id for p in supported_platforms],
-                 is_listed=is_listed, is_sideload=is_sideload)
+                 is_unlisted=not is_listed, is_sideload=is_sideload)
         r = self.client.post(self.url, d, follow=True)
         eq_(r.status_code, status_code)
         if not expect_errors:

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1386,7 +1386,7 @@ def submit_addon(request, step):
 
             p = data.get('supported_platforms', [])
 
-            is_listed = data['is_listed']
+            is_listed = not data['is_unlisted']
             if not waffle.flag_is_active(request, 'unlisted-addons'):
                 is_listed = True
 

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -403,6 +403,12 @@ form .char-count b {
     display: block;
     padding-bottom: 3px;
 }
+.addon-submission-process form label span.beta-warning {
+    display: none;
+}
+.beta-warning em {
+    color: #f00;
+}
 .addon-submission-process form label[for=id_is_sideload] {
     display: none;
     margin-left: 20px;

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -265,10 +265,14 @@
                 // If the addon is detected as beta, automatically check
                 // the "beta" input, but only if the addon is listed.
                 var $new_form = $('.new-addon-file');
-                var isListed = $('#id_is_listed').is(':checked') || $new_form.data('addon-is-listed')
-                if (results.beta && isListed) {
-                  $('#id_beta').prop('checked', true);
+                var isUnlisted = $('#id_is_unlisted').is(':checked') || !$new_form.data('addon-is-listed')
+                  var $beta = $('#id_beta');
+                if (results.beta && !isUnlisted) {
+                  $beta.prop('checked', true);
                   $('.beta-status').show();
+                } else {
+                  $beta.prop('checked', false);
+                  $('.beta-status').hide();
                 }
                 if(results.error) {
                     // This shouldn't happen.  But it might.
@@ -337,7 +341,7 @@
                       // Specific messages for unlisted addons.
                       var isSideload = $('#id_is_sideload').is(':checked') || $new_form.data('addon-is-sideload');
                       var automaticValidation = $('#create-addon').data('automatic-validation') || $new_form.data('automatic-validation');
-                      if (!isListed) {
+                      if (isUnlisted) {
                         if (isSideload) {
                           $("<p>").text(gettext("Your submission will go through a manual review.")).appendTo(upload_results);
                         } else {
@@ -356,10 +360,22 @@
                         }
                       } else {  // This is a listed add-on.
                         if (automaticValidation && results.beta) {
-                          if (!v.passed_auto_validation) {
-                            $('#invalid-beta').show().removeClass('hidden');
-                            $('.addon-upload-dependant').attr('disabled', true);
+                          function updateBetaStatus() {
+                            if (!$beta.is(':checked') || v.passed_auto_validation) {
+                              $('#invalid-beta').hide().addClass('hidden');
+                              $('.addon-upload-dependant').attr('disabled', false);
+                            } else {
+                              $('#invalid-beta').show().removeClass('hidden');
+                              $('.addon-upload-dependant').attr('disabled', true);
+                            }
+                            if ($beta.is(':checked')) {
+                              $('p.beta-warning').show();
+                            } else {
+                              $('p.beta-warning').hide();
+                            }
                           }
+                          $beta.bind('change', updateBetaStatus);
+                          updateBetaStatus();
                         }
                       }
                     }

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -85,24 +85,27 @@ $(document).ready(function() {
 
     var $new_form = $('.new-addon-file');
     if ($new_form.data('unlisted-addons')) {
-      // is_listed checkbox: should the add-on be listed on AMO? If not, change
-      // the addon upload button's data-upload-url.
+      // is_unlisted checkbox: should the add-on be listed on AMO? If not,
+      // change the addon upload button's data-upload-url.
       // If this add-on is unlisted, then tell the upload view so
       // it'll run the validator with the "listed=False"
       // parameter.
-      var $isListed = $('#id_is_listed');
+      var $isUnlisted = $('#id_is_unlisted');
+      var $betaWarningLabel = $('span.beta-warning');
       var $isSideloadLabel = $('label[for=id_is_sideload]');
       var $isSideload = $('#id_is_sideload');
       var $isManualReview = $('#manual-review');
       var $submitAddonProgress = $('.submit-addon-progress');
       function updateListedStatus() {
-        if ($isListed.is(':checked') || $new_form.data('addon-is-listed')) {  // It's a listed add-on.
+        if (!$isUnlisted.is(':checked') || $new_form.data('addon-is-listed')) {  // It's a listed add-on.
           $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-listed'));
+          $betaWarningLabel.hide();
           $isSideloadLabel.hide();
           $isSideload.attr('checked', false);
           $submitAddonProgress.removeClass('unlisted');
         } else {  // It's an unlisted add-on.
           $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-unlisted'));
+          $betaWarningLabel.show();
           $isSideloadLabel.show();
           $submitAddonProgress.addClass('unlisted');
         }
@@ -113,25 +116,13 @@ $(document).ready(function() {
         $('.upload-status').remove();
         $isManualReview.hide();
       }
-      $isListed.bind('change', updateListedStatus);
+      $isUnlisted.bind('change', updateListedStatus);
       $isSideload.bind('change', updateListedStatus);
       updateListedStatus();
     }
 
     $('#id_is_manual_review').bind('change', function() {
         $('.addon-upload-dependant').attr('disabled', !($(this).is(':checked')));
-    });
-
-    $('#id_beta').bind('change', function() {
-        // User unchecked the beta checkbox, meaning they want this file to go
-        // through the usual review process.
-        if ($('#id_beta').is(':checked')) {
-            $('#invalid-beta').show();
-            $('.addon-upload-dependant').attr('disabled', true);
-        } else {
-            $('#invalid-beta').hide();
-            $('.addon-upload-dependant').attr('disabled', false);
-        }
     });
 
     if ($(".add-file-modal").length) {


### PR DESCRIPTION
Fixes [bug 1173064](https://bugzilla.mozilla.org/show_bug.cgi?id=1173064)

Listed add-on submission
![screen shot 2015-06-10 at 11 54 33](https://cloud.githubusercontent.com/assets/167767/8084545/d1d923a0-0f8b-11e5-984e-e137fd91b9c0.png)

Unlisted add-on submission
![screen shot 2015-06-10 at 11 54 19](https://cloud.githubusercontent.com/assets/167767/8084557/e2bee7ea-0f8b-11e5-8865-c9a00fabf881.png)

Upload a new file or add a new version to an unlisted add-on
![screen shot 2015-06-10 at 12 01 47](https://cloud.githubusercontent.com/assets/167767/8084566/f7a3f916-0f8b-11e5-8159-e5b6cce09f5d.png)

Upload a beta version on a fully reviewed listed add-on, validation failed
![screen shot 2015-06-10 at 16 12 21](https://cloud.githubusercontent.com/assets/167767/8084576/06546360-0f8c-11e5-8cd6-bb5b14116354.png)

Upload a beta version on a fully reviewed listed add-on, validation failed, not publishing to beta channel
![screen shot 2015-06-10 at 16 12 33](https://cloud.githubusercontent.com/assets/167767/8084591/1cece084-0f8c-11e5-92ff-9ade79904dc2.png)
