### PR TITLE
Open the links for the 'unlisted ui is in beta' in a new tab (bug 1174012)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/upload.html
+++ b/apps/devhub/templates/devhub/addons/submit/upload.html
@@ -35,7 +35,8 @@
               Submission of unlisted add-ons for signing is currently in an
               open beta. Manual review may still be required for a large
               number of add-ons. Please
-              <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+              <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a>
+              that you encounter.
             {% endtrans %}
           </span>
         </label>

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -18,7 +18,8 @@
             Submission of updates to unlisted add-ons for signing is currently
             in an open beta. Manual review may still be required for a large
             number of add-ons. Please
-            <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+            <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a>
+            that you encounter.
           {% endtrans %}
         </p>
       {% endif %}
@@ -59,10 +60,10 @@
         <p class="beta-warning"><em>{{ _('Warning:') }}</em>
           {% trans addon_signing_url='https://wiki.mozilla.org/Addons/Extension_Signing', bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
             The behavior of the beta channel has changed to accommodate
-            <a href="{{ addon_signing_url }}">mandatory add-on signing</a>. The
-            new process is currently in an open beta, and may change
+            <a href="{{ addon_signing_url }}" target="_blank">mandatory add-on signing</a>.
+            The new process is currently in an open beta, and may change
             significantly in the near future. Please
-            <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+            <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a> that you encounter.
           {% endtrans %}
         </p>
       </div>

--- a/apps/devhub/templates/devhub/versions/list.html
+++ b/apps/devhub/templates/devhub/versions/list.html
@@ -299,7 +299,8 @@
       <p class="beta-warning"><br /><em>{{ _('Warning:') }}</em>
         {% trans bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
           Switching add-ons to unlisted is currently in an open beta. Please
-          <a href="{{ bugzilla_url }}">report any bugs</a> that you encounter.
+          <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a> that
+          you encounter.
         {% endtrans %}
       </p>
       <p>


### PR DESCRIPTION
Fixes [bug 1174012](https://bugzilla.mozilla.org/show_bug.cgi?id=1174012)