### PR TITLE
Fixup following #591: LOG id was already used (bug 1172035)

### DIFF
--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -584,19 +584,21 @@ class ADDON_UNLISTED(_LOG):
 
 
 class BETA_SIGNED_VALIDATION_PASSED(_LOG):
-    id = 129
+    id = 131
     format = _(u'{file} was signed.')
     keep = True
 
 
 class BETA_SIGNED_VALIDATION_FAILED(_LOG):
-    id = 130
+    id = 132
     format = _(u'{file} was signed.')
     keep = True
 
 
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
+# Make sure there's no duplicate IDs.
+assert len(LOGS) == len(set(log.id for log in LOGS))
 
 LOG_BY_ID = dict((l.id, l) for l in LOGS)
 LOG = AttributeDict((l.__name__, l) for l in LOGS)


### PR DESCRIPTION
Fixes [bug 1172035](https://bugzilla.mozilla.org/show_bug.cgi?id=1172035) (again)

PR #591 was faulty: the id `130` was [already used](https://github.com/mozilla/olympia/pull/608/files#diff-629b196ecea6af2c8cdab1b4433f3896L359). This was causing some intermittent test failures (depending on the `PYTHONHASHSEED`, we would sometimes have one log class instead of the other).