### PR TITLE
Shows announcement tab on all admin pages (bug 1196720)

### DIFF
--- a/apps/editors/templates/editors/base.html
+++ b/apps/editors/templates/editors/base.html
@@ -82,7 +82,7 @@
           {{ _('Signed Beta Files Log') }}</a></li>
       </ul>
     </li>
-    {% if is_admin %}
+    {% if motd_editable %}
       <li class="top">
         <a href="{{ url('editors.motd') }}" class="controller">{{ _('Announcement') }}</a>
       </li>


### PR DESCRIPTION
The issue was that not all views related to tabs were adding `is_admin` to the context of the template, and since the announcement tab was wrapped in `if is_admin:` it wasn't showing on some pages. This PR corrects that.