### PR TITLE
Don't require a license when editing an unlisted addon (bug 1170266)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -141,6 +141,8 @@ class LicenseForm(AMOModelForm):
               for x in License.objects.builtins().filter(on_form=True)]
         cs.append((License.OTHER, _('Other')))
         self.fields['builtin'].choices = cs
+        if addon and not addon.is_listed:
+            self.fields['builtin'].required = False
 
     class Meta:
         model = License
@@ -185,6 +187,8 @@ class LicenseForm(AMOModelForm):
         changed = self.changed_data
 
         builtin = self.cleaned_data['builtin']
+        if builtin == '':  # No license chosen, it must be an unlisted add-on.
+            return
         if builtin != License.OTHER:
             license = License.objects.get(builtin=builtin)
         else:

--- a/apps/devhub/tests/test_views_ownership.py
+++ b/apps/devhub/tests/test_views_ownership.py
@@ -83,6 +83,21 @@ class TestEditLicense(TestOwnership):
             del data['text']
         return data
 
+    def test_no_license(self):
+        data = self.formset(builtin='')
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        license_form = response.context['license_form']
+        assert license_form.errors == {'builtin': [u'This field is required.']}
+
+    def test_no_license_required_for_unlisted(self):
+        self.addon.update(is_listed=False)
+        self.addon.latest_version.update(version=None)
+        data = self.formset(builtin='')
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        assert not self.addon.latest_version.version
+
     def test_success_add_builtin(self):
         data = self.formset(builtin=1)
         r = self.client.post(self.url, data)


### PR DESCRIPTION
Fixes [bug 1170266](https://bugzilla.mozilla.org/show_bug.cgi?id=1170266)