### PR TITLE
BUG 1196293 : Remove rating stars from edit review reply

### DIFF
--- a/apps/reviews/forms.py
+++ b/apps/reviews/forms.py
@@ -22,12 +22,12 @@ class ReviewReplyForm(forms.Form):
         required=False,
         label="Title",
         widget=forms.TextInput(
-            attrs={'id':'id_review_reply_title'},
+            attrs={'id': 'id_review_reply_title', },
         ),
     )
     body = forms.CharField(
         widget=forms.Textarea(
-            attrs={'rows': 3, 'id':'id_review_reply_body'},
+            attrs={'rows': 3, 'id': 'id_review_reply_body', },
         ),
         label="Review",
     )
@@ -48,12 +48,12 @@ class ReviewForm(ReviewReplyForm):
         required=False,
         label="Title",
         widget=forms.TextInput(
-            attrs={'id':'id_review_title'},
+            attrs={'id': 'id_review_title', },
         ),
     )
     body = forms.CharField(
         widget=forms.Textarea(
-            attrs={'rows': 3, 'id':'id_review_body'},
+            attrs={'rows': 3, 'id': 'id_review_body', },
         ),
         label="Review",
     )

--- a/apps/reviews/forms.py
+++ b/apps/reviews/forms.py
@@ -18,9 +18,11 @@ from editors.models import ReviewerScore
 
 
 class ReviewReplyForm(forms.Form):
+    form_id = "review-reply-edit"
+
     title = forms.CharField(
         required=False,
-        label="Title",
+        label=_lazy(u"Title"),
         widget=forms.TextInput(
             attrs={'id': 'id_review_reply_title', },
         ),
@@ -39,14 +41,13 @@ class ReviewReplyForm(forms.Form):
             raise_required()
         return body
 
-    def form_id(self):
-        return "review-reply-edit"
-
 
 class ReviewForm(ReviewReplyForm):
+    form_id = "review-edit"
+
     title = forms.CharField(
         required=False,
-        label="Title",
+        label=_lazy(u"Title"),
         widget=forms.TextInput(
             attrs={'id': 'id_review_title', },
         ),
@@ -57,7 +58,9 @@ class ReviewForm(ReviewReplyForm):
         ),
         label="Review",
     )
-    rating = forms.ChoiceField(zip(range(1, 6), range(1, 6)), label="Rating")
+    rating = forms.ChoiceField(
+        zip(range(1, 6), range(1, 6)), label=_lazy(u"Rating")
+    )
     flags = re.I | re.L | re.U | re.M
     # This matches the following three types of patterns:
     # http://... or https://..., generic domain names, and IPv4
@@ -76,9 +79,6 @@ class ReviewForm(ReviewReplyForm):
         if self.link_pattern.search(data) is not None:
             self.cleaned_data['flag'] = True
             self.cleaned_data['editorreview'] = True
-
-    def form_id(self):
-        return "review-edit"
 
 
 class ReviewFlagForm(forms.ModelForm):

--- a/apps/reviews/forms.py
+++ b/apps/reviews/forms.py
@@ -18,8 +18,19 @@ from editors.models import ReviewerScore
 
 
 class ReviewReplyForm(forms.Form):
-    title = forms.CharField(required=False)
-    body = forms.CharField(widget=forms.Textarea(attrs={'rows': 3}))
+    title = forms.CharField(
+        required=False,
+        label="Title",
+        widget=forms.TextInput(
+            attrs={'id':'id_review_reply_title'},
+        ),
+    )
+    body = forms.CharField(
+        widget=forms.Textarea(
+            attrs={'rows': 3, 'id':'id_review_reply_body'},
+        ),
+        label="Review",
+    )
 
     def clean_body(self):
         body = self.cleaned_data.get('body', '')
@@ -28,9 +39,25 @@ class ReviewReplyForm(forms.Form):
             raise_required()
         return body
 
+    def form_id(self):
+        return "review-reply-edit"
+
 
 class ReviewForm(ReviewReplyForm):
-    rating = forms.ChoiceField(zip(range(1, 6), range(1, 6)))
+    title = forms.CharField(
+        required=False,
+        label="Title",
+        widget=forms.TextInput(
+            attrs={'id':'id_review_title'},
+        ),
+    )
+    body = forms.CharField(
+        widget=forms.Textarea(
+            attrs={'rows': 3, 'id':'id_review_body'},
+        ),
+        label="Review",
+    )
+    rating = forms.ChoiceField(zip(range(1, 6), range(1, 6)), label="Rating")
     flags = re.I | re.L | re.U | re.M
     # This matches the following three types of patterns:
     # http://... or https://..., generic domain names, and IPv4
@@ -49,6 +76,9 @@ class ReviewForm(ReviewReplyForm):
         if self.link_pattern.search(data) is not None:
             self.cleaned_data['flag'] = True
             self.cleaned_data['editorreview'] = True
+
+    def form_id(self):
+        return "review-edit"
 
 
 class ReviewFlagForm(forms.ModelForm):

--- a/apps/reviews/helpers.py
+++ b/apps/reviews/helpers.py
@@ -61,6 +61,15 @@ def edit_review_form(context):
     return c
 
 
+@jingo.register.inclusion_tag('reviews/edit_review.html')
+@jinja2.contextfunction
+def edit_review_reply_form(context):
+    c = dict(context.items())
+    c.update(form=forms.ReviewReplyForm())
+    return c
+
+
+
 def user_can_delete_review(request, review):
     """Return whether or not the request.user can delete reviews.
 

--- a/apps/reviews/helpers.py
+++ b/apps/reviews/helpers.py
@@ -69,7 +69,6 @@ def edit_review_reply_form(context):
     return c
 
 
-
 def user_can_delete_review(request, review):
     """Return whether or not the request.user can delete reviews.
 

--- a/apps/reviews/templates/reviews/edit_review.html
+++ b/apps/reviews/templates/reviews/edit_review.html
@@ -1,19 +1,19 @@
 {% from "includes/forms.html" import pretty_field, required_note %}
 <div class="hidden">
-  <form method="post" id="{{ form.form_id() }}-form" action="#"
+  <form method="post" id="{{ form.form_id }}-form" action="#"
         class="review article review-form prettyform">
     {{ csrf() }}
     <fieldset>
       <ul>
         {% for field in form %}
-        {{ pretty_field(field, _(field.label)) }}
+        {{ pretty_field(field, field.label) }}
         {% endfor %}
       </ul>
     </fieldset>
     <footer>
       {{ required_note() }}
-      <input id="{{ form.form_id() }}-submit" type="submit" value="{{ _('Submit review') }}">
-       {{ _('or') }} <a href="#" id="{{ form.form_id() }}-cancel">{{ _('Cancel') }}</a>
+      <input id="{{ form.form_id }}-submit" type="submit" value="{{ _('Submit review') }}">
+       {{ _('or') }} <a href="#" id="{{ form.form_id }}-cancel">{{ _('Cancel') }}</a>
     </footer>
   </form>
 </div>

--- a/apps/reviews/templates/reviews/edit_review.html
+++ b/apps/reviews/templates/reviews/edit_review.html
@@ -1,19 +1,19 @@
 {% from "includes/forms.html" import pretty_field, required_note %}
 <div class="hidden">
-  <form method="post" id="review-edit-form" action="#"
+  <form method="post" id="{{ form.form_id() }}-form" action="#"
         class="review article review-form prettyform">
     {{ csrf() }}
     <fieldset>
       <ul>
-        {{ pretty_field(form.title, _('Title')) }}
-        {{ pretty_field(form.rating, _('Rating')) }}
-        {{ pretty_field(form.body, _('Review')) }}
+        {% for field in form %}
+        {{ pretty_field(field, _(field.label)) }}
+        {% endfor %}
       </ul>
     </fieldset>
     <footer>
       {{ required_note() }}
-      <input type="submit" value="{{ _('Submit review') }}">
-       {{ _('or') }} <a href="#" id="review-edit-cancel">{{ _('Cancel') }}</a>
+      <input id="{{ form.form_id() }}-submit" type="submit" value="{{ _('Submit review') }}">
+       {{ _('or') }} <a href="#" id="{{ form.form_id() }}-cancel">{{ _('Cancel') }}</a>
     </footer>
   </form>
 </div>

--- a/apps/reviews/templates/reviews/review.html
+++ b/apps/reviews/templates/reviews/review.html
@@ -85,7 +85,7 @@
     {% if review.user_id == request.user.id %}
       {% if is_reply %}
         <li>
-          <a class="review-edit" href="#">
+          <a class="review-reply-edit" href="#">
             {{ _('Edit reply') }}</a>
         </li>
       {% else %}

--- a/apps/reviews/templates/reviews/review_list.html
+++ b/apps/reviews/templates/reviews/review_list.html
@@ -95,6 +95,7 @@
     {{ reviews|impala_paginator }}
     {% endblock review_list %}
     {{ edit_review_form() }}
+    {{ edit_review_reply_form() }}
   </div>
   {{ report_review_popup() }}
 {% endblock content %}

--- a/apps/reviews/tests/test_views.py
+++ b/apps/reviews/tests/test_views.py
@@ -135,7 +135,7 @@ class TestViews(ReviewTest):
         actions = item.find('.item-actions')
         eq_(actions.length, 1)
         classes = sorted(c.get('class') for c in actions.find('li a'))
-        eq_(classes, ['delete-review', 'review-edit'])
+        eq_(classes, ['delete-review', 'review-reply-edit'])
 
     def test_cant_view_unlisted_addon_reviews(self):
         """An unlisted addon doesn't have reviews."""
@@ -420,7 +420,7 @@ class TestEdit(ReviewTest):
         response = self.client.get(helpers.url('addons.reviews.list',
                                    self.addon.slug))
         doc = pq(response.content)
-        assert doc('#review-218468 .review-edit').text() == 'Edit reply'
+        assert doc('#review-218468 .review-reply-edit').text() == 'Edit reply'
 
 
 class TestTranslate(ReviewTest):

--- a/static/js/impala/reviews.js
+++ b/static/js/impala/reviews.js
@@ -56,75 +56,93 @@ $(document).ready(function() {
         }
     });
 
-    $('.primary').delegate('.review-edit', 'click', function(e) {
-        e.preventDefault();
-        var $form = $('#review-edit-form'),
-            $review = $(this).closest('.review'),
-            rating = $review.attr('data-rating'),
-            edit_url = $('a.permalink', $review).attr('href') + 'edit',
-            $cancel = $('#review-edit-cancel'),
-            title_selector;
+    // A review comment can either be a review or a review reply
+    function review_comment_edit_click(comment_form_id, comment_title_widget_id, comment_body_widget_id, comment_cancel_btn_id) {
+        return function(e) {
+            e.preventDefault();
+            var $form = $('#' + comment_form_id),
+                $review = $(this).closest('.review'),
+                edit_url = $('a.permalink', $review).attr('href') + 'edit',
+                $cancel = $('#' + comment_cancel_btn_id),
+                title_selector;
 
-        clearErrors($form);
-        $form.unbind().hide();
-        $('.review').not($review).show();
-        $form.detach().insertAfter($review);
-
-        if ($review.find('h4').length) {
-            $form.find('fieldset h3').remove();
-            title_selector = 'h4 > b';
-            $form.find('fieldset').prepend($review.find('h3').clone());
-        } else {
-            title_selector = 'h3 > b';
-        }
-
-        $form.find('#id_title').val($review.find(title_selector).text());
-        $form.find('.ratingwidget input:radio[value=' + rating + ']').click();
-        $form.find('#id_body').val($review.children('p.description').html().replace(/<br>/g, '\n'));
-        $review.hide();
-        $form.show();
-        $window.resize();
-        location.hash = '#review-edit-form';
-
-        function done_edit() {
             clearErrors($form);
             $form.unbind().hide();
-            $review.show();
-            $cancel.unbind();
+            $('.review').not($review).show();
+            $form.detach().insertAfter($review);
+
+            if ($review.find('h4').length) {
+                $form.find('fieldset h3').remove();
+                title_selector = 'h4 > b';
+                $form.find('fieldset').prepend($review.find('h3').clone());
+            } else {
+                title_selector = 'h3 > b';
+            }
+
+            $form.find('#' + comment_title_widget_id).val($review.find(title_selector).text());
+            $form.find('#' + comment_body_widget_id).val($review.children('p.description').html().replace(/<br>/g, '\n'));
+            $review.hide();
+            $form.show();
             $window.resize();
-        }
+            location.hash = '#' + comment_form_id;
 
-        $cancel.click(_pd(done_edit));
+            function done_edit() {
+                clearErrors($form);
+                $form.unbind().hide();
+                $review.show();
+                $cancel.unbind();
+                $window.resize();
+            }
 
-        $form.submit(function (e) {
-            e.preventDefault();
-            $.ajax({type: 'POST',
-                url: edit_url,
-                data: $form.serialize(),
-                success: function(response, status) {
-                    clearErrors($form);
-                    $review.find(title_selector).text($form.find('#id_title').val());
-                    var rating = $form.find('.ratingwidget input:radio:checked').val();
-                    $('.stars', $review).removeClass('stars-0 stars-1 stars-2 stars-3 stars-4 stars-5').addClass('stars-' + rating);
-                    rating = $review.attr('data-rating', rating);
-                    $review.children('p.description').html(
-                        $form.find('#id_body').val()
-                             .replace(/&/g,'&amp;')
-                             .replace(/</g,'&lt;')
-                             .replace(/>/g,'&gt;')
-                             .replace(/\n/g, '<br>'));
-                    done_edit();
-                },
-                error: function(xhr) {
-                    var errors = $.parseJSON(xhr.responseText);
-                    populateErrors($form, errors);
-                },
-                dataType: 'json'
+            $cancel.click(_pd(done_edit));
+
+            $form.submit(function (e) {
+                e.preventDefault();
+                $.ajax({type: 'POST',
+                    url: edit_url,
+                    data: $form.serialize(),
+                    success: function(response, status) {
+                        clearErrors($form);
+                        $review.find(title_selector).text($form.find('#' + comment_title_widget_id).val());
+                        var rating = $form.find('.ratingwidget input:radio:checked').val();
+                        $('.stars', $review).removeClass('stars-0 stars-1 stars-2 stars-3 stars-4 stars-5').addClass('stars-' + rating);
+                        rating = $review.attr('data-rating', rating);
+                        $review.children('p.description').html(
+                            $form.find('#' + comment_body_widget_id).val()
+                                .replace(/&/g,'&amp;')
+                                .replace(/</g,'&lt;')
+                                .replace(/>/g,'&gt;')
+                                .replace(/\n/g, '<br>'));
+                        done_edit();
+                    },
+                    error: function(xhr) {
+                        var errors = $.parseJSON(xhr.responseText);
+                        populateErrors($form, errors);
+                    },
+                    dataType: 'json'
+                });
+                return false;
             });
-            return false;
-        });
-    });
+        }
+    }
 
+    $('.primary').delegate('.review-reply-edit', 'click',
+        review_comment_edit_click(
+            'review-reply-edit-form',
+            'id_review_reply_title',
+            'id_review_reply_body',
+            'review-reply-edit-cancel'
+        )
+    );
+
+    $('.primary').delegate('.review-edit', 'click',
+        review_comment_edit_click(
+            'review-edit-form',
+            'id_review_title',
+            'id_review_body',
+            'review-edit-cancel'
+        )
+    );
 
     $('.delete-review').click(function(e) {
         e.preventDefault();

--- a/static/js/impala/reviews.js
+++ b/static/js/impala/reviews.js
@@ -98,7 +98,8 @@ $(document).ready(function() {
 
             $form.submit(function (e) {
                 e.preventDefault();
-                $.ajax({type: 'POST',
+                $.ajax({
+                    type: 'POST',
                     url: edit_url,
                     data: $form.serialize(),
                     success: function(response, status) {


### PR DESCRIPTION
Includes refactoring.

ReviewReplyForm is now used for editing review replies instead of ReviewForm. ReviewReplyForm does not have stars; ReviewForm does.

This pull request now renders both forms on the HTML page (a reply form and a regular review form).

I had to make some tweaks in order to allow for this:

* The form element IDs are specified/changed so that they do not clash with one another.
* The javascript has been amended to use a parameterized form of the original 'click' function to display either form. It is parameterized so that different form & field IDs can be passed in depending on whether it is a review reply form or the review form is used.

This still isn't as clean as I would like, but under the constraints it's a start.

The above changes were tested using two hitch tests (one for adding/editing reviews and one for adding/editing replies) which will follow in another pull request.