### PR TITLE
Fix two issues in the automated signing validation code:

### DIFF
--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -623,6 +623,7 @@ def upload(request, addon=None, is_standalone=False, is_listed=True,
     if addon:
         # TODO: Handle betas.
         automated = addon.automated_signing
+        is_listed = addon.is_listed
 
     fu = FileUpload.from_post(filedata, filedata.name, filedata.size)
     fu.update(automated_signing=automated)

--- a/static/js/zamboni/validator.js
+++ b/static/js/zamboni/validator.js
@@ -225,7 +225,8 @@ function initValidator($doc) {
 
     MsgVisitor.prototype.filterMessage = function(msg) {
         return !(this.hideIgnored && msg.ignored ||
-                 this.hideNonSigning && !msg.signing_severity)
+                 this.hideNonSigning && !(msg.signing_severity ||
+                                          msg.type == "error"))
     };
 
     MsgVisitor.prototype.message = function(msg, options) {


### PR DESCRIPTION
 - Correctly set the is_listed flag for uploads to existing add-ons.
 - Show hard errors in the validation viewer even if they have no signing_severity flag.'