### PR TITLE
Bug 1201123: Make sure validation tasks go to the correct queue.

### DIFF
--- a/apps/devhub/tasks.py
+++ b/apps/devhub/tasks.py
@@ -144,7 +144,6 @@ def handle_file_validation_result(results, file_id, annotate=True):
     return FileValidation.from_json(file_, results)
 
 
-@task
 def annotate_validation_results(results):
     """Annotates validation results with information such as whether the
     results pass auto validation, and which results are unchanged from a

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1006,9 +1006,13 @@ CELERY_ROUTES = {
     # Other queues we prioritize below.
 
     # AMO Devhub.
-    'devhub.tasks.validator': {'queue': 'devhub'},
+    'devhub.tasks.validate_file': {'queue': 'devhub'},
+    'devhub.tasks.validate_file_path': {'queue': 'devhub'},
+    'devhub.tasks.handle_upload_validation_result': {'queue': 'devhub'},
+    'devhub.tasks.handle_file_validation_result': {'queue': 'devhub'},
+    # This is currently used only by validation tasks.
+    'celery.chord_unlock': {'queue': 'devhub'},
     'devhub.tasks.compatibility_check': {'queue': 'devhub'},
-    'devhub.tasks.file_validator': {'queue': 'devhub'},
 
     # Videos.
     'lib.video.tasks.resize_video': {'queue': 'devhub'},


### PR DESCRIPTION
I managed to test this locally, and all validation-related tasks are now going to the devhub queue.

r? @magopian @jasonthomas 