### PR TITLE
Search box text overflows as ellipsis (bug 1196711)

### DIFF
--- a/static/css/impala/header.less
+++ b/static/css/impala/header.less
@@ -433,6 +433,7 @@ button.search-button {
     .box-shadow(0 0 2px rgba(0, 0, 0, 0.4) inset);
     float: left;
     font: 14px @head-sans;
+    text-overflow: ellipsis;
     padding: 6px 6px 6px 32px;
     .width-calc(~'100% - 42px', 238px);
 }


### PR DESCRIPTION
Was:
<img width="327" alt="screen shot 2015-09-08 at 7 18 18 pm" src="https://cloud.githubusercontent.com/assets/2600677/9749774/582250d0-565e-11e5-891d-214e466e4fe6.png">

Now is:
<img width="335" alt="screen shot 2015-09-08 at 7 17 24 pm" src="https://cloud.githubusercontent.com/assets/2600677/9749766/38390340-565e-11e5-9d7c-276ddc6d62a1.png">
