### PR TITLE
Bug 1198855 - Linking directly to Version Information or Development Channel sections should be possible

### DIFF
--- a/static/js/impala/addon_details.js
+++ b/static/js/impala/addon_details.js
@@ -119,12 +119,13 @@ $(function () {
             var origHeight = $document.height();
 
             // We need to correct scrolling position if the user scrolled down
-            // already (e.g. by using a link with anchor). This corection is
+            // already (e.g. by using a link with anchor). This correction is
             // only necessary if the scrolling position is below the element we
             // replace or the user scrolled down to the bottom of the document.
             var shouldCorrectScrolling = scrollTop > $moreEl.offset().top;
-            if (scrollTop && scrollTop >= origHeight - $(window).height())
+            if (scrollTop && scrollTop >= origHeight - $(window).height()) {
                 shouldCorrectScrolling = true;
+            }
 
             var $newContent = $(resp);
             $moreEl.replaceWith($newContent);

--- a/static/js/impala/addon_details.js
+++ b/static/js/impala/addon_details.js
@@ -114,12 +114,31 @@ $(function () {
         var $moreEl = $('#more-webpage');
             url = $moreEl.attr('data-more-url');
         $.get(url, function(resp) {
+            var $document = $(document);
+            var scrollTop = $document.scrollTop();
+            var origHeight = $document.height();
+
+            // We need to correct scrolling position if the user scrolled down
+            // already (e.g. by using a link with anchor). This corection is
+            // only necessary if the scrolling position is below the element we
+            // replace or the user scrolled down to the bottom of the document.
+            var shouldCorrectScrolling = scrollTop > $moreEl.offset().top;
+            if (scrollTop && scrollTop >= origHeight - $(window).height())
+                shouldCorrectScrolling = true;
+
             var $newContent = $(resp);
             $moreEl.replaceWith($newContent);
             $newContent.find('.listing-grid h3').truncate( {dir: 'h'} );
             $newContent.find('.install').installButton();
             $newContent.find('.listing-grid').each(listing_grid);
             $('#reviews-link').addClass('scrollto').attr('href', '#reviews');
+
+            if (shouldCorrectScrolling) {
+                // User scrolled down already, adjust scrolling position so
+                // that the same content stays visible.
+                var heightDifference = $document.height() - origHeight;
+                $document.scrollTop(scrollTop + heightDifference);
+            }
         });
     }
 

--- a/static/js/impala/global.js
+++ b/static/js/impala/global.js
@@ -119,6 +119,8 @@ $(function() {
     }));
 
     if (window.location.hash) {
+        // If the page URL is pointing directly to an expando section (e.g.
+        // external link to that section), make sure the contents are visible.
         var $target = $(window.location.hash);
         if ($target.hasClass('expando'))
             $target.addClass('expanded');

--- a/static/js/impala/global.js
+++ b/static/js/impala/global.js
@@ -118,6 +118,12 @@ $(function() {
         $(this).closest('.expando').toggleClass('expanded');
     }));
 
+    if (window.location.hash) {
+        var $target = $(window.location.hash);
+        if ($target.hasClass('expando'))
+            $target.addClass('expanded');
+    }
+
     $('#page').delegate('.scrollto', 'click', function(e) {
         e.preventDefault();
         var href = $(this).attr('href'),


### PR DESCRIPTION
The change to the expando logic affects all pages, not just the add-on details page. However, the new behavior is the correct one IMHO.