### PR TITLE
Hide unreviewable addons from editor tools (bug 1109299)

### DIFF
--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -157,8 +157,9 @@ def queue_tabnav(context):
     """
     from .views import queue_counts
 
-    counts = queue_counts()
-    unlisted_counts = queue_counts(unlisted=True)
+    counts = queue_counts(admin_reviewer=context.get('admin_reviewer'))
+    unlisted_counts = queue_counts(
+        admin_reviewer=context.get('admin_reviewer'), unlisted=True)
     listed = not context.get('unlisted')
 
     if listed:

--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -155,11 +155,8 @@ def queue_tabnav(context):
 
     Each tuple contains three elements: (tab_code, page_url, tab_text)
     """
-    from .views import queue_counts
-
-    counts = queue_counts(admin_reviewer=context.get('admin_reviewer'))
-    unlisted_counts = queue_counts(
-        admin_reviewer=context.get('admin_reviewer'), unlisted=True)
+    counts = context['queue_counts']
+    unlisted_counts = context['unlisted_queue_counts']
     listed = not context.get('unlisted')
 
     if listed:

--- a/apps/editors/templates/editors/queue.html
+++ b/apps/editors/templates/editors/queue.html
@@ -37,6 +37,10 @@
                 <label for="id_{{ elem }}">{{ search_form[elem].label }}</label>
                 <div class="form-elem">{{ search_form[elem] }}</div>
               {% endfor %}
+              <label>
+                <input type="checkbox" value="1" name="include_admin_only" />
+                {{ _('Include admin only review addons.') }}
+              </label>
             </div>
           </div>
           <div class="column2">

--- a/apps/editors/templates/editors/queue.html
+++ b/apps/editors/templates/editors/queue.html
@@ -37,10 +37,6 @@
                 <label for="id_{{ elem }}">{{ search_form[elem].label }}</label>
                 <div class="form-elem">{{ search_form[elem] }}</div>
               {% endfor %}
-              <label>
-                <input type="checkbox" value="1" name="include_admin_only" />
-                {{ _('Include admin only review addons.') }}
-              </label>
             </div>
           </div>
           <div class="column2">

--- a/apps/editors/templates/editors/themes/queue_list.html
+++ b/apps/editors/templates/editors/themes/queue_list.html
@@ -74,14 +74,8 @@
       {{ no_results_amo() }}
     {% endif %}
 
-    {% if queue_counts[tab] == 0 %}
-      <div class="no-results">
-        {{ _('There are currently no items of this type to review.') }}
-      </div>
-    {% else %}
-      <div class="impala-paginator">{{ pager|impala_paginator }}</div>
-      <div class="mobile-paginator hidden">{{ pager|mobile_impala_paginator }}</div>
-    {% endif %}
+    <div class="impala-paginator">{{ pager|impala_paginator }}</div>
+    <div class="mobile-paginator hidden">{{ pager|mobile_impala_paginator }}</div>
   </section>
 
   {# Populated by dynamic search #}

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1413,13 +1413,6 @@ class SearchTest(EditorTest):
         return r
 
 
-def login_as_admin(fn):
-    def inner(suite, *args, **kwargs):
-        suite.login_as_admin()
-        return fn(suite, *args, **kwargs)
-    return inner
-
-
 class TestQueueSearch(SearchTest):
     fixtures = ['base/users', 'base/appversion']
 
@@ -1485,22 +1478,22 @@ class TestQueueSearch(SearchTest):
     def generate_file(self, name):
         return self.generate_files([name])[name]
 
-    @login_as_admin
     def test_search_by_admin_reviewed_admin(self):
+        self.login_as_admin()
         self.generate_files(['Not Admin Reviewed', 'Admin Reviewed'])
         r = self.search(admin_review=1)
         eq_(self.named_addons(r), ['Admin Reviewed'])
 
-    @login_as_admin
     def test_queue_counts_admin(self):
+        self.login_as_admin()
         self.generate_files(['Not Admin Reviewed', 'Admin Reviewed'])
         r = self.search(text_query='admin', per_page=1)
         doc = pq(r.content)
         eq_(doc('.data-grid-top .num-results').text(),
             u'Results 1 \u2013 1 of 2')
 
-    @login_as_admin
     def test_search_by_addon_name_admin(self):
+        self.login_as_admin()
         self.generate_files(['Not Admin Reviewed', 'Admin Reviewed',
                              'Justin Bieber Theme'])
         r = self.search(text_query='admin')

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1500,24 +1500,36 @@ class TestQueueSearch(SearchTest):
         eq_(sorted(self.named_addons(r)), ['Admin Reviewed',
                                            'Not Admin Reviewed'])
 
+    def test_not_searching(self):
+        self.generate_files(['Not Admin Reviewed', 'Admin Reviewed'])
+        r = self.search()
+        eq_(sorted(self.named_addons(r)), ['Not Admin Reviewed'])
+
+    def test_search_by_nothing(self):
+        self.generate_files(['Not Admin Reviewed', 'Admin Reviewed'])
+        r = self.search(searching='True')
+        eq_(sorted(self.named_addons(r)),
+            ['Admin Reviewed', 'Not Admin Reviewed'])
+
     def test_search_by_admin_reviewed(self):
         self.generate_files(['Not Admin Reviewed', 'Admin Reviewed'])
-        r = self.search(admin_review=1)
-        eq_(self.named_addons(r), [])
+        r = self.search(admin_review=1, searching='True')
+        eq_(self.named_addons(r), ['Admin Reviewed'])
 
     def test_queue_counts(self):
         self.generate_files(['Not Admin Reviewed',
                              'Another Not Admin Reviewed', 'Admin Reviewed'])
-        r = self.search(text_query='admin', per_page=1)
+        r = self.search(text_query='admin', per_page=1, searching='True')
         doc = pq(r.content)
         eq_(doc('.data-grid-top .num-results').text(),
-            u'Results 1 \u2013 1 of 2')
+            u'Results 1 \u2013 1 of 3')
 
     def test_search_by_addon_name(self):
         self.generate_files(['Not Admin Reviewed', 'Admin Reviewed',
                              'Justin Bieber Theme'])
-        r = self.search(text_query='admin')
-        eq_(sorted(self.named_addons(r)), ['Not Admin Reviewed'])
+        r = self.search(text_query='admin', searching='True')
+        eq_(sorted(self.named_addons(r)),
+            ['Admin Reviewed', 'Not Admin Reviewed'])
 
     def test_search_by_addon_in_locale(self):
         name = 'Not Admin Reviewed'

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1500,7 +1500,7 @@ class TestQueueSearch(SearchTest):
         eq_(sorted(self.named_addons(r)), ['Admin Reviewed',
                                            'Not Admin Reviewed'])
 
-    def test_search_by_admin_reviewed_regular(self):
+    def test_search_by_admin_reviewed(self):
         self.generate_files(['Not Admin Reviewed', 'Admin Reviewed'])
         r = self.search(admin_review=1)
         eq_(self.named_addons(r), [])

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1513,8 +1513,8 @@ class TestQueueSearch(SearchTest):
         eq_(self.named_addons(r), [])
 
     def test_queue_counts(self):
-        self.generate_files(['Not Admin Reviewed', 'Another Not Admin Reviewed',
-                             'Admin Reviewed'])
+        self.generate_files(['Not Admin Reviewed',
+                             'Another Not Admin Reviewed', 'Admin Reviewed'])
         r = self.search(text_query='admin', per_page=1)
         doc = pq(r.content)
         eq_(doc('.data-grid-top .num-results').text(),

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -55,8 +55,7 @@ def base_context(**kw):
 
 def context(request, **kw):
     admin_reviewer = is_admin_reviewer(request)
-    ctx = {'admin_reviewer': admin_reviewer,
-           'queue_counts': queue_counts(admin_reviewer=admin_reviewer),
+    ctx = {'queue_counts': queue_counts(admin_reviewer=admin_reviewer),
            'unlisted_queue_counts': queue_counts(
                unlisted=True, admin_reviewer=admin_reviewer)}
     ctx.update(base_context(**kw))

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -47,14 +47,19 @@ from .decorators import (addons_reviewer_required, any_reviewer_required,
                          unlisted_addons_reviewer_required)
 
 
+def base_context(**kw):
+    ctx = dict(motd=get_config('editors_review_motd'))
+    ctx.update(kw)
+    return ctx
+
+
 def context(request, **kw):
     admin_reviewer = is_admin_reviewer(request)
-    ctx = dict(motd=get_config('editors_review_motd'),
-               admin_reviewer=admin_reviewer,
+    ctx = dict(admin_reviewer=admin_reviewer,
                queue_counts=queue_counts(admin_reviewer=admin_reviewer),
                unlisted_queue_counts=queue_counts(
                    unlisted=True, admin_reviewer=admin_reviewer))
-    ctx.update(kw)
+    ctx.update(base_context(**kw))
     return ctx
 
 

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -395,12 +395,11 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False):
                           unlisted=unlisted))
 
 
-def queue_counts(type=None, unlisted=False, admin_reviewer=None, **kw):
+def queue_counts(type=None, unlisted=False, admin_reviewer=False, **kw):
     def construct_query(query_type, days_min=None, days_max=None):
         query = query_type.objects
 
-        # admin_reviewer defaults to True so explicitly check against False.
-        if admin_reviewer is False:
+        if not admin_reviewer:
             query = exclude_admin_only_addons(query)
         if days_min:
             query = query.having('waiting_time_days >=', days_min)

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -48,17 +48,17 @@ from .decorators import (addons_reviewer_required, any_reviewer_required,
 
 
 def base_context(**kw):
-    ctx = dict(motd=get_config('editors_review_motd'))
+    ctx = {'motd': get_config('editors_review_motd')}
     ctx.update(kw)
     return ctx
 
 
 def context(request, **kw):
     admin_reviewer = is_admin_reviewer(request)
-    ctx = dict(admin_reviewer=admin_reviewer,
-               queue_counts=queue_counts(admin_reviewer=admin_reviewer),
-               unlisted_queue_counts=queue_counts(
-                   unlisted=True, admin_reviewer=admin_reviewer))
+    ctx = {'admin_reviewer': admin_reviewer,
+           'queue_counts': queue_counts(admin_reviewer=admin_reviewer),
+           'unlisted_queue_counts': queue_counts(
+               unlisted=True, admin_reviewer=admin_reviewer)}
     ctx.update(base_context(**kw))
     return ctx
 

--- a/apps/editors/views_themes.py
+++ b/apps/editors/views_themes.py
@@ -20,7 +20,7 @@ from amo.utils import paginate
 from devhub.models import ActivityLog
 from editors import forms
 from editors.models import RereviewQueueTheme, ReviewerScore, ThemeLock
-from editors.views import context
+from editors.views import base_context as context
 from search.views import name_only_query
 from zadmin.decorators import admin_required
 from .decorators import personas_reviewer_required


### PR DESCRIPTION
I'm pretty sure the tests are going to fail.