### PR TITLE
Bug 1187097 Download Anyway Addon Link

### DIFF
--- a/apps/addons/templates/addons/impala/button.html
+++ b/apps/addons/templates/addons/impala/button.html
@@ -76,6 +76,6 @@
   {% endwith %}
 {% endif %}
 <p>
-    <a id="downloadAnyway">Download Anyway</a>
+    <a id="downloadAnyway" hidden="true">Download Anyway</a>
 </p>
 </div> {# install-shell #}

--- a/apps/addons/templates/addons/impala/button.html
+++ b/apps/addons/templates/addons/impala/button.html
@@ -75,5 +75,7 @@
     </div>
   {% endwith %}
 {% endif %}
-
+<p>
+    <a id="downloadAnyway">Download Anyway</a>
+</p>
 </div> {# install-shell #}

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -403,10 +403,12 @@ var installButton = function() {
         var opts = search ? {addPopup: false, addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
+        $('#downloadAnyway').attr('href',escape_($button.filter(':visible').attr('href')));
+        $('#downloadAnyway').show();
         $button.addClass('concealed');
         versionsAndPlatforms({addPopup: false});
         $button.addClass('CTA');
-        $button.text('Only with Firefox -- Get Firefox Now!');
+        $button.text('Only with Firefox \u2014 Get Firefox Now!');
         $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2&utm_source=addons.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button#download-fx');
         $('#site-nonfx').hide();
     } else if (z.app == 'thunderbird') {


### PR DESCRIPTION
![screen shot 2015-08-06 at 2 03 14 pm](https://cloud.githubusercontent.com/assets/9794516/9123374/ea93dfb8-3c43-11e5-8128-b5a43ba1a8ef.png)

Added a "download anyway" link below the download firefox button for non-firefox users, and changed the "--" in the button to a single em dash. I can merge these into one commit if needed.

@magopian r?