### PR TITLE
Warn that unlisting an add-on is irreversible (bug 1184037)

### DIFF
--- a/apps/devhub/templates/devhub/versions/list.html
+++ b/apps/devhub/templates/devhub/versions/list.html
@@ -303,6 +303,7 @@
           you encounter.
         {% endtrans %}
       </p>
+      <p class="beta-warning"><em>{% trans %}Unlisting an add-on is irreversible!{% endtrans %}</em> {% trans %}An unlisted add-on cannot be switched to be listed.{% endtrans %}</p>
       <p>
         {% trans %}
           Are you sure you wish to unlist your add-on?


### PR DESCRIPTION
Fixes [bug 1184037](https://bugzilla.mozilla.org/show_bug.cgi?id=1184037)