### PR TITLE
Properly deal with unicode filenames for source uploads (bug 1193056)

### DIFF
--- a/apps/amo/helpers.py
+++ b/apps/amo/helpers.py
@@ -669,7 +669,7 @@ def id_to_path(pk):
     12 => 2/12/12
     123456 => 6/56/123456
     """
-    pk = str(pk)
+    pk = unicode(pk)
     path = [pk[-1]]
     if len(pk) >= 2:
         path.append(pk[-2:])

--- a/apps/amo/utils.py
+++ b/apps/amo/utils.py
@@ -628,8 +628,11 @@ class HttpResponseSendFile(http.HttpResponse):
         self.path = path
         super(HttpResponseSendFile, self).__init__('', status=status,
                                                    content_type=content_type)
+        header_path = self.path
+        if isinstance(header_path, unicode):
+            header_path = header_path.encode('utf8')
         if settings.XSENDFILE:
-            self[settings.XSENDFILE_HEADER] = path
+            self[settings.XSENDFILE_HEADER] = header_path
         if etag:
             self['ETag'] = '"%s"' % etag
 

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -60,9 +60,9 @@ def source_upload_path(instance, filename):
             break
 
     return os.path.join(
-        'version_source',
+        u'version_source',
         id_to_path(instance.pk),
-        '{0}-{1}-src{2}'.format(
+        u'{0}-{1}-src{2}'.format(
             instance.addon.slug,
             instance.version,
             ext)

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -142,6 +142,10 @@ def download_source(request, version_id):
         if not owner_or_unlisted_reviewer(request, version.addon):
             raise http.Http404  # Not listed, not owner or admin.
     res = HttpResponseSendFile(request, version.source.path)
-    name = os.path.basename(version.source.path.replace('"', ''))
-    res['Content-Disposition'] = 'attachment; filename="{0}"'.format(name)
+    path = version.source.path
+    if not isinstance(path, unicode):
+        path = path.decode('utf8')
+    name = os.path.basename(path.replace(u'"', u''))
+    disposition = u'attachment; filename="{0}"'.format(name).encode('utf8')
+    res['Content-Disposition'] = disposition
     return res


### PR DESCRIPTION
Fixes [bug 1193056](https://bugzilla.mozilla.org/show_bug.cgi?id=1193056)