### PR TITLE
Addon name is only unique for a given type (bug 1173609)

### DIFF
--- a/apps/addons/tests/test_addon_utils.py
+++ b/apps/addons/tests/test_addon_utils.py
@@ -13,19 +13,26 @@ class TestReverseNameLookup(amo.tests.TestCase):
         self.addon = Addon.objects.get()
 
     def test_delete_addon(self):
-        eq_(reverse_name_lookup('Delicious Bookmarks'), 3615)
+        eq_(reverse_name_lookup('Delicious Bookmarks',
+                                addon_type=amo.ADDON_EXTENSION), 3615)
         self.addon.delete('farewell my sweet amo, it was a good run')
-        eq_(reverse_name_lookup('Delicious Bookmarks'), None)
+        eq_(reverse_name_lookup('Delicious Bookmarks',
+                                addon_type=amo.ADDON_EXTENSION), None)
 
     def test_update_addon(self):
-        eq_(reverse_name_lookup('Delicious Bookmarks'), 3615)
+        eq_(reverse_name_lookup('Delicious Bookmarks',
+                                addon_type=amo.ADDON_EXTENSION), 3615)
         self.addon.name = 'boo'
         self.addon.save()
-        eq_(reverse_name_lookup('Delicious Bookmarks'), None)
-        eq_(reverse_name_lookup('boo'), 3615)
+        eq_(reverse_name_lookup('Delicious Bookmarks',
+                                addon_type=amo.ADDON_EXTENSION), None)
+        eq_(reverse_name_lookup('boo',
+                                addon_type=amo.ADDON_EXTENSION), 3615)
 
     def test_get_strip(self):
-        eq_(reverse_name_lookup('Delicious Bookmarks   '), 3615)
+        eq_(reverse_name_lookup('Delicious Bookmarks   ',
+                                addon_type=amo.ADDON_EXTENSION), 3615)
 
     def test_get_case(self):
-        eq_(reverse_name_lookup('delicious bookmarks'), 3615)
+        eq_(reverse_name_lookup('delicious bookmarks',
+                                addon_type=amo.ADDON_EXTENSION), 3615)

--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -2147,11 +2147,6 @@ class TestAddonFromUpload(UploadTest):
                                   [self.platform], is_listed=False)
         assert not addon.is_listed
 
-    def test_is_not_listed_not_unique_name_bug_1173607(self):
-        """An unlisted add-on should be able to choose any name."""
-        Addon.from_upload(self.get_upload('extension.xpi'),
-                          [self.platform], is_listed=False)
-
 
 REDIRECT_URL = 'http://outgoing.mozilla.org/v1/'
 

--- a/apps/addons/utils.py
+++ b/apps/addons/utils.py
@@ -11,9 +11,13 @@ log = commonware.log.getLogger('z.redis')
 rnlog = logging.getLogger('z.rn')
 
 
-def reverse_name_lookup(key):
+def reverse_name_lookup(key, addon_type):
     from addons.models import Addon
-    qs = Addon.objects.filter(name__localized_string=key).no_cache()
+    # This uses the Addon.objects manager, which filters out unlisted addons,
+    # on purpose. We don't want to enforce name uniqueness between listed and
+    # unlisted addons.
+    qs = Addon.objects.filter(name__localized_string=key,
+                              type=addon_type).no_cache()
     values = list(qs.distinct().values_list('id', flat=True))
     if values:
         if len(values) > 1:

--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -549,7 +549,7 @@ class NewAddonForm(AddonUploadForm):
             xpi = parse_addon(self.cleaned_data['upload'])
             # We don't enforce name uniqueness for unlisted add-ons.
             if not self.cleaned_data.get('is_unlisted', False):
-                addons.forms.clean_name(xpi['name'])
+                addons.forms.clean_name(xpi['name'], addon_type=xpi['type'])
         return self.cleaned_data
 
 


### PR DESCRIPTION
Fixes [bug 1173609](https://bugzilla.mozilla.org/show_bug.cgi?id=1173609)

The PR also completes/fixes PR #636