### PR TITLE
Auto sign beta files and log them (bug 1172035)

### DIFF
--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -583,6 +583,18 @@ class ADDON_UNLISTED(_LOG):
     keep = True
 
 
+class BETA_SIGNED_VALIDATION_PASSED(_LOG):
+    id = 129
+    format = _(u'{file} was signed.')
+    keep = True
+
+
+class BETA_SIGNED_VALIDATION_FAILED(_LOG):
+    id = 130
+    format = _(u'{file} was signed.')
+    keep = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -88,9 +88,6 @@
         </label>
       </div>
     {% endif %}
-    <div id="invalid-beta" class="hidden">
-        <p class="error">{{ _("Your version was detected as beta. It didn't pass automatic validation and thus can't be submitted. If you didn't mean to submit it as beta, please uncheck the beta channel option.") }}</p>
-    </div>
 
     <div class="upload-status-button-add">
       <button class="addon-upload-dependant button" id="upload-file-finish" disabled>{{ action_label }}</button>

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1206,15 +1206,14 @@ def auto_sign_file(file_, is_beta=False, admin_override=False):
                              'comments': 'automatic validation'})
             helper.handler.process_preliminary(auto_validation=True)
     elif is_beta:
-        # Beta won't be reviewed. Either they pass validation (or have an admin
-        # override) and are automatically reviewed and signed, or they aren't
-        # accepted.
-        if validation.passed_auto_validation or admin_override:
-            # Beta files always get signed with prelim cert.
-            sign_file(file_, settings.PRELIMINARY_SIGNING_SERVER)
+        # Beta won't be reviewed. They will always get signed, and logged, for
+        # further review if needed.
+        if validation.passed_auto_validation:
+            amo.log(amo.LOG.BETA_SIGNED_VALIDATION_PASSED, file_)
         else:
-            file_.update(status=amo.STATUS_DISABLED)
-            raise PermissionDenied
+            amo.log(amo.LOG.BETA_SIGNED_VALIDATION_FAILED, file_)
+        # Beta files always get signed with prelim cert.
+        sign_file(file_, settings.PRELIMINARY_SIGNING_SERVER)
 
 
 @json_view

--- a/apps/editors/forms.py
+++ b/apps/editors/forms.py
@@ -54,6 +54,17 @@ class EventLogForm(happyforms.Form):
         return data
 
 
+class BetaSignedLogForm(happyforms.Form):
+    VALIDATION_CHOICES = (
+        ('', ''),
+        (amo.LOG.BETA_SIGNED_VALIDATION_PASSED.id,
+         _lazy(u'Passed automatic validation')),
+        (amo.LOG.BETA_SIGNED_VALIDATION_FAILED.id,
+         _lazy(u'Failed automatic validation')))
+    filter = forms.ChoiceField(required=False, choices=VALIDATION_CHOICES,
+                               label=_lazy(u'Filter by automatic validation'))
+
+
 class ReviewLogForm(happyforms.Form):
     start = forms.DateField(required=False,
                             label=_lazy(u'View entries between'))

--- a/apps/editors/templates/editors/base.html
+++ b/apps/editors/templates/editors/base.html
@@ -78,6 +78,8 @@
           {{ _('Add-on Review Log') }}</a></li>
         <li><a href="{{ url('editors.eventlog') }}">
           {{ _('Moderated Review Log') }}</a></li>
+        <li><a href="{{ url('editors.beta_signed_log') }}">
+          {{ _('Signed Beta Files Log') }}</a></li>
       </ul>
     </li>
     {% if is_admin %}

--- a/apps/editors/templates/editors/beta_signed_log.html
+++ b/apps/editors/templates/editors/beta_signed_log.html
@@ -1,0 +1,56 @@
+{% extends "editors/base.html" %}
+
+{% block breadcrumbs %}
+{{ editors_breadcrumbs(items=[(None, _('Signed Beta Files Log'))]) }}
+{% endblock %}
+
+{% block content %}
+<h2>{{ _('Signed Beta Files Log') }}</h2>
+
+<div class="listing results">
+  <div class="results-inner controls">
+    <form action="{{ url('editors.beta_signed_log') }}">
+      <p class="date_range">
+        {{ form.filter.label_tag() }}
+        {{ form.filter }}
+        {# L10n: "Filter" is a button label (verb) #}
+        <button type="submit">{{ _('Filter') }}</button>
+      </p>
+    </form>
+    {% if pager.object_list %}
+      <table class="data-grid">
+        <thead><tr class="listing-header">
+          <th>{{ _('Date') }}</th>
+          <th>{{ _('Event') }}</th>
+        </tr></thead>
+        <tbody>
+          {% for item in pager.object_list %}
+          <tr>
+            <td>
+              {{ item.created|babel_datetime }}
+            </td>
+            <td>
+              {{ item.to_string() }}
+              {% if item.details %}
+              <a class="more-details"
+                 href="{{ url('editors.eventlog.detail', item.id) }}">
+                {{ _('More details.') }}
+              </a>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="no-results">{{ _('No events found for this period.') }}</p>
+    {% endif %}
+  </div>
+
+  {% if pager.has_other_pages() %}
+  <div class="listing-footer">
+    {{ pager|paginator }}
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -119,6 +119,59 @@ class TestEventLogDetail(TestEventLog):
         eq_(r.status_code, 200)
 
 
+class TestBetaSignedLog(EditorTest):
+
+    def setUp(self):
+        super(TestBetaSignedLog, self).setUp()
+        self.login_as_editor()
+        self.url = reverse('editors.beta_signed_log')
+        amo.set_user(UserProfile.objects.get(username='editor'))
+        addon = amo.tests.addon_factory()
+        version = addon.versions.get()
+        self.file1 = version.files.get()
+        self.file2 = amo.tests.file_factory(version=version)
+        self.file1_url = reverse('files.list', args=[self.file1.pk])
+        self.file2_url = reverse('files.list', args=[self.file2.pk])
+
+        self.log1 = amo.log(amo.LOG.BETA_SIGNED_VALIDATION_PASSED, self.file1)
+        self.log2 = amo.log(amo.LOG.BETA_SIGNED_VALIDATION_FAILED, self.file2)
+
+    def test_log(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_action_no_filter(self):
+        response = self.client.get(self.url)
+        results = pq(response.content)('tbody tr')
+        assert results.length == 2
+        assert self.file1_url in unicode(results)
+        assert self.file2_url in unicode(results)
+
+    def test_action_filter_validation_passed(self):
+        response = self.client.get(
+            self.url, {'filter': amo.LOG.BETA_SIGNED_VALIDATION_PASSED.id})
+        results = pq(response.content)('tbody tr')
+        assert results.length == 1
+        assert self.file1_url in unicode(results)
+        assert self.file2_url not in unicode(results)
+
+    def test_action_filter_validation_failed(self):
+        response = self.client.get(
+            self.url, {'filter': amo.LOG.BETA_SIGNED_VALIDATION_FAILED.id})
+        results = pq(response.content)('tbody tr')
+        assert results.length == 1
+        assert self.file1_url not in unicode(results)
+        assert self.file2_url in unicode(results)
+
+    def test_no_results(self):
+        ActivityLog.objects.all().delete()
+        response = self.client.get(self.url)
+        assert '"no-results"' in response.content
+
+    def test_breadcrumbs(self):
+        self._test_breadcrumbs([('Signed Beta Files Log', None)])
+
+
 class TestReviewLog(EditorTest):
     fixtures = EditorTest.fixtures + ['base/addon_3615']
 

--- a/apps/editors/urls.py
+++ b/apps/editors/urls.py
@@ -31,6 +31,8 @@ urlpatterns = (
     url(r'^logs$', views.eventlog, name='editors.eventlog'),
     url(r'^log/(\d+)$', views.eventlog_detail, name='editors.eventlog.detail'),
     url(r'^reviewlog$', views.reviewlog, name='editors.reviewlog'),
+    url(r'^beta_signed_log$', views.beta_signed_log,
+        name='editors.beta_signed_log'),
     url(r'^queue_version_notes/%s?$' % ADDON_ID, views.queue_version_notes,
         name='editors.queue_version_notes'),
     url(r'^queue_viewing$', views.queue_viewing,

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -103,6 +103,23 @@ def eventlog_detail(request, id):
     return render(request, 'editors/eventlog_detail.html', data)
 
 
+@addons_reviewer_required
+def beta_signed_log(request):
+    """Log of all the beta files that got signed."""
+    form = forms.BetaSignedLogForm(request.GET)
+    beta_signed_log = ActivityLog.objects.beta_signed_events()
+
+    if form.is_valid():
+        if form.cleaned_data['filter']:
+            beta_signed_log = beta_signed_log.filter(
+                action=form.cleaned_data['filter'])
+
+    pager = amo.utils.paginate(request, beta_signed_log, 50)
+
+    data = context(form=form, pager=pager)
+    return render(request, 'editors/beta_signed_log.html', data)
+
+
 @any_reviewer_required
 def home(request):
     if (not acl.action_allowed(request, 'Addons', 'Review') and

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -361,15 +361,6 @@
                       } else {  // This is a listed add-on.
                         if (automaticValidation && results.beta) {
                           function updateBetaStatus() {
-                            if (!$beta.is(':checked') || v.passed_auto_validation) {
-                              $('#invalid-beta').hide().addClass('hidden');
-                              $('.addon-upload-dependant').attr('disabled', false);
-                              $('.addon-upload-failure-dependant').attr('disabled', true);
-                            } else {
-                              $('#invalid-beta').show().removeClass('hidden');
-                              $('.addon-upload-dependant').attr('disabled', true);
-                              $('.addon-upload-failure-dependant').attr('disabled', false);
-                            }
                             if ($beta.is(':checked')) {
                               $('p.beta-warning').show();
                             } else {


### PR DESCRIPTION
Fixes [bug 1172035](https://bugzilla.mozilla.org/show_bug.cgi?id=1172035)

This is based on PR #590, and reverts most of what was done in it, because if
we do merge this PR, we won't need the PR #590 anymore. This also reverts part of what was done to prevent submitting a beta file that failed the automatic validation, obviously (was PR #555).

Only the last commit is relevant to the bug.

The logs are in a new "Signed Beta Files Log" menu, in the editor tools, and can be filtered to only show files that passed or failed validation:
![screen shot 2015-06-19 at 17 46 30](https://cloud.githubusercontent.com/assets/167767/8257046/32c03d2c-16ab-11e5-95ae-d719609e11d2.png)
