### PR TITLE
Truncate add-on GUID when posting to signing endpoint (bug 1202880)

### DIFF
--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -70,7 +70,8 @@ def call_signing(file_obj, endpoint):
         response = requests.post(
             endpoint,
             timeout=settings.SIGNING_SERVER_TIMEOUT,
-            data={'addon_id': file_obj.version.addon.guid},
+            # We don't want GUIDs longer than 64 chars: bug 1202880.
+            data={'addon_id': file_obj.version.addon.guid[:64]},
             files={'file': (u'mozilla.sf', unicode(jar.signatures))})
     if response.status_code != 200:
         msg = u'Posting to add-on signing failed: {0}'.format(response.reason)

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -47,12 +47,17 @@ class TestPackaged(amo.tests.TestCase):
     @pytest.fixture(autouse=True)
     def mock_post(self, monkeypatch):
         """Fake a standard trunion response."""
+        self.requests_post_calls = []
+
         class FakeResponse:
             status_code = 200
             content = '{"mozilla.rsa": ""}'
 
-        monkeypatch.setattr(
-            'requests.post', lambda url, timeout, data, files: FakeResponse)
+        def mock_post_call(url, timeout, data, files):
+            self.requests_post_calls.append((url, timeout, data, files))
+            return FakeResponse
+
+        monkeypatch.setattr('requests.post', mock_post_call)
 
     @pytest.fixture(autouse=True)
     def mock_get_signature_serial_number(self, monkeypatch):
@@ -65,12 +70,14 @@ class TestPackaged(amo.tests.TestCase):
         assert not self.file_.cert_serial_num
         assert not self.file_.hash
         assert not packaged.is_signed(self.file_.file_path)
+        assert not self.requests_post_calls
 
     def assert_signed(self):
         assert self.file_.is_signed
         assert self.file_.cert_serial_num
         assert self.file_.hash
         assert packaged.is_signed(self.file_.file_path)
+        assert len(self.requests_post_calls) == 1
 
     def test_supports_firefox_old_not_default_to_compatible(self):
         max_appversion = self.version.apps.first().max
@@ -204,6 +211,29 @@ class TestPackaged(amo.tests.TestCase):
                     os.path.join(folder, 'random_theme.xpi'))
             finally:
                 amo.utils.rm_local_tmp_dir(folder)
+
+    def test_call_signing(self):
+        packaged.call_signing(self.file_, 'endpoint_url')
+        assert self.requests_post_calls == [
+            ('endpoint_url',
+             settings.SIGNING_SERVER_TIMEOUT,
+             {'addon_id': 'xxxxx'},
+             {'file': (u'mozilla.sf',
+                       u'Signature-Version: 1.0\nMD5-Digest-Manifest: '
+                       u'//axi91xGZwlaVjKiw9xuw==\nSHA1-Digest-Manifest: '
+                       u'ep9V9fWlCso0PZUcnM60watGvrM=\n\n')})]
+
+    def test_call_signing_too_long_guid_bug_1202880(self):
+        self.addon.update(guid='x' * 65)
+        packaged.call_signing(self.file_, 'endpoint_url')
+        assert self.requests_post_calls == [
+            ('endpoint_url',
+             settings.SIGNING_SERVER_TIMEOUT,
+             {'addon_id': 'x' * 64},  # Truncated to 64 chars.
+             {'file': (u'mozilla.sf',
+                       u'Signature-Version: 1.0\nMD5-Digest-Manifest: '
+                       u'//axi91xGZwlaVjKiw9xuw==\nSHA1-Digest-Manifest: '
+                       u'ep9V9fWlCso0PZUcnM60watGvrM=\n\n')})]
 
 
 class TestTasks(amo.tests.TestCase):


### PR DESCRIPTION
Fixes [bug 1202880](https://bugzilla.mozilla.org/show_bug.cgi?id=1202880)