### PR TITLE
Don't enforce name uniqueness for unlisted add-ons (bug 1173607)

### DIFF
--- a/apps/addons/forms.py
+++ b/apps/addons/forms.py
@@ -41,6 +41,10 @@ def clean_name(name, instance=None):
     if not instance:
         log.debug('clean_name called without an instance: %s' % name)
 
+    # We don't enforce uniqueness for unlsited addons.
+    if instance and not instance.is_listed:
+        return name
+
     id = reverse_name_lookup(name)
 
     # If we get an id and either there's no instance or the instance.id != id.

--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -2167,6 +2167,11 @@ class TestAddonFromUpload(UploadTest):
                                   [self.platform], is_listed=False)
         assert not addon.is_listed
 
+    def test_is_not_listed_not_unique_name_bug_1173607(self):
+        """An unlisted add-on should be able to choose any name."""
+        Addon.from_upload(self.get_upload('extension.xpi'),
+                          [self.platform], is_listed=False)
+
 
 REDIRECT_URL = 'http://outgoing.mozilla.org/v1/'
 

--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -527,7 +527,9 @@ class NewAddonForm(AddonUploadForm):
         if not self.errors:
             self._clean_upload()
             xpi = parse_addon(self.cleaned_data['upload'])
-            addons.forms.clean_name(xpi['name'])
+            # We don't enforce name uniqueness for unlisted add-ons.
+            if not self.cleaned_data.get('is_unlisted', False):
+                addons.forms.clean_name(xpi['name'])
         return self.cleaned_data
 
 


### PR DESCRIPTION
Fixes [bug 1173607](https://bugzilla.mozilla.org/show_bug.cgi?id=1173607)