### PR TITLE
Provide a latest-beta extension download link (bug 539318)

### DIFF
--- a/apps/addons/buttons.py
+++ b/apps/addons/buttons.py
@@ -16,8 +16,16 @@ from translations.models import Translation
 @jinja2.contextfunction
 def install_button(context, addon, version=None, show_contrib=True,
                    show_warning=True, src='', collection=None, size='',
-                   detailed=False, mobile=False, impala=False, is_beta=False):
-    """If version isn't given, we use the latest version."""
+                   detailed=False, mobile=False, impala=False,
+                   latest_beta=False):
+    """
+    If version isn't given, we use the latest version. You can set latest_beta
+    parameter to use latest beta version instead.
+    """
+    assert not version or not latest_beta, ('version and latest_beta '
+                                            'parameters cannot be specified '
+                                            'at the same time')
+
     request = context['request']
     app, lang = context['APP'], context['LANG']
     src = src or context.get('src') or request.GET.get('src', '')
@@ -29,7 +37,8 @@ def install_button(context, addon, version=None, show_contrib=True,
                   or request.GET.get('collection_uuid'))
     button = install_button_factory(addon, app, lang, version, show_contrib,
                                     show_warning, src, collection, size,
-                                    detailed, impala, is_beta)
+                                    detailed, impala,
+                                    latest_beta)
     installed = (request.user.is_authenticated() and
                  addon.id in request.amo_user.mobile_addons)
     c = {'button': button, 'addon': addon, 'version': button.version,
@@ -87,12 +96,13 @@ class InstallButton(object):
 
     def __init__(self, addon, app, lang, version=None, show_contrib=True,
                  show_warning=True, src='', collection=None, size='',
-                 detailed=False, impala=False, is_beta=False):
+                 detailed=False, impala=False,
+                 latest_beta=False):
         self.addon, self.app, self.lang = addon, app, lang
         self.latest = version is None
         self.version = version
         if not self.version:
-            self.version = (addon.current_beta_version if is_beta
+            self.version = (addon.current_beta_version if latest_beta
                             else addon.current_version)
         self.src = src
         self.collection = collection

--- a/apps/addons/buttons.py
+++ b/apps/addons/buttons.py
@@ -90,9 +90,8 @@ class InstallButton(object):
                  detailed=False, impala=False, is_beta=False):
         self.addon, self.app, self.lang = addon, app, lang
         self.latest = version is None
-        if version:
-            self.version = version
-        else:
+        self.version = version
+        if not self.version:
             self.version = (addon.current_beta_version if is_beta
                             else addon.current_version)
         self.src = src

--- a/apps/addons/buttons.py
+++ b/apps/addons/buttons.py
@@ -90,7 +90,11 @@ class InstallButton(object):
                  detailed=False, impala=False):
         self.addon, self.app, self.lang = addon, app, lang
         self.latest = version is None
-        self.version = version or addon.current_version
+        self.latest_beta = version == 'beta'
+        if version == 'beta':
+            self.version = addon.current_beta_version
+        else:
+            self.version = version or addon.current_version
         self.src = src
         self.collection = collection
         self.size = size
@@ -157,6 +161,8 @@ class InstallButton(object):
         if self.latest and (
                 self.addon.status == file.status == amo.STATUS_PUBLIC):
             url = file.latest_xpi_url()
+        elif self.latest_beta and self.addon.show_beta:
+            url = file.latest_xpi_url(beta=True)
         else:
             url = file.get_url_path(self.src)
 

--- a/apps/addons/templates/addons/details_box.html
+++ b/apps/addons/templates/addons/details_box.html
@@ -223,7 +223,7 @@
             <dl>
               <dt class="beta-version">{{ _('Version {0}:')|f(
                 addon.current_beta_version.version) }}</dt>
-              <dd>{{ install_button(addon, version='beta',
+              <dd>{{ install_button(addon, is_beta=True,
                                     show_warning=False) }}</dd>
             </dl>
           </div>{# /install-beta #}

--- a/apps/addons/templates/addons/details_box.html
+++ b/apps/addons/templates/addons/details_box.html
@@ -223,7 +223,7 @@
             <dl>
               <dt class="beta-version">{{ _('Version {0}:')|f(
                 addon.current_beta_version.version) }}</dt>
-              <dd>{{ install_button(addon, is_beta=True,
+              <dd>{{ install_button(addon, latest_beta=True,
                                     show_warning=False) }}</dd>
             </dl>
           </div>{# /install-beta #}

--- a/apps/addons/templates/addons/details_box.html
+++ b/apps/addons/templates/addons/details_box.html
@@ -223,7 +223,7 @@
             <dl>
               <dt class="beta-version">{{ _('Version {0}:')|f(
                 addon.current_beta_version.version) }}</dt>
-              <dd>{{ install_button(addon, version=addon.current_beta_version,
+              <dd>{{ install_button(addon, version='beta',
                                     show_warning=False) }}</dd>
             </dl>
           </div>{# /install-beta #}

--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -286,7 +286,7 @@
           <dl>
             <dt class="beta-version">{{ _('Version {0}:')|f(
               addon.current_beta_version.version) }}</dt>
-            <dd>{{ install_button(addon, is_beta=True,
+            <dd>{{ install_button(addon, latest_beta=True,
                                   show_warning=False, impala=True,
                                   src=request.GET.get('src', 'dp-btn-devchannel')) }}</dd>
           </dl>

--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -286,7 +286,7 @@
           <dl>
             <dt class="beta-version">{{ _('Version {0}:')|f(
               addon.current_beta_version.version) }}</dt>
-            <dd>{{ install_button(addon, version='beta',
+            <dd>{{ install_button(addon, is_beta=True,
                                   show_warning=False, impala=True,
                                   src=request.GET.get('src', 'dp-btn-devchannel')) }}</dd>
           </dl>

--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -286,7 +286,7 @@
           <dl>
             <dt class="beta-version">{{ _('Version {0}:')|f(
               addon.current_beta_version.version) }}</dt>
-            <dd>{{ install_button(addon, version=addon.current_beta_version,
+            <dd>{{ install_button(addon, version='beta',
                                   show_warning=False, impala=True,
                                   src=request.GET.get('src', 'dp-btn-devchannel')) }}</dd>
           </dl>

--- a/apps/addons/tests/test_buttons.py
+++ b/apps/addons/tests/test_buttons.py
@@ -7,6 +7,7 @@ import jingo
 from mock import patch, Mock
 from nose.tools import eq_
 from pyquery import PyQuery
+import pytest
 
 import amo
 import amo.models
@@ -150,7 +151,7 @@ class TestButtonSetup(ButtonTest):
         assert b.version == self.version
         assert not b.is_beta
 
-        b = self.get_button(is_beta=True)
+        b = self.get_button(latest_beta=True)
         assert b.version == self.beta_version
         assert b.is_beta
 
@@ -161,6 +162,9 @@ class TestButtonSetup(ButtonTest):
         b = self.get_button(version=self.beta_version)
         assert b.version == self.beta_version
         assert b.is_beta
+
+        with pytest.raises(AssertionError):
+            self.get_button(version=self.version, latest_beta=True)
 
 
 class TestButton(ButtonTest):

--- a/apps/addons/tests/test_buttons.py
+++ b/apps/addons/tests/test_buttons.py
@@ -45,6 +45,18 @@ class ButtonTest(amo.tests.TestCase):
         self.file = self.get_file(amo.PLATFORM_ALL.id)
         v.all_files = [self.file]
 
+        self.beta_version = v = Mock()
+        v.is_compatible = False
+        v.compat_override_app_versions.return_value = []
+        v.is_unreviewed = False
+        v.is_beta = True
+        v.is_lite = False
+        v.version = 'v2-beta'
+        self.addon.current_beta_version = v
+
+        self.beta_file = self.get_file(amo.PLATFORM_ALL.id)
+        v.all_files = [self.beta_file]
+
         self.platforms = amo.PLATFORM_MAC.id, amo.PLATFORM_LINUX.id
         self.platform_files = map(self.get_file, self.platforms)
 
@@ -133,6 +145,23 @@ class TestButtonSetup(ButtonTest):
         b = self.get_button(collection=c)
         eq_(b.collection, 'ff')
 
+    def test_version(self):
+        b = self.get_button()
+        assert b.version == self.version
+        assert not b.is_beta
+
+        b = self.get_button(is_beta=True)
+        assert b.version == self.beta_version
+        assert b.is_beta
+
+        b = self.get_button(version=self.version)
+        assert b.version == self.version
+        assert not b.is_beta
+
+        b = self.get_button(version=self.beta_version)
+        assert b.version == self.beta_version
+        assert b.is_beta
+
 
 class TestButton(ButtonTest):
     """Tests for the InstallButton class."""
@@ -195,8 +224,7 @@ class TestButton(ButtonTest):
     def test_beta(self):
         # Throw featured in there to make sure it's ignored.
         self.addon.is_featured.return_value = True
-        self.version.is_beta = True
-        b = self.get_button()
+        b = self.get_button(version=self.beta_version)
         assert not b.featured
         assert b.is_beta
         eq_(b.button_class, ['download', 'caution'])

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -279,9 +279,9 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
         return u'%s...%s' % (m.group('slug')[0:(maxlen - 3)],
                              m.group('suffix'))
 
-    def latest_xpi_url(self):
+    def latest_xpi_url(self, beta=False):
         addon = self.version.addon
-        kw = {'addon_id': addon.pk}
+        kw = {'addon_id': addon.pk, 'beta': '-beta' if beta else ''}
         if self.platform != amo.PLATFORM_ALL.id:
             kw['platform'] = self.platform
         return os.path.join(reverse('downloads.latest', kwargs=kw),

--- a/apps/files/tests/test_models.py
+++ b/apps/files/tests/test_models.py
@@ -187,14 +187,24 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
     def test_latest_url(self):
         # With platform.
         f = File.objects.get(id=74797)
-        base = '/firefox/downloads/latest/'
+        base = '/firefox/downloads/latest{1}/'
         expected = base + '{0}/platform:3/addon-{0}-latest.xpi'
-        eq_(expected.format(f.version.addon_id), f.latest_xpi_url())
+
+        actual = f.latest_xpi_url()
+        assert expected.format(f.version.addon_id, '') == actual
+
+        actual = f.latest_xpi_url(beta=True)
+        assert expected.format(f.version.addon_id, '-beta') == actual
 
         # No platform.
         f = File.objects.get(id=67442)
         expected = base + '{0}/addon-{0}-latest.xpi'
-        eq_(expected.format(f.version.addon_id), f.latest_xpi_url())
+
+        actual = f.latest_xpi_url()
+        assert expected.format(f.version.addon_id, '') == actual
+
+        actual = f.latest_xpi_url(beta=True)
+        assert expected.format(f.version.addon_id, '-beta') == actual
 
     def test_eula_url(self):
         f = File.objects.get(id=67442)

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -615,6 +615,9 @@ class TestDownloadsBase(amo.tests.TestCase):
         self.beta_file = File.objects.get(id=64874)
         self.file_url = reverse('downloads.file', args=[self.file.id])
         self.latest_url = reverse('downloads.latest', args=[self.addon.slug])
+        self.latest_beta_url = reverse('downloads.latest',
+                                        kwargs={'addon_id': self.addon.slug,
+                                                'beta': '-beta'})
 
     def assert_served_by_host(self, response, host, file_=None):
         if not file_:
@@ -651,6 +654,7 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
         self.addon.update(is_listed=False)
         assert self.client.get(self.file_url).status_code == 404
         assert self.client.get(self.latest_url).status_code == 404
+        assert self.client.get(self.latest_beta_url).status_code == 404
 
     @mock.patch.object(acl, 'check_addons_reviewer', lambda x: False)
     @mock.patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
@@ -661,6 +665,7 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
         self.addon.update(is_listed=False)
         assert self.client.get(self.file_url).status_code == 302
         assert self.client.get(self.latest_url).status_code == 302
+        assert self.client.get(self.latest_beta_url).status_code == 302
 
     @mock.patch.object(acl, 'check_addons_reviewer', lambda x: True)
     @mock.patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
@@ -671,6 +676,7 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
         self.addon.update(is_listed=False)
         assert self.client.get(self.file_url).status_code == 404
         assert self.client.get(self.latest_url).status_code == 404
+        assert self.client.get(self.latest_beta_url).status_code == 404
 
     @mock.patch.object(acl, 'check_addons_reviewer', lambda x: False)
     @mock.patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: True)
@@ -681,6 +687,7 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
         self.addon.update(is_listed=False)
         assert self.client.get(self.file_url).status_code == 302
         assert self.client.get(self.latest_url).status_code == 302
+        assert self.client.get(self.latest_beta_url).status_code == 302
 
 
 class TestDownloads(TestDownloadsBase):
@@ -832,6 +839,22 @@ class TestDownloadsLatest(TestDownloadsBase):
     def test_success(self):
         assert self.addon.current_version
         self.assert_served_by_mirror(self.client.get(self.latest_url))
+
+    def test_beta(self):
+        r = self.client.get(self.latest_beta_url)
+        eq_(r.status_code, 302)
+        beta_file_url = reverse('downloads.file', args=[self.beta_file.id])
+        url = beta_file_url + '/' + self.beta_file.filename
+        assert r['Location'].endswith(url), r['Location']
+
+        # No beta downloads for unreviewed addons 
+        self.addon.status = amo.STATUS_PENDING
+        self.addon.save()
+        r = self.client.get(self.latest_beta_url)
+        eq_(r.status_code, 302)
+        beta_file_url = reverse('downloads.file', args=[self.beta_file.id])
+        url = self.file_url + '/' + self.file.filename
+        assert r['Location'].endswith(url), r['Location']
 
     def test_platform(self):
         # We still match PLATFORM_ALL.

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -841,20 +841,20 @@ class TestDownloadsLatest(TestDownloadsBase):
         self.assert_served_by_mirror(self.client.get(self.latest_url))
 
     def test_beta(self):
-        r = self.client.get(self.latest_beta_url)
-        eq_(r.status_code, 302)
+        response = self.client.get(self.latest_beta_url)
+        assert response.status_code == 302
         beta_file_url = reverse('downloads.file', args=[self.beta_file.id])
         url = beta_file_url + '/' + self.beta_file.filename
-        assert r['Location'].endswith(url), r['Location']
+        assert response['Location'].endswith(url)
 
-        # No beta downloads for unreviewed addons
+    def test_beta_unreviewed_addon(self):
         self.addon.status = amo.STATUS_PENDING
         self.addon.save()
-        r = self.client.get(self.latest_beta_url)
-        eq_(r.status_code, 302)
-        beta_file_url = reverse('downloads.file', args=[self.beta_file.id])
-        url = self.file_url + '/' + self.file.filename
-        assert r['Location'].endswith(url), r['Location']
+        assert self.client.get(self.latest_beta_url).status_code == 404
+
+    def test_beta_no_files(self):
+        self.beta_file.update(status=amo.STATUS_PUBLIC)
+        assert self.client.get(self.latest_beta_url).status_code == 404
 
     def test_platform(self):
         # We still match PLATFORM_ALL.

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -616,8 +616,8 @@ class TestDownloadsBase(amo.tests.TestCase):
         self.file_url = reverse('downloads.file', args=[self.file.id])
         self.latest_url = reverse('downloads.latest', args=[self.addon.slug])
         self.latest_beta_url = reverse('downloads.latest',
-                                        kwargs={'addon_id': self.addon.slug,
-                                                'beta': '-beta'})
+                                       kwargs={'addon_id': self.addon.slug,
+                                               'beta': '-beta'})
 
     def assert_served_by_host(self, response, host, file_=None):
         if not file_:
@@ -847,7 +847,7 @@ class TestDownloadsLatest(TestDownloadsBase):
         url = beta_file_url + '/' + self.beta_file.filename
         assert r['Location'].endswith(url), r['Location']
 
-        # No beta downloads for unreviewed addons 
+        # No beta downloads for unreviewed addons
         self.addon.status = amo.STATUS_PENDING
         self.addon.save()
         r = self.client.get(self.latest_beta_url)

--- a/apps/versions/urls.py
+++ b/apps/versions/urls.py
@@ -25,7 +25,8 @@ download_patterns = patterns(
         views.download_source, name='downloads.source'),
 
     # /latest/1865/type:xpi/platform:5
-    url('^latest/%s/(?:type:(?P<type>\w+)/)?'
+    # /latest-beta/1865/type:xpi/platform:5
+    url('^latest(?P<beta>-beta)?/%s/(?:type:(?P<type>\w+)/)?'
         '(?:platform:(?P<platform>\d+)/)?.*' % ADDON_ID,
         views.download_latest, name='downloads.latest'),
 )

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -115,9 +115,9 @@ def download_latest(request, addon, beta=False, type='xpi', platform=None):
     if platform is not None and int(platform) in amo.PLATFORMS:
         platforms.append(int(platform))
     if beta and addon.show_beta:
-      version = addon.current_beta_version.id
+        version = addon.current_beta_version.id
     else:
-      version = addon._current_version_id
+        version = addon._current_version_id
     files = File.objects.filter(platform__in=platforms,
                                 version=version)
     try:

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -110,12 +110,16 @@ def guard():
 
 
 @addon_view_factory(guard)
-def download_latest(request, addon, type='xpi', platform=None):
+def download_latest(request, addon, beta=False, type='xpi', platform=None):
     platforms = [amo.PLATFORM_ALL.id]
     if platform is not None and int(platform) in amo.PLATFORMS:
         platforms.append(int(platform))
+    if beta and addon.show_beta:
+      version = addon.current_beta_version.id
+    else:
+      version = addon._current_version_id
     files = File.objects.filter(platform__in=platforms,
-                                version=addon._current_version_id)
+                                version=version)
     try:
         # If there's a file matching our platform, it'll float to the end.
         file = sorted(files, key=lambda f: f.platform == platforms[-1])[-1]

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -114,7 +114,9 @@ def download_latest(request, addon, beta=False, type='xpi', platform=None):
     platforms = [amo.PLATFORM_ALL.id]
     if platform is not None and int(platform) in amo.PLATFORMS:
         platforms.append(int(platform))
-    if beta and addon.show_beta:
+    if beta:
+        if not addon.show_beta:
+            raise http.Http404()
         version = addon.current_beta_version.id
     else:
         version = addon._current_version_id


### PR DESCRIPTION
Sorry about reviving bug 539318 but this feature is actually important to us. We need to link to the latest file in the beta channel directly in order to simplify installation both for our users and third-party testers.