### PR TITLE
Bug 1038301 "Continue to download" fix

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -600,6 +600,7 @@ MINIFY_BUNDLES = {
             'js/zamboni/buttons.js',
             'js/zamboni/tabs.js',
             'js/common/keys.js',
+            'js/common-min.js',
 
             # jQuery UI
             'js/lib/jquery-ui/jquery.ui.core.js',


### PR DESCRIPTION
This is fixing the issue with the non-ability to click the "Continue to Download" button on collections pages. The common-min.js file needed to be referenced in the settings_base.py file.

@magopian r?