### PR TITLE
Can now submit unlisted addons to the standalone validator (bug 1172037)

### DIFF
--- a/apps/devhub/templates/devhub/validate_addon.html
+++ b/apps/devhub/templates/devhub/validate_addon.html
@@ -7,7 +7,8 @@
   {{ dev_breadcrumbs(addon, items=[(None, title)]) }}
   <h2>{{ title }}</h2>
 </header>
-<form method="post" id="create-addon" class="item">
+<form method="post" id="create-addon" class="item new-addon-file"
+      data-unlisted-addons="{% if waffle.flag('unlisted-addons') %}true{% else %}false{% endif %}">
   {{ csrf() }}
   <p>
   {% trans %}
@@ -38,8 +39,34 @@
     </p>
   {% endif %}
   <section id="upload-file" class="validate-addon">
+    {% if waffle.flag('unlisted-addons') %}
+      <div class="list-addon">
+        <label>{{ _('Do you want your add-on to be distributed on this site?') }}</label>
+        <div>
+          <label for="{{ new_addon_form.is_unlisted.auto_id }}">
+            {{ new_addon_form.is_unlisted }}
+            {{ new_addon_form.is_unlisted.label }}
+            <span class="tip tooltip"
+                  title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
+            <span class="beta-warning"><br /><em>{{ _('Warning:') }}</em>
+              {% trans bugzilla_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Developer%20Pages' %}
+                Submission of unlisted add-ons for signing is currently in an
+                open beta. Manual review may still be required for a large
+                number of add-ons. Please
+                <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a> that you encounter.
+              {% endtrans %}
+            </span>
+          </label>
+        </div>
+      </div>
+    {% endif %}
 
-    <input type="file" id="upload-addon" data-upload-url="{{ upload_url }}">
+    <input type="file" id="upload-addon"
+      data-upload-url="{{ url('devhub.standalone_upload') }}"
+      {% if waffle.flag('unlisted-addons') %}
+        data-upload-url-listed="{{ url('devhub.standalone_upload') }}"
+        data-upload-url-unlisted="{{ url('devhub.standalone_upload_unlisted') }}"
+      {% endif %}>
 
   </section>
 </form>

--- a/apps/devhub/urls.py
+++ b/apps/devhub/urls.py
@@ -178,6 +178,8 @@ urlpatterns = decorate(write, patterns(
         name='devhub.upload_detail'),
     url('^standalone-upload$', views.standalone_upload,
         name='devhub.standalone_upload'),
+    url('^standalone-upload-unlisted$', views.standalone_upload_unlisted,
+        name='devhub.standalone_upload_unlisted'),
     url('^standalone-upload/([^/]+)$', views.standalone_upload_detail,
         name='devhub.standalone_upload_detail'),
 

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -577,7 +577,9 @@ def compat_application_versions(request):
 def validate_addon(request):
     return render(request, 'devhub/validate_addon.html',
                   {'title': _('Validate Add-on'),
-                   'upload_url': reverse('devhub.standalone_upload')})
+                   # Hack: we just need the "is_unlisted" field from this form.
+                   'new_addon_form': forms.NewAddonForm(
+                       None, None, request=request)})
 
 
 @login_required
@@ -586,7 +588,9 @@ def check_addon_compatibility(request):
     return render(request, 'devhub/validate_addon.html',
                   {'appversion_form': form,
                    'title': _('Check Add-on Compatibility'),
-                   'upload_url': reverse('devhub.standalone_upload')})
+                   # Hack: we just need the "is_unlisted" field from this form.
+                   'new_addon_form': forms.NewAddonForm(
+                       None, None, request=request)})
 
 
 @dev_required
@@ -670,6 +674,12 @@ def upload_manifest(request):
 @post_required
 def standalone_upload(request):
     return upload(request, is_standalone=True)
+
+
+@login_required
+@post_required
+def standalone_upload_unlisted(request):
+    return upload(request, is_standalone=True, is_listed=False)
 
 
 @login_required


### PR DESCRIPTION
Fixes [bug 1172037](https://bugzilla.mozilla.org/show_bug.cgi?id=1172037)

![screen shot 2015-06-12 at 17 41 36](https://cloud.githubusercontent.com/assets/167767/8133739/5588b266-112a-11e5-9c2f-2cde49756b14.png)

![screen shot 2015-06-12 at 17 41 43](https://cloud.githubusercontent.com/assets/167767/8133742/5c28ee06-112a-11e5-9348-49117686f37b.png)
