### PR TITLE
Make sure we only install packages from pyrepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ update_code:
 	$(DOCKER_PREFIX) git checkout master && git pull
 
 update_deps:
-	$(DOCKER_PREFIX) pip install --no-deps --exists-action=w --download-cache=/tmp/pip-cache -r requirements/dev.txt --find-links https://pyrepo.addons.mozilla.org/wheelhouse/
+	$(DOCKER_PREFIX) pip install --no-deps --exists-action=w -r requirements/dev.txt --find-links https://pyrepo.addons.mozilla.org/wheelhouse/ --find-links https://pyrepo.addons.mozilla.org/ --no-index
 	$(DOCKER_PREFIX) npm install
 
 update_db:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = es, addons-devhub-editors, main, flake8, docs, assets
 
 [testenv]
 basepython = python2.7
-install_command = pip install --no-deps --exists-action=w --download-cache=/tmp/pip-cache --find-links https://pyrepo.addons.mozilla.org/wheelhouse/ {opts} {packages}
+install_command = pip install --no-deps --exists-action=w --find-links https://pyrepo.addons.mozilla.org/wheelhouse/ --find-links https://pyrepo.addons.mozilla.org/ --no-index {opts} {packages}
 setenv =
     PYTHONPATH=apps
 whitelist_externals =


### PR DESCRIPTION
For some context: all our builds (locally and on travis) suddenly started failing. It was caused by https://pypi.python.org/pypi/python-memcached/1.53 which suddenly had a wheel with content from a 1.55 version (which is broken in some ways).

This PR will force the download of packages only from our own pyrepo server, making sure we won't have this issue in the future anymore. We would have spotted the issue much earlier if we were [using peep](https://github.com/mozilla/olympia/pull/446)