### PR TITLE
location.hash isn't unescaped automatically anymore in FF >= 41 (bug 1184131)

### DIFF
--- a/static/js/zamboni/discovery_pane.js
+++ b/static/js/zamboni/discovery_pane.js
@@ -74,7 +74,7 @@ function getGuids() {
     // Store GUIDs of installed extensions.
     var guids = [];
     if (location.hash) {
-        $.each(JSON.parse(location.hash.slice(1)), function(i, val) {
+        $.each(JSON.parse(unescape(location.hash).slice(1)), function(i, val) {
             if (val.type == "extension") {
                 guids.push(i);
             }


### PR DESCRIPTION
Fixes [bug 1184131](https://bugzilla.mozilla.org/show_bug.cgi?id=1184131)

After [bug 1093611](https://bugzilla.mozilla.org/show_bug.cgi?id=1093611),
`location.hash` isn't automatically unescaped anymore. So if you're doing a
`JSON.parse` on it, it'll fail.

I haven't found any other occurences of `location.hash` where we would do a
`JSON.parse`.