### PR TITLE
Check automatic-validation waffle flag on the standalone validator (bug 1181236)

### DIFF
--- a/apps/devhub/templates/devhub/validate_addon.html
+++ b/apps/devhub/templates/devhub/validate_addon.html
@@ -8,6 +8,7 @@
   <h2>{{ title }}</h2>
 </header>
 <form method="post" id="create-addon" class="item new-addon-file"
+      data-automatic-validation="{% if waffle.flag('automatic-validation') %}true{% else %}false{% endif %}"
       data-unlisted-addons="{% if waffle.flag('unlisted-addons') %}true{% else %}false{% endif %}">
   {{ csrf() }}
   <p>
@@ -53,9 +54,16 @@
                 Submission of unlisted add-ons for signing is currently in an
                 open beta. Manual review may still be required for a large
                 number of add-ons. Please
-                <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a> that you encounter.
+                <a href="{{ bugzilla_url }}" target="_blank">report any bugs</a>
+                that you encounter.
               {% endtrans %}
             </span>
+          </label>
+          <label for="{{ new_addon_form.is_sideload.auto_id }}">
+            {{ new_addon_form.is_sideload }}
+            {{ new_addon_form.is_sideload.label }}
+            <span class="tip tooltip"
+                  title="{{ new_addon_form.is_sideload.help_text }}">?</span>
           </label>
         </div>
       </div>

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -398,7 +398,7 @@ form .char-count b {
     margin-bottom: 1em;
 }
 
-.addon-submission-process form label,
+form.new-addon-file label,
 #edit-addon-basic .addon-app-cats label {
     display: block;
     padding-bottom: 3px;
@@ -409,7 +409,7 @@ form .char-count b {
 .beta-warning em {
     color: #f00;
 }
-.addon-submission-process form label[for=id_is_sideload] {
+form.new-addon-file label[for=id_is_sideload] {
     display: none;
     margin-left: 20px;
 }


### PR DESCRIPTION
Fixes [bug 1181236](https://bugzilla.mozilla.org/show_bug.cgi?id=1181236)

It was misssing the `automatic-validation` waffle flag (to mimic https://github.com/mozilla/olympia/blob/master/apps/devhub/templates/devhub/addons/submit/upload.html#L8).

Also took the opportunity to add the "is sideload" checkbox, to better reflect the add-on submission flow.

Should have been done at the same time as https://github.com/mozilla/olympia/commit/e3f853d170aa21b5fe4ebaeffc3eeefb7eb6869e