### PR TITLE
Modified badge height so longer badges fit (bug 1196141)

### DIFF
--- a/static/css/impala/users.less
+++ b/static/css/impala/users.less
@@ -127,14 +127,13 @@ img.icon {
         color: #246;
         font-size: 12px;
         font-weight: bold;
-        height: 25px;
         text-transform: uppercase;
-        line-height: 25px;
+        line-height: 14px;
         padding: 0 3px;
 
         p {
             margin: 0 6px;
-            padding: 0;
+            padding: 5px 0;
             text-align: center;
 
             &:before {


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1196141

Issue was:
<img width="228" alt="screen shot 2015-09-01 at 12 23 46 pm" src="https://cloud.githubusercontent.com/assets/2600677/9609918/620898ee-50a4-11e5-9dd7-2edfcb2da010.png">

Now it should look like:
<img width="235" alt="screen shot 2015-09-01 at 12 23 54 pm" src="https://cloud.githubusercontent.com/assets/2600677/9609921/6b054c3a-50a4-11e5-8e38-4fa054e10569.png">
