### PR TITLE
Remove dump_apps from cron and deploy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -161,7 +161,6 @@ def update():
     execute(compress_assets)
     execute(collectstatic)
     execute(schematic)
-    managecmd('dump_apps')
     managecmd('statsd_ping --key=update')
 
 
@@ -188,7 +187,6 @@ def deploy_jenkins():
 
     install_dir = os.path.join(rpmbuild.install_to, 'olympia')
     execute(schematic, install_dir)
-    managecmd('dump_apps', install_dir)
 
     rpmbuild.remote_install(['web', 'celery'])
     helpers.restart_uwsgi(getattr(settings, 'UWSGI', []))

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -42,7 +42,6 @@ HOME=/tmp
 30 18 * * * %(z_cron)s recs
 0 22 * * * %(z_cron)s gc
 30 6 * * * %(z_cron)s deliver_hotness
-45 7 * * * %(django)s dump_apps
 0 8 * * * %(django)s update_product_details
 
 # Collect visitor stats from Google Analytics once per day.


### PR DESCRIPTION
I believe dump_apps is not need for olympia. It was historically used as part of dumping apps for marketplace.