### PR TITLE
Bug 1170736 non ff dl btn collection fix

### DIFF
--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -316,7 +316,6 @@ button[disabled],
     -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
     background-image:linear-gradient(to bottom,#43a6e2,#277ac1);
     color:#fff;
-    text-align:center;
     text-decoration:none;
     min-width:80px;
     border:0;
@@ -331,6 +330,10 @@ button[disabled],
     -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
     background-image:linear-gradient(to bottom,#81bc2e,#659324);
     cursor:pointer;
-    text-align:left;
-    border-radius:6px
+    text-align:center;
+    border-radius:6px;
+    font-size: 25px;
+    font-family: "Open Sans",X-LocaleSpecific,sans-serif;
+    font-weight: normal;
+    padding: 25px;
 }

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -298,6 +298,7 @@ button[disabled],
     color: #919497;
     .box-shadow(0 3px rgba(0, 0, 0, 0.05), 0 -4px rgba(0, 0, 0, 0.05) inset);
     text-shadow: 0 1px 0 rgba(255,255,255,.5);
+    white-space: normal;
 }
 button[disabled],
 .button.disabled,

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -305,35 +305,37 @@ button[disabled],
     pointer-events: none;
 }
 .button.CTA {
-    display:inline-block;
-    *display:inline;
-    *zoom:1;
-    border-radius:.25em;
-    box-shadow:0 1px 0 0 rgba(0,0,0,0.2),inset 0 -1px 0 0 rgba(0,0,0,0.3);
-    background-color:#43a6e2;
-    background-color:#277ac1;
-    background-image:-webkit-linear-gradient(top,#43a6e2,#277ac1);
-    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
-    background-image:linear-gradient(to bottom,#43a6e2,#277ac1);
-    color:#fff;
-    text-decoration:none;
-    min-width:80px;
-    border:0;
-    text-shadow:0 1px 0 rgba(0,0,0,0.25);
-    font-family:'Open Sans',X-LocaleSpecific,sans-serif;
-    -webkit-transition:all linear .25s;
-    transition:all linear .25s;
-    background-color:#81bc2e;
-    background-color:#659324;
-    background-repeat:repeat-x;
-    background-image:-webkit-linear-gradient(top,#81bc2e,#659324);
-    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
-    background-image:linear-gradient(to bottom,#81bc2e,#659324);
-    cursor:pointer;
-    text-align:center;
-    border-radius:6px;
-    font-size: 25px;
-    font-family: "Open Sans",X-LocaleSpecific,sans-serif;
-    font-weight: normal;
+    display: inline-block;
+    min-width: 80px;
     padding: 25px;
+    border: 0;
+    border-radius: 6px;
+    border-radius: .25em;
+    box-shadow: 0 1px 0 0 rgba(0,0,0,0.2), inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    color: #fff;
+    background-color: #43a6e2;
+    background-color: #277ac1;
+    background-color: #81bc2e;
+    background-color: #659324;
+    background-image: -webkit-linear-gradient(top, #43a6e2, #277ac1);
+    background-image: linear-gradient(to bottom, #43a6e2, #277ac1);
+    background-image: -webkit-linear-gradient(top, #81bc2e, #659324);
+    background-image: linear-gradient(to bottom, #81bc2e, #659324);
+    background-repeat: repeat-x;
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+    font-family: 'Open Sans',X-LocaleSpecific,sans-serif;
+    -webkit-transition: all linear .25s;
+    transition: all linear .25s;
+    text-align: center;
+    font-size: 25px;
+    font-family: "Open Sans", X-LocaleSpecific, sans-serif;
+    font-weight: normal;
+
+    /* IE7 and Below */
+    *display: inline;
+    *zoom: 1;
 }

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -304,3 +304,33 @@ button[disabled],
 .button.caution.concealed {
     pointer-events: none;
 }
+.button.CTA {
+    display:inline-block;
+    *display:inline;
+    *zoom:1;
+    border-radius:.25em;
+    box-shadow:0 1px 0 0 rgba(0,0,0,0.2),inset 0 -1px 0 0 rgba(0,0,0,0.3);
+    background-color:#43a6e2;
+    background-color:#277ac1;
+    background-image:-webkit-linear-gradient(top,#43a6e2,#277ac1);
+    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
+    background-image:linear-gradient(to bottom,#43a6e2,#277ac1);
+    color:#fff;
+    text-align:center;
+    text-decoration:none;
+    min-width:80px;
+    border:0;
+    text-shadow:0 1px 0 rgba(0,0,0,0.25);
+    font-family:'Open Sans',X-LocaleSpecific,sans-serif;
+    -webkit-transition:all linear .25s;
+    transition:all linear .25s;
+    background-color:#81bc2e;
+    background-color:#659324;
+    background-repeat:repeat-x;
+    background-image:-webkit-linear-gradient(top,#81bc2e,#659324);
+    -ms-filter:"progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
+    background-image:linear-gradient(to bottom,#81bc2e,#659324);
+    cursor:pointer;
+    text-align:left;
+    border-radius:6px
+}

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -298,7 +298,6 @@ button[disabled],
     color: #919497;
     .box-shadow(0 3px rgba(0, 0, 0, 0.05), 0 -4px rgba(0, 0, 0, 0.05) inset);
     text-shadow: 0 1px 0 rgba(255,255,255,.5);
-    white-space: normal;
 }
 button[disabled],
 .button.disabled,

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -305,36 +305,36 @@ button[disabled],
     pointer-events: none;
 }
 .button.CTA {
-min-width: 80px;
-padding: 25px;
-border: 0;
-border-radius: 6px;
-border-radius: .25em;
-box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2), inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
-cursor: pointer;
-color: #fff !important;
-background-color: #43a6e2 !important;
-background-color: #277ac1 !important;
-background-color: #81bc2e !important;
-background-color: #659324 !important;
-background-image: -webkit-linear-gradient(top, #43a6e2, #277ac1) !important;
-background-image: linear-gradient(to bottom, #43a6e2, #277ac1) !important;
-background-image: -webkit-linear-gradient(top, #81bc2e, #659324) !important;
-background-image: linear-gradient(to bottom, #81bc2e, #659324) !important;
-background-repeat: repeat-x !important;
--ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
--ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
-text-decoration: none;
-text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
-font-family: 'Open Sans', X-LocaleSpecific, sans-serif;
--webkit-transition: all linear .25s;
-transition: all linear .25s;
-text-align: center;
-font-size: 25px;
-font-family: "Open Sans", X-LocaleSpecific, sans-serif;
-font-weight: normal;
-/* IE7 and Below */
+    min-width: 80px;
+    padding: 25px;
+    border: 0;
+    border-radius: 6px;
+    border-radius: .25em;
+    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2), inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    color: #fff !important;
+    background-color: #43a6e2 !important;
+    background-color: #277ac1 !important;
+    background-color: #81bc2e !important;
+    background-color: #659324 !important;
+    background-image: -webkit-linear-gradient(top, #43a6e2, #277ac1) !important;
+    background-image: linear-gradient(to bottom, #43a6e2, #277ac1) !important;
+    background-image: -webkit-linear-gradient(top, #81bc2e, #659324) !important;
+    background-image: linear-gradient(to bottom, #81bc2e, #659324) !important;
+    background-repeat: repeat-x !important;
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+    font-family: 'Open Sans', X-LocaleSpecific, sans-serif;
+    -webkit-transition: all linear .25s;
+    transition: all linear .25s;
+    text-align: center;
+    font-size: 25px;
+    font-family: "Open Sans", X-LocaleSpecific, sans-serif;
+    font-weight: normal;
 
-*display: inline;
-*zoom: 1;
+    /* IE7 and Below */
+    *display: inline;
+    *zoom: 1;
 }

--- a/static/css/impala/buttons.less
+++ b/static/css/impala/buttons.less
@@ -305,37 +305,36 @@ button[disabled],
     pointer-events: none;
 }
 .button.CTA {
-    display: inline-block;
-    min-width: 80px;
-    padding: 25px;
-    border: 0;
-    border-radius: 6px;
-    border-radius: .25em;
-    box-shadow: 0 1px 0 0 rgba(0,0,0,0.2), inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
-    cursor: pointer;
-    color: #fff;
-    background-color: #43a6e2;
-    background-color: #277ac1;
-    background-color: #81bc2e;
-    background-color: #659324;
-    background-image: -webkit-linear-gradient(top, #43a6e2, #277ac1);
-    background-image: linear-gradient(to bottom, #43a6e2, #277ac1);
-    background-image: -webkit-linear-gradient(top, #81bc2e, #659324);
-    background-image: linear-gradient(to bottom, #81bc2e, #659324);
-    background-repeat: repeat-x;
-    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
-    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
-    text-decoration: none;
-    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
-    font-family: 'Open Sans',X-LocaleSpecific,sans-serif;
-    -webkit-transition: all linear .25s;
-    transition: all linear .25s;
-    text-align: center;
-    font-size: 25px;
-    font-family: "Open Sans", X-LocaleSpecific, sans-serif;
-    font-weight: normal;
+min-width: 80px;
+padding: 25px;
+border: 0;
+border-radius: 6px;
+border-radius: .25em;
+box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2), inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
+cursor: pointer;
+color: #fff !important;
+background-color: #43a6e2 !important;
+background-color: #277ac1 !important;
+background-color: #81bc2e !important;
+background-color: #659324 !important;
+background-image: -webkit-linear-gradient(top, #43a6e2, #277ac1) !important;
+background-image: linear-gradient(to bottom, #43a6e2, #277ac1) !important;
+background-image: -webkit-linear-gradient(top, #81bc2e, #659324) !important;
+background-image: linear-gradient(to bottom, #81bc2e, #659324) !important;
+background-repeat: repeat-x !important;
+-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#81bc2e', endColorstr='#659324', GradientType=0)";
+-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#43a6e2', endColorstr='#277ac1', GradientType=0)";
+text-decoration: none;
+text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+font-family: 'Open Sans', X-LocaleSpecific, sans-serif;
+-webkit-transition: all linear .25s;
+transition: all linear .25s;
+text-align: center;
+font-size: 25px;
+font-family: "Open Sans", X-LocaleSpecific, sans-serif;
+font-weight: normal;
+/* IE7 and Below */
 
-    /* IE7 and Below */
-    *display: inline;
-    *zoom: 1;
+*display: inline;
+*zoom: 1;
 }

--- a/static/css/legacy/main.css
+++ b/static/css/legacy/main.css
@@ -2287,7 +2287,7 @@ ol.pagination + .num-results {
 
 .item-info {
     float: right;
-    width: 15em;
+    width: 19em;
     padding-left:2%;
     margin-left: 2%;
 }

--- a/static/css/zamboni/zamboni.css
+++ b/static/css/zamboni/zamboni.css
@@ -500,6 +500,7 @@ input[type=button].caution.concealed {
     border-color: #a70;
     background: -moz-linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.6) 60%),
     -moz-repeating-linear-gradient(-45deg, #F0B500, #F0B500 7px, #FFD000 7px, #FFD000 14px);
+    white-space: normal;
 }
 
 a.button.caution: hover,

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -403,6 +403,8 @@ var installButton = function() {
         var opts = search ? {addPopup: false, addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
+        $button.addClass('concealed');
+        versionsAndPlatforms({addPopup: false});
         $button.addClass('CTA');
         $button.text('Only with Firefox -- Get Firefox Now!');
         $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2#download-fx');

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -407,7 +407,8 @@ var installButton = function() {
         versionsAndPlatforms({addPopup: false});
         $button.addClass('CTA');
         $button.text('Only with Firefox -- Get Firefox Now!');
-        $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2#download-fx');
+        $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2&utm_source=addons.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button#download-fx');
+        $('#site-nonfx').hide();
     } else if (z.app == 'thunderbird') {
         var msg = function() {
             return $(message('learn_more')()).html();

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -403,8 +403,9 @@ var installButton = function() {
         var opts = search ? {addPopup: false, addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
-        $button.addPopup(message('learn_more')).addClass('concealed');
-        versionsAndPlatforms({addPopup: false});
+        $button.addClass('CTA');
+        $button.text('Only with Firefox -- Get Firefox Now!');
+        $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2#download-fx');
     } else if (z.app == 'thunderbird') {
         var msg = function() {
             return $(message('learn_more')()).html();


### PR DESCRIPTION
The only change between this PR and the previous one (https://github.com/mozilla/olympia/pull/588) is the change of the width of the item-info class to make room for a wider button. This button is only shown to non-firefox users.

Previous issue:
![screen shot 2015-07-02 at 11 13 52 am](https://cloud.githubusercontent.com/assets/9794516/8484259/7a485558-20ab-11e5-9a8d-b1d128dc4498.png)

Current PR:
![screen shot 2015-07-02 at 11 14 01 am](https://cloud.githubusercontent.com/assets/9794516/8484264/7e2eee66-20ab-11e5-8c08-90196d25762d.png)

It is worthy noting that these buttons currently do not work on the collections page as part of an outstanding bug from 11 months ago (https://bugzilla.mozilla.org/show_bug.cgi?id=1038301). Once that bug is fixed, it should fix this button and the "Continue to Download" button.

@magopian r?