### PR TITLE
Upgrade Celery and remove some now-unnecessary cruft (bug 1194181)

### DIFF
--- a/apps/addons/cron.py
+++ b/apps/addons/cron.py
@@ -15,10 +15,10 @@ import cronjobs
 import multidb
 from lib import recommend
 from celery.task.sets import TaskSet
-from celeryutils import task
 import waffle
 
 import amo
+from amo.celery import task
 from amo.decorators import write
 from amo.utils import chunked, walkfiles
 from addons.models import Addon, AppSupport, FrozenAddon, Persona

--- a/apps/addons/tasks.py
+++ b/apps/addons/tasks.py
@@ -6,12 +6,12 @@ from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.db import transaction
 
-from celeryutils import task
 from PIL import Image
 
+import amo
 from addons.models import AppSupport, Persona
 from editors.models import RereviewQueueTheme
-import amo
+from amo.celery import task
 from amo.decorators import set_modified_on, write
 from amo.helpers import user_media_path
 from amo.storage_utils import rm_stored_dir

--- a/apps/amo/celery.py
+++ b/apps/amo/celery.py
@@ -1,0 +1,40 @@
+"""Loads and instantiates Celery, registers our tasks, and performs any other
+necessary Celery-related setup. Also provides Celery-related utility methods,
+in particular exposing a shortcut to the @task decorator."""
+from __future__ import absolute_import
+
+import commonware.log
+from celery import Celery
+from celery.signals import task_failure
+from django.conf import settings
+
+
+log = commonware.log.getLogger('z.celery')
+
+
+app = Celery('olympia')
+task = app.task
+
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(settings.INSTALLED_APPS)
+
+
+@task_failure.connect
+def process_failure_signal(exception, traceback, sender, task_id,
+                           signal, args, kwargs, einfo, **kw):
+    """Catch any task failure signals from within our worker processes and log
+    them as exceptions, so they appear in Sentry and ordinary logging
+    output."""
+
+    exc_info = (type(exception), exception, traceback)
+    log.error(
+        u'Celery TASK exception: {0.__name__}: {1}'.format(*exc_info),
+        exc_info=exc_info,
+        extra={
+            'data': {
+                'task_id': task_id,
+                'sender': sender,
+                'args': args,
+                'kwargs': kwargs
+            }
+        })

--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -1,8 +1,12 @@
-from inspect import isclass
+# The absolute import feature is required so that we get the root celery
+# module rather than `amo.celery`.
+from __future__ import absolute_import
 
+from inspect import isclass
 
 from celery.datastructures import AttributeDict
 from tower import ugettext_lazy as _
+
 
 __all__ = ('LOG', 'LOG_BY_ID', 'LOG_KEEP',)
 

--- a/apps/amo/tasks.py
+++ b/apps/amo/tasks.py
@@ -5,11 +5,11 @@ from django.core.mail import EmailMessage, EmailMultiAlternatives
 
 import commonware.log
 import phpserialize
-from celeryutils import task
 from hera.contrib.django_utils import flush_urls
 
 import amo
 from addons.models import Addon
+from amo.celery import task
 from amo.utils import get_email_backend
 from bandwagon.models import Collection
 from devhub.models import ActivityLog

--- a/apps/bandwagon/cron.py
+++ b/apps/bandwagon/cron.py
@@ -6,9 +6,9 @@ from django.db.models import Count
 
 import commonware.log
 from celery.task.sets import TaskSet
-from celeryutils import task
 
 import amo
+from amo.celery import task
 from amo.utils import chunked, slugify
 from bandwagon.models import (Collection, SyncedCollection, CollectionVote,
                               CollectionWatcher)

--- a/apps/bandwagon/tasks.py
+++ b/apps/bandwagon/tasks.py
@@ -4,9 +4,8 @@ import math
 from django.core.files.storage import default_storage as storage
 from django.db.models import Count
 
-from celeryutils import task
-
 import amo
+from amo.celery import task
 from amo.decorators import set_modified_on
 from amo.helpers import user_media_path
 from amo.utils import attach_trans_dict, resize_image

--- a/apps/editors/tasks.py
+++ b/apps/editors/tasks.py
@@ -4,11 +4,11 @@ from django.conf import settings
 from django.utils.translation import override
 
 import commonware.log
-from celeryutils import task
 from tower import ugettext as _
 
 import constants.editors as rvw
 from addons.tasks import create_persona_preview_images
+from amo.celery import task
 from amo.decorators import write
 from amo.helpers import user_media_path
 from amo.storage_utils import copy_stored_file, move_stored_file

--- a/apps/files/tasks.py
+++ b/apps/files/tasks.py
@@ -3,8 +3,10 @@ import logging
 from django.conf import settings
 
 from cache_nuggets.lib import Message
-from celeryutils import task
 from tower import ugettext as _
+
+from amo.celery import task
+
 
 task_log = logging.getLogger('z.task')
 jp_log = logging.getLogger('z.jp.repack')

--- a/apps/reviews/models.py
+++ b/apps/reviews/models.py
@@ -6,11 +6,11 @@ from django.db import models
 
 import bleach
 import caching.base as caching
-from celeryutils import task
 from tower import ugettext_lazy as _
 
 import amo.models
 from amo import helpers
+from amo.celery import task
 from translations.fields import save_signal, TranslatedField
 from users.models import UserProfile
 

--- a/apps/reviews/tasks.py
+++ b/apps/reviews/tasks.py
@@ -3,9 +3,9 @@ import logging
 from django.db.models import Count, Avg, F
 
 import caching.base as caching
-from celeryutils import task
 
 from addons.models import Addon
+from amo.celery import task
 from .models import Review, GroupedRating
 
 log = logging.getLogger('z.task')

--- a/apps/stats/tasks.py
+++ b/apps/stats/tasks.py
@@ -8,13 +8,13 @@ from django.db.models import Sum, Max
 
 import commonware.log
 from apiclient.discovery import build
-from celeryutils import task
 from elasticsearch.helpers import bulk_index
 from oauth2client.client import OAuth2Credentials
 
 import amo
 import amo.search
 from addons.models import Addon
+from amo.celery import task
 from bandwagon.models import Collection
 from reviews.models import Review
 from stats.models import Contribution

--- a/apps/tags/tasks.py
+++ b/apps/tags/tasks.py
@@ -1,6 +1,6 @@
-from celeryutils import task
 import commonware.log
 
+from amo.celery import task
 from amo.utils import slugify
 from tags.models import AddonTag, Tag
 

--- a/apps/users/tasks.py
+++ b/apps/users/tasks.py
@@ -1,9 +1,9 @@
 from django.core.files.storage import default_storage as storage
 
 import commonware.log
-from celeryutils import task
 from lib.es.utils import index_objects
 
+from amo.celery import task
 from amo.decorators import set_modified_on
 from amo.utils import resize_image
 from amo.helpers import user_media_path

--- a/apps/zadmin/tasks.py
+++ b/apps/zadmin/tasks.py
@@ -18,11 +18,11 @@ from django.template import Context, Template
 from django.utils import translation
 
 import requests
-from celeryutils import task
 
 import amo
 from addons.models import Addon, AddonUser
 from amo import set_user
+from amo.celery import task
 from amo.decorators import write
 from amo.helpers import absolutify
 from amo.urlresolvers import reverse

--- a/docs/topics/install-olympia/advanced-installation.rst
+++ b/docs/topics/install-olympia/advanced-installation.rst
@@ -55,7 +55,7 @@ RabbitMQ and Celery
 
 See the :doc:`./celery` page for installation instructions.  The
 :ref:`example settings <example-settings>` set ``CELERY_ALWAYS_EAGER = True``.
-If you're setting up Rabbit and want to use ``celeryd``, make sure you remove
+If you're setting up Rabbit and want to use ``celery``, make sure you remove
 that line from your ``local_settings.py``.
 
 

--- a/docs/topics/install-olympia/celery.rst
+++ b/docs/topics/install-olympia/celery.rst
@@ -52,7 +52,7 @@ Then run the following commands: ::
 
 Back in safe and happy django-land you should be able to run: ::
 
-  ./manage.py celeryd $OPTIONS
+  celery -A olympia worker -E
 
 Celery understands python and any tasks that you have defined in your app are
 now runnable asynchronously.
@@ -76,7 +76,7 @@ that it happens.  We can define it like so: ::
               task_log.debug("Missing addon: %d" % pk)
 
 ``@task`` is a decorator for Celery to find our tasks.  We can specify a
-``rate_limit`` like ``2/m`` which means ``celeryd`` will only run this command
+``rate_limit`` like ``2/m`` which means ``celery`` will only run this command
 2 times a minute at most.  This keeps write-heavy tasks from killing your
 database.
 
@@ -129,7 +129,7 @@ rate, and your data will be updated ... eventually.
 During Development
 ------------------
 
-``celeryd`` only knows about code as it was defined at instantiation time.  If
+``celery`` only knows about code as it was defined at instantiation time.  If
 you change your ``@task`` function, you'll need to ``HUP`` the process.
 
 However, if you've got the ``@task`` running perfectly you can tweak all the

--- a/docs/topics/install-olympia/troubleshooting.rst
+++ b/docs/topics/install-olympia/troubleshooting.rst
@@ -13,19 +13,19 @@ Checking your image settings
 ____________________________
 
 Check that ``CELERY_ALWAYS_EAGER`` is set to ``True`` in your settings file. This
-means it will process tasks without celeryd running::
+means it will process tasks without a celery worker running::
 
     CELERY_ALWAYS_EAGER = True
 
-If that yields no joy you can try running celeryd in the foreground,
+If that yields no joy you can try running a celery worker in the foreground,
 set ``CELERY_ALWAYS_EAGER = False`` and run::
 
-    ./manage.py celeryd $OPTIONS
+    celery -A olympia worker -E
 
 
 .. note::
 
-    This requires the rabbit setup as detailed in the
+    This requires a RabbitMQ server to be set up as detailed in the
     :doc:`./celery` instructions.
 
 This may help you to see where the image processing tasks are failing. For

--- a/lib/crypto/tasks.py
+++ b/lib/crypto/tasks.py
@@ -7,11 +7,11 @@ import zipfile
 from django.conf import settings
 from django.db.models import Q
 
-from celeryutils import task
 from lxml import etree
 
 import amo
 from addons.models import AddonUser
+from amo.celery import task
 from lib.crypto.packaged import sign_file
 from versions.compare import version_int
 from versions.models import Version

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -260,7 +260,6 @@ TEMPLATE_LOADERS = (
 # apps that don't use Jinja2. The Following is a list of prefixes for jingo to
 # ignore.
 JINGO_EXCLUDE_APPS = (
-    'djcelery',
     'django_extensions',
     'admin',
     'toolbar_statsd',
@@ -363,8 +362,9 @@ AUTH_USER_MODEL = 'users.UserProfile'
 ROOT_URLCONF = 'lib.urls_base'
 
 INSTALLED_APPS = (
-    # Import ordering issues ahoy.
-    'djcelery',
+    # This the path management and monkey-patching required to load the rest,
+    # so it must come first.
+    'olympia',
 
     'amo',  # amo comes first so it always takes precedence.
     'abuse',

--- a/lib/video/tasks.py
+++ b/lib/video/tasks.py
@@ -4,9 +4,8 @@ import shutil
 
 from django.conf import settings
 
-from celeryutils import task
-
 import amo
+from amo.celery import task
 from amo.decorators import set_modified_on
 from lib.video import library
 import waffle

--- a/manage.py
+++ b/manage.py
@@ -2,22 +2,10 @@
 import os
 import sys
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
-
-import setup_olympia  # noqa
-
-# No third-party imports until we've added all our sitedirs!
-from django.core.management import (call_command,
-                                    execute_from_command_line)  # noqa
-
 
 if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
-    # If product details aren't present, get them.
-    from product_details import product_details
-    if not product_details.last_update:
-        print 'Product details missing, downloading...'
-        call_command('update_product_details')
-        product_details.__init__()  # reload the product details
+    from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,15 +1,15 @@
 -r compiled.txt
 amo-validator==1.8.5
-amqp==1.0.13
+amqp==1.4.6
 anyjson==0.3.3
 argparse==1.2.1
 babel==0.9.6
 basket-client==0.3.7
-billiard==2.7.3.34
+billiard==3.3.0.20
 bleach==1.4
 boto==2.20.0
 cef==0.5
-celery==3.0.24
+celery==3.1.18
 celery-tasktree==0.3.2
 certifi==0.0.8
 chardet==2.1.1
@@ -20,7 +20,6 @@ dennis==0.4.2
 Django==1.6.11
 dj-database-url==0.2.2
 django-cache-nuggets==0.1.1
-django-celery==3.0.23
 django-cronjobs==0.2.3
 django_csp==2.0.3
 django-extensions==1.2.5
@@ -48,7 +47,7 @@ html5lib==0.999
 httplib2==0.8.0
 importlib-no-failure==1.0.2
 jingo==0.7
-kombu==2.5.16
+kombu==3.0.26
 heka-py==0.30.3
 heka-py-cef==0.3.1
 heka-py-raven==0.6

--- a/settings_test.py
+++ b/settings_test.py
@@ -33,22 +33,6 @@ def _polite_tmpdir():
 # Make sure the app needed to test translations is present.
 INSTALLED_APPS += TEST_INSTALLED_APPS
 
-# Make sure our initialization code gets loaded before any other apps.
-#
-# Since ordinary runs currently load this module from `manage.py`, it would
-# be nice to load it from `conftest.py` in tests, for symmetry. Unfortunately,
-# the `conftest.py` does not reliably load early enough for our setup to have
-# any effect.
-#
-# In particular, pytest-django will load our settings module and initialize
-# django immediately well before our own `conftest.py` file is even collected,
-# if it already has a `DJANGO_SETTINGS_MODULE` environment variable or config
-# setting at that point. When using pytest-xdist to split the tests into
-# multiple, parallel processes, that variable is always set when worker
-# processes are forked, so those processes will always initialize django
-# before we would otherwise have a chance to configure it.
-INSTALLED_APPS = ('setup_olympia',) + INSTALLED_APPS
-
 # See settings.py for documentation:
 IN_TEST_SUITE = True
 MEDIA_ROOT = _polite_tmpdir()

--- a/wsgi/zamboni.wsgi
+++ b/wsgi/zamboni.wsgi
@@ -1,10 +1,6 @@
 import os
 import site
-import sys
-import setup_olympia
 from datetime import datetime
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 # Remember when mod_wsgi loaded this file so we can track it in nagios.
 wsgi_loaded = datetime.now()
@@ -12,12 +8,12 @@ wsgi_loaded = datetime.now()
 # Tell celery that we're using Django.
 os.environ['CELERY_LOADER'] = 'django'
 
-# Add the zamboni dir to the python path so we can import manage.
+# Add the zamboni dir to the python path so we can import olympia.
 wsgidir = os.path.dirname(__file__)
 site.addsitedir(os.path.abspath(os.path.join(wsgidir, '../')))
 
-# manage adds /apps and /lib to the Python path.
-import manage
+# adds /apps and /lib to the Python path.
+import olympia
 
 import django.conf
 import django.core.handlers.wsgi
@@ -47,7 +43,7 @@ def application(env, start_response):
     return django_app(env, start_response)
 
 
-if setup_olympia.load_newrelic:
+if olympia.load_newrelic:
     import newrelic.agent
     application = newrelic.agent.wsgi_application()(application)
 # Uncomment this to figure out what's going on with the mod_wsgi environment.


### PR DESCRIPTION
We're going to need to add these three packages to the wheelhouse and have Jason change the worker deploy scripts to launch `celery` directly rather than via `manage.py`.