### PR TITLE
Fixed alt tag a11y issues on main page (bug 1196953)

### DIFF
--- a/apps/addons/templates/addons/impala/addon_hovercard.html
+++ b/apps/addons/templates/addons/impala/addon_hovercard.html
@@ -4,9 +4,9 @@
     <div class="icon">
       <a href="{{ details_link }}">
       {% if lazyload %}
-        <img src="{{ addon.icon_url }}" alt="">
+      <img src="{{ addon.icon_url }}" alt="{{ _('Icon for {0}')|fe(addon.name) }}">
       {% else %}
-        <img data-defer-src="{{ addon.icon_url }}" alt=""
+        <img data-defer-src="{{ addon.icon_url }}" alt="{{ _('Icon for {0}')|fe(addon.name) }}"
              src="{{ static('img/addon-icons/default-32.png') }}">
       {% endif %}
       </a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -155,7 +155,7 @@
         <div id="footer" role="contentinfo">
           <div class="section">
             {% block footer_extras %}
-              <img class="footerlogo" src="{{ static('img/zamboni/footer-logo-med.png') }}" alt="">
+            <img class="footerlogo" src="{{ static('img/zamboni/footer-logo-med.png') }}" alt="{{ _('Footer logo') }}">
             {% endblock %}
             {% include "footer.html" %}
           </div> {# section #}

--- a/templates/impala/base.html
+++ b/templates/impala/base.html
@@ -191,7 +191,7 @@
       <div id="footer" role="contentinfo">
         <div class="section">
           {% block footer_extras %}
-            <img class="footerlogo" src="{{ static('img/zamboni/footer-logo-med.png') }}" alt="">
+          <img class="footerlogo" src="{{ static('img/zamboni/footer-logo-med.png') }}" alt="{{ _('Footer logo') }}">
           {% endblock %}
           {% with hide_mobile_link=hide_mobile_link %}
             {% include 'footer.html' %}


### PR DESCRIPTION
Simply added more descriptive alt tags to describe images on the main page. This is not a site wide fix.