### PR TITLE
Allow multiple files (platforms) when submitting unlisted addons (bug 1173125)

### DIFF
--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1247,8 +1247,9 @@ def version_add(request, addon_id, addon):
                   args=[addon.slug, str(version.id)])
 
     if waffle.flag_is_active(request, 'automatic-validation'):
-        file_ = version.files.get()
-        auto_sign_file(file_, is_beta=is_beta)
+        # Sign all the files submitted, one for each platform.
+        for file_ in version.files.all():
+            auto_sign_file(file_, is_beta=is_beta)
 
     return dict(url=url)
 
@@ -1399,13 +1400,11 @@ def submit_addon(request, step):
                 if data.get('is_sideload'):  # Full review needed.
                     addon.update(status=amo.STATUS_NOMINATED)
                 else:  # Otherwise, simply do a prelim review.
-                    # We need to get to the file: we're submitting a brand new
-                    # addon here, so only one version, and one file for this
-                    # version.
-                    addon_file = addon.versions.get().files.get()
                     addon.update(status=amo.STATUS_UNREVIEWED)
                     if waffle.flag_is_active(request, 'automatic-validation'):
-                        auto_sign_file(addon_file)
+                        # Sign all the files submitted, one for each platform.
+                        for file_ in addon.versions.get().files.all():
+                            auto_sign_file(file_)
             SubmitStep.objects.create(addon=addon, step=3)
             return redirect(_step_url(3), addon.slug)
     is_admin = acl.action_allowed(request, 'ReviewerAdminTools', 'View')


### PR DESCRIPTION
Fixes [bug 1173125](https://bugzilla.mozilla.org/show_bug.cgi?id=1173125)

This PR is based on PR #578, only the last commit is relevant to this change.