### PR TITLE
fix regression: updateURL should be allowed for unlisted addons (bug 1175060)

### DIFF
--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -265,8 +265,8 @@
                 // If the addon is detected as beta, automatically check
                 // the "beta" input, but only if the addon is listed.
                 var $new_form = $('.new-addon-file');
-                var isUnlisted = $('#id_is_unlisted').is(':checked') || !$new_form.data('addon-is-listed')
-                  var $beta = $('#id_beta');
+                var isUnlisted = ($('#id_is_unlisted').length && $('#id_is_unlisted').is(':checked')) || !$new_form.data('addon-is-listed')
+                var $beta = $('#id_beta');
                 if (results.beta && !isUnlisted) {
                   $beta.prop('checked', true);
                   $('.beta-status').show();

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
       var $isManualReview = $('#manual-review');
       var $submitAddonProgress = $('.submit-addon-progress');
       function updateListedStatus() {
-        if (!$isUnlisted.is(':checked') || $new_form.data('addon-is-listed')) {  // It's a listed add-on.
+        if (($isUnlisted.length && !$isUnlisted.is(':checked')) || $new_form.data('addon-is-listed')) {  // It's a listed add-on.
           $uploadAddon.attr('data-upload-url', $uploadAddon.attr('data-upload-url-listed'));
           $betaWarningLabel.hide();
           $isSideloadLabel.hide();


### PR DESCRIPTION
Fixes [bug 1175060](https://bugzilla.mozilla.org/show_bug.cgi?id=1175060)