### PR TITLE
Delete unused .gitmodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor"]
-	path = vendor
-	url = https://github.com/mozilla/zamboni-lib.git


### PR DESCRIPTION
vendor/ was removed in https://github.com/mozilla/olympia/pull/206