### PR TITLE
Add `amo.validator` to `lib.log_settings_base.loggers`.

### DIFF
--- a/lib/log_settings_base.py
+++ b/lib/log_settings_base.py
@@ -63,12 +63,18 @@ handlers = {
 
 loggers = {
     'z': {},
+    'amo': {},
     'django.request': {
         'handlers': ['statsd'],
         'level': 'ERROR',
         'propagate': True,
     },
     'z.celery': {
+        'handlers': ['statsd'],
+        'level': 'ERROR',
+        'propagate': True,
+    },
+    'amo.validator': {
         'handlers': ['statsd'],
         'level': 'ERROR',
         'propagate': True,


### PR DESCRIPTION
This is my best guess at the reason validator errors aren't currently showing up in Sentry.