### PR TITLE
Add the google analytics scripts to the discovery pages (bug 1191391)

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -761,6 +761,7 @@ MINIFY_BUNDLES = {
             'js/impala/capabilities.js',
             'js/lib/format.js',
             'js/impala/carousel.js',
+            'js/zamboni/analytics.js',
 
             # Add-ons details
             'js/lib/jquery.cookie.js',


### PR DESCRIPTION
Fixes [bug 1191391](https://bugzilla.mozilla.org/show_bug.cgi?id=1191391)

This is also linked to [bug 1128713](https://bugzilla.mozilla.org/show_bug.cgi?id=1128713)