### PR TITLE
Remove 'Reviewer' from theme review page (bug 1199035)

### DIFF
--- a/apps/editors/templates/editors/themes/themes.html
+++ b/apps/editors/templates/editors/themes/themes.html
@@ -41,7 +41,7 @@
       <dt class="license">{{ _('License') }}</dt><dd>{{ license_link(theme.license) }}</dd>
     </dl>
     <dl class="meta">
-      {% if hasOneToOne(theme, 'themelock') %}
+      {% if hasOneToOne(theme, 'themelock') and theme.themelock.reviewer != request.user %}
         <dt>{{ _('Reviewer') }}</dt><dd>{{ emaillink(theme.themelock.reviewer.email) }}</dd>
       {% endif %}
     </dl>


### PR DESCRIPTION
I removed this as per bug https://bugzilla.mozilla.org/show_bug.cgi?id=1199035

I noticed this template is used in more than one page, and I had a brief look but I think this removal is ok. Hopefully this isn't useful in any other pages. :)