### PR TITLE
use the active locale for urls in the file viewer (bug 1168794)

### DIFF
--- a/apps/files/helpers.py
+++ b/apps/files/helpers.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.utils.datastructures import SortedDict
 from django.utils.encoding import smart_unicode
+from django.utils.translation import get_language
 from django.template.defaultfilters import filesizeformat
 
 import jinja2
@@ -219,7 +220,7 @@ class FileViewer(object):
         # In case a cron job comes along and deletes the files
         # mid tree building.
         try:
-            self._files = self._get_files()
+            self._files = self._get_files(locale=get_language())
             return self._files
         except (OSError, IOError):
             return {}
@@ -262,7 +263,16 @@ class FileViewer(object):
         return 'plain'
 
     @memoize(prefix='file-viewer', time=60 * 60)
-    def _get_files(self):
+    def _get_files(self, locale=None):
+        """We need the `locale` parameter for the memoization.
+
+        The `@memoize` decorator uses the prefix *and the parameters* to come
+        up with a memoize key. We thus add a (seemingly useless) `locale`
+        parameter.
+
+        Otherwise, we would just always have the urls for the files with the
+        locale from the first person checking them.
+        """
         all_files, res = [], SortedDict()
         # Not using os.path.walk so we get just the right order.
 

--- a/apps/files/tests/test_helpers.py
+++ b/apps/files/tests/test_helpers.py
@@ -130,7 +130,19 @@ class TestFileHelper(amo.tests.TestCase):
         files = self.viewer.get_files()
         url = reverse('files.list', args=[self.viewer.file.id,
                                           'file', 'install.js'])
-        assert files['install.js']['url'].endswith(url)
+        file_url = files['install.js']['url']
+        assert file_url == url
+        assert file_url.startswith('/en-US')
+
+        # Make sure that the locale is properly used (see bug 1168794).
+        with self.activate('fr'):
+            self.viewer._files = {}  # Reset the viewer's internal cache.
+            files = self.viewer.get_files()
+            url = reverse('files.list', args=[self.viewer.file.id,
+                                              'file', 'install.js'])
+            file_url = files['install.js']['url']
+            assert file_url == url
+            assert file_url.startswith('/fr')
 
     def test_get_files_depth(self):
         self.viewer.extract()


### PR DESCRIPTION
Fixes [bug 1168794](https://bugzilla.mozilla.org/show_bug.cgi?id=1168794)