### PR TITLE
Nullify the addon guid on soft deletion (bug 1176697)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -447,6 +447,9 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
                         .values_list('id', flat=True))
 
         if soft_deletion:
+            # /!\ If we ever stop using soft deletion, and remove this code, we
+            # need to make sure that the logs created below aren't cascade
+            # deleted!
 
             if self.guid:
                 log.debug('Adding guid to blacklist: %s' % self.guid)
@@ -492,8 +495,10 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
             # Update or NULL out various fields.
             models.signals.pre_delete.send(sender=Addon, instance=self)
             self._reviews.all().delete()
+            # The last parameter is needed to automagically create an AddonLog.
+            amo.log(amo.LOG.DELETE_ADDON, self.pk, self.guid, self)
             self.update(status=amo.STATUS_DELETED, slug=None, app_domain=None,
-                        _current_version=None)
+                        _current_version=None, guid=None)
             models.signals.post_delete.send(sender=Addon, instance=self)
 
             send_mail(subject, email_msg, recipient_list=to)

--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -595,6 +595,14 @@ class BETA_SIGNED_VALIDATION_FAILED(_LOG):
     keep = True
 
 
+class DELETE_ADDON(_LOG):
+    id = 133
+    action_class = 'delete'
+    # L10n: {0} is the add-on GUID.
+    format = _(u'Addon id {0} with GUID {1} has been deleted')
+    keep = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.

--- a/migrations/818-deleted-addons-nullify-guid.py
+++ b/migrations/818-deleted-addons-nullify-guid.py
@@ -1,0 +1,22 @@
+"""Deleting add-ons is in fact soft deleting them, and emptying some of its
+fields with a unique constraint (like the slug).
+We now also empty the GUID field, to allow re-submitting those add-ons (once
+the GUID has been removed from the BlacklistedGuid through the admin.
+
+This migration empties all the previously soft deleted add-ons."""
+
+from django.conf import settings
+
+import amo
+from addons.models import Addon
+from users.models import UserProfile
+
+
+addons = Addon.unfiltered.filter(status=amo.STATUS_DELETED)
+user = UserProfile.objects.get(pk=settings.TASK_USER_ID)
+amo.set_user(user)
+for addon in addons:
+    amo.log(amo.LOG.DELETE_ADDON, addon.pk, addon.guid, addon,
+            created=addon.modified)
+    addon.guid = None
+    addon.save()


### PR DESCRIPTION
Fixes [bug 1185789](https://bugzilla.mozilla.org/show_bug.cgi?id=1176697)