### PR TITLE
Fix drop-backup-version migration.

### DIFF
--- a/migrations/823-drop-backup-version.sql
+++ b/migrations/823-drop-backup-version.sql
@@ -1,5 +1,11 @@
 ALTER TABLE
     `addons`
+DROP FOREIGN KEY
+    `addons_ibfk_16`
+;
+
+ALTER TABLE
+    `addons`
 DROP COLUMN
     `backup_version`
 ;


### PR DESCRIPTION
Not sure why this worked different for me than on dev. Updated to drop foreign key before the column.