### PR TITLE
Bug 1193137: Remove `commit_manually` decorator from app version update task.

### DIFF
--- a/apps/addons/cron.py
+++ b/apps/addons/cron.py
@@ -252,6 +252,7 @@ def update_addon_appsupport():
     ids = (Addon.objects.valid().distinct()
            .filter(newish, good).values_list('id', flat=True))
 
+    task_log.info('Updating appsupport for %d new-ish addons.' % len(ids))
     ts = [_update_appsupport.subtask(args=[chunk])
           for chunk in chunked(ids, 20)]
     TaskSet(ts).apply_async()
@@ -270,9 +271,9 @@ def update_all_appsupport():
 
 
 @task
-@transaction.commit_manually
 def _update_appsupport(ids, **kw):
     from .tasks import update_appsupport
+    task_log.info('Updating appsupport for %d of new-ish addons.' % len(ids))
     update_appsupport(ids)
 
 

--- a/apps/addons/tasks.py
+++ b/apps/addons/tasks.py
@@ -61,6 +61,7 @@ def update_last_updated(addon_id):
         Addon.objects.filter(pk=pk).update(last_updated=t)
 
 
+@write
 def update_appsupport(ids):
     log.info("[%s@None] Updating appsupport for %s." % (len(ids), ids))
 


### PR DESCRIPTION
As far as I can tell, what's happening on production is that, because we have a `transaction.atomic` block inside of a `transaction.commit_manually` block in the `update_addon_appsupport` cron job, we always end that block with a pending commit.

When that happens, in our version of django, anyway, the connection also seems to sometimes keep the `in_atomic_block` flag, which leaves that worker broken for any task that runs next.

I've confirmed that this change fixes at least the first part of the problem. That cron job no longer ends with a transaction error. I haven't been able to reproduce the `TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.` error in a local web instance yet, but I think this should fix that as well.