### PR TITLE
Signing is only enforced in Firefox above version 41 (bug 1193256)

### DIFF
--- a/apps/addons/templates/addons/popups.html
+++ b/apps/addons/templates/addons/popups.html
@@ -108,8 +108,8 @@
 <div class="install-note">
   <p class="msg m-unreviewed">{% trans %}
     <strong>Caution:</strong> This add-on has not been reviewed by Mozilla and
-    can't be installed on release versions of Firefox.  Be careful when
-    installing third-party software that might harm your computer.
+    can't be installed on release versions of Firefox 41 and above.  Be careful
+    when installing third-party software that might harm your computer.
   {% endtrans %}</p>
   <p><a href="{url}" class="button installer">{msg}</a></p>
 </div>


### PR DESCRIPTION
Fixes [bug 1193256](https://bugzilla.mozilla.org/show_bug.cgi?id=1193256)