### PR TITLE
Bug 1196168 - Allow filtering by status on the versions page

### DIFF
--- a/apps/versions/feeds.py
+++ b/apps/versions/feeds.py
@@ -45,18 +45,13 @@ class VersionsRss(Feed):
     feed_type = PagedFeed
     addon = None
 
-    def get_object(self, request, addon_id, status=None):
+    def get_object(self, request, addon_id, beta=False):
         """Get the Addon for which we are about to output
            the RSS feed of it Versions"""
         qs = Addon.objects
         self.addon = get_object_or_404(qs.id_or_slug(addon_id) & qs.valid())
 
-        status = amo.STATUS_CHOICES_API_LOOKUP.get(status)
-        if status is not None and status in amo.VALID_STATUSES:
-            status_list = (status,)
-        else:
-            status_list = amo.VALID_STATUSES
-
+        status_list = (amo.STATUS_BETA,) if beta else amo.VALID_STATUSES
         items_qs = (self.addon.versions
                     .filter(files__status__in=status_list)
                     .distinct().order_by('-created'))

--- a/apps/versions/feeds.py
+++ b/apps/versions/feeds.py
@@ -45,13 +45,20 @@ class VersionsRss(Feed):
     feed_type = PagedFeed
     addon = None
 
-    def get_object(self, request, addon_id):
+    def get_object(self, request, addon_id, status=None):
         """Get the Addon for which we are about to output
            the RSS feed of it Versions"""
         qs = Addon.objects
         self.addon = get_object_or_404(qs.id_or_slug(addon_id) & qs.valid())
+
+        status = amo.STATUS_CHOICES_API_LOOKUP.get(status)
+        if status is not None and status in amo.VALID_STATUSES:
+            status_list = (status,)
+        else:
+            status_list = amo.VALID_STATUSES
+
         items_qs = (self.addon.versions
-                    .filter(files__status__in=amo.VALID_STATUSES)
+                    .filter(files__status__in=status_list)
                     .distinct().order_by('-created'))
         self.feed_type.page = amo.utils.paginate(request, items_qs, PER_PAGE)
         return self.addon

--- a/apps/versions/templates/versions/version_list.html
+++ b/apps/versions/templates/versions/version_list.html
@@ -1,8 +1,13 @@
 {% extends "impala/base_shared.html" %}
 
 {% block rss_feed %}
+{% if beta %}
+  {% set feed_view = 'addons.beta-versions.rss' %}
+{% else %}
+  {% set feed_view = 'addons.versions.rss' %}
+{% endif %}
 <link  rel="alternate" type="application/rss+xml"
-       title="RSS" href="{{ request.get_full_path() }}format:rss">
+       title="RSS" href="{{ url(feed_view, addon_id=addon.slug) }}">
 {% endblock %}
 
 {# L10n: {0} is an add-on name. #}

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -557,7 +557,7 @@ class TestFeeds(amo.tests.TestCase):
     def get_feed(self, slug, **kwargs):
         status = kwargs.get('status')
         if status:
-          del kwargs['status']
+            del kwargs['status']
 
         url = reverse('addons.versions.rss',
                       kwargs={'addon_id': slug, 'status': status})

--- a/apps/versions/urls.py
+++ b/apps/versions/urls.py
@@ -6,8 +6,10 @@ from . import views
 
 urlpatterns = patterns(
     '',
-    url('^$', views.version_list, name='addons.versions'),
-    url('^format:rss$', VersionsRss(), name='addons.versions.rss'),
+    url('^(?:status:(?P<status>[^/]+))?$',
+        views.version_list, name='addons.versions'),
+    url('^(?:status:(?P<status>[^/]+)/)format:rss$',
+        VersionsRss(), name='addons.versions.rss'),
     url('^(?P<version_num>[^/]+)$', views.version_detail,
         name='addons.versions'),
     url('^(?P<version_num>[^/]+)/updateinfo/$', views.update_info,

--- a/apps/versions/urls.py
+++ b/apps/versions/urls.py
@@ -6,10 +6,15 @@ from . import views
 
 urlpatterns = patterns(
     '',
-    url('^(?:status:(?P<status>[^/]+))?$',
+    url('^$',
         views.version_list, name='addons.versions'),
-    url('^(?:status:(?P<status>[^/]+)/)format:rss$',
+    url('^beta$',
+        views.version_list, name='addons.beta-versions',
+        kwargs={'beta': True}),
+    url('^format:rss$',
         VersionsRss(), name='addons.versions.rss'),
+    url('^beta/format:rss$',
+        VersionsRss(), name='addons.beta-versions.rss', kwargs={'beta': True}),
     url('^(?P<version_num>[^/]+)$', views.version_detail,
         name='addons.versions'),
     url('^(?P<version_num>[^/]+)/updateinfo/$', views.update_info,

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -28,8 +28,13 @@ log = commonware.log.getLogger('z.versions')
 
 @addon_view
 @mobile_template('versions/{mobile/}version_list.html')
-def version_list(request, addon, template):
-    qs = (addon.versions.filter(files__status__in=amo.VALID_STATUSES)
+def version_list(request, addon, template, status=None):
+    status = amo.STATUS_CHOICES_API_LOOKUP.get(status)
+    if status is not None and status in amo.VALID_STATUSES:
+        status_list = (status,)
+    else:
+        status_list = amo.VALID_STATUSES
+    qs = (addon.versions.filter(files__status__in=status_list)
           .distinct().order_by('-created'))
     versions = amo.utils.paginate(request, qs, PER_PAGE)
     versions.object_list = list(versions.object_list)

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -28,12 +28,8 @@ log = commonware.log.getLogger('z.versions')
 
 @addon_view
 @mobile_template('versions/{mobile/}version_list.html')
-def version_list(request, addon, template, status=None):
-    status = amo.STATUS_CHOICES_API_LOOKUP.get(status)
-    if status is not None and status in amo.VALID_STATUSES:
-        status_list = (status,)
-    else:
-        status_list = amo.VALID_STATUSES
+def version_list(request, addon, template, beta=False):
+    status_list = (amo.STATUS_BETA,) if beta else amo.VALID_STATUSES
     qs = (addon.versions.filter(files__status__in=status_list)
           .distinct().order_by('-created'))
     versions = amo.utils.paginate(request, qs, PER_PAGE)

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -35,7 +35,8 @@ def version_list(request, addon, template, beta=False):
     versions = amo.utils.paginate(request, qs, PER_PAGE)
     versions.object_list = list(versions.object_list)
     Version.transformer(versions.object_list)
-    return render(request, template, {'addon': addon, 'versions': versions})
+    return render(request, template, {'addon': addon, 'beta': beta,
+                                      'versions': versions})
 
 
 @addon_view


### PR DESCRIPTION
Ideally, there would be a link to `/addon/adblock-plus/versions/status:beta` in the Development Channel section - right now it shows the current beta build but tracking down older ones is complicated. However, this introduces a new string and a new UI element so I'd rather have the corresponding discussion in a separate pull request.