### PR TITLE
Bug 1192645: Fix error in the compatibility validation viewer.

### DIFF
--- a/static/js/zamboni/validator.js
+++ b/static/js/zamboni/validator.js
@@ -384,9 +384,17 @@ function initValidator($doc) {
 
     CompatMsgVisitor.prototype.message = function(msg) {
         if (msg.for_appversions) {
-            if (this.hasMatchingAppVer(msg.for_appversions)) {
-                var app = {guid: guid, version: version, id: id};
-                msg.tier = id;  // change the tier to match app/version
+            var guid = this.findMatchingApp(msg.for_appversions)
+            if (guid) {
+                var app = {guid: guid, version: this.majorTargetVer[guid]};
+                // This is basically just black magic to create a separate
+                // "tier" in the output for each app/version we have
+                // compatibility messages for. As far as I can tell, the actual
+                // contents of the ID are pretty arbitrary, and the
+                // sluggification regexp isn't really necessary.
+                app.id = (app.guid + '-' + app.version).replace(/[^a-z0-9_-]+/gi, '');
+
+                msg.tier = app.id;  // change the tier to match app/version
                 MsgVisitor.prototype.message.apply(this, [msg, {app: app}]);
             }
         } else if (this.getMsgType(msg) === 'error') {
@@ -395,14 +403,14 @@ function initValidator($doc) {
         }
     };
 
-    CompatMsgVisitor.hasMatchingAppVer = function(appVersions) {
+    CompatMsgVisitor.prototype.findMatchingApp = function(appVersions) {
         // Returns true if any of the given app version ranges match the
-        // versions we're chacking.
+        // versions we're checking.
         //
         // {'{ec8030f7-c20a-464f-9b0e-13a3a9e97384}': ['4.0b1']}
-        return _.some(appVersions, function(matchingVersions, guid) {
+        return _.find(_.keys(appVersions), function(guid) {
             var targetMajorVersion = this.majorTargetVer[guid];
-            return _.some(matchingVersions, function(version) {
+            return _.some(appVersions[guid], function(version) {
                 return version.split('.')[0] == targetMajorVersion;
             });
         }, this);


### PR DESCRIPTION
I haven't been able to test this locally. I've never been able to get the compat validator to run anywhere but on production, and the viewer explodes if you try to get it to run with fake compatibility results.

I tested the individual pieces of this code when I made this change, so aside from the missing `.prototype`, it should work. But I really wish I had a way to test it properly.