### PR TITLE
Don't sign multi-packages at all (bug 1172696)

### DIFF
--- a/lib/crypto/tasks.py
+++ b/lib/crypto/tasks.py
@@ -95,21 +95,13 @@ def sign_addons(addon_ids, force=False, **kw):
             file_supports_firefox(settings.MIN_NOT_D2C_VERSION)))
 
     addons_emailed = []
-    # We only care about extensions and (complete) themes. The latter is
-    # because they may have multi-package XPIs, containing extensions.
+    # We only care about extensions.
     for version in Version.objects.filter(addon_id__in=addon_ids,
-                                          addon__type__in=[
-                                              amo.ADDON_EXTENSION,
-                                              amo.ADDON_THEME]):
-
+                                          addon__type=amo.ADDON_EXTENSION):
         # We only sign files that have been reviewed and are compatible with
         # versions of Firefox that are recent enough.
         to_sign = version.files.filter(ff_version_filter,
                                        status__in=amo.REVIEWED_STATUSES)
-        # We only care about multi-package XPIs for themes, because they may
-        # have extensions inside.
-        if version.addon.type == amo.ADDON_THEME:
-            to_sign = version.files.filter(is_multi_package=True)
 
         if force:
             to_sign = to_sign.all()
@@ -261,19 +253,16 @@ def unsign_addons(addon_ids, force=False, **kw):
             file_supports_firefox(settings.MIN_NOT_D2C_VERSION)))
 
     addons_emailed = []
+    # We only care about extensions.
     for version in Version.objects.filter(addon_id__in=addon_ids,
-                                          addon__type__in=[
-                                              amo.ADDON_EXTENSION,
-                                              amo.ADDON_THEME]):
+                                          addon__type=amo.ADDON_EXTENSION):
+        # We only unsign files that have been reviewed and are compatible with
+        # versions of Firefox that are recent enough.
         if not version.version.endswith(bumped_suffix):
             log.info(u'Version {0} was not bumped, skip.'.format(version.pk))
             continue
         to_unsign = version.files.filter(ff_version_filter,
                                          status__in=amo.REVIEWED_STATUSES)
-        # We only care about multi-package XPIs for themes, because they may
-        # have extensions inside.
-        if version.addon.type == amo.ADDON_THEME:
-            to_unsign = version.files.filter(is_multi_package=True)
 
         if force:
             to_unsign = to_unsign.all()

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -184,34 +184,22 @@ class TestPackaged(amo.tests.TestCase):
 
     def test_sign_file_multi_package(self):
         with amo.tests.copy_file('apps/files/fixtures/files/multi-package.xpi',
-                                 self.file_.file_path,
-                                 overwrite=True):
+                                 self.file_.file_path, overwrite=True):
             self.file_.update(is_multi_package=True)
             self.assert_not_signed()
-            # Make sure the internal XPIs aren't signed either.
-            folder = tempfile.mkdtemp()
-            try:
-                extract_xpi(self.file_.file_path, folder)
-                assert not packaged.is_signed(
-                    os.path.join(folder, 'random_extension.xpi'))
-                assert not packaged.is_signed(
-                    os.path.join(folder, 'random_theme.xpi'))
-            finally:
-                amo.utils.rm_local_tmp_dir(folder)
 
             packaged.sign_file(self.file_, settings.SIGNING_SERVER)
-            assert self.file_.is_signed
-            assert self.file_.cert_serial_num
-            assert self.file_.hash
-            # It's not the multi-package itself that is signed.
+            self.assert_not_signed()
+            # The multi-package itself isn't signed.
             assert not packaged.is_signed(self.file_.file_path)
-            # It's the internal xpi.
+            # The internal extensions aren't either.
             folder = tempfile.mkdtemp()
             try:
                 extract_xpi(self.file_.file_path, folder)
-                assert packaged.is_signed(
+                # The extension isn't.
+                assert not packaged.is_signed(
                     os.path.join(folder, 'random_extension.xpi'))
-                # And only the one that is an extension.
+                # And the theme isn't either.
                 assert not packaged.is_signed(
                     os.path.join(folder, 'random_theme.xpi'))
             finally:


### PR DESCRIPTION
Fixes [bug 1172696](https://bugzilla.mozilla.org/show_bug.cgi?id=1172696)

This implements the [proposal a](https://bugzilla.mozilla.org/show_bug.cgi?id=1172696#c3), and reverts (partially) the PR #541