### PR TITLE
Removed redundant install development version link (bug 1197712)

### DIFF
--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -273,7 +273,6 @@
             stop receiving development updates, reinstall the default version from the link
             above.
           {% endtrans %}
-          <a href="#install-beta">{{ _('Install development version') }}</a>
         </p>
         <div class="install-beta" id="install-beta">
           <p>


### PR DESCRIPTION
was:
<img width="700" alt="screen shot 2015-09-10 at 2 25 11 pm" src="https://cloud.githubusercontent.com/assets/2600677/9797187/e88ffdc4-57c7-11e5-9a49-42caff0543ea.png">
Now is:
<img width="692" alt="screen shot 2015-09-10 at 2 24 54 pm" src="https://cloud.githubusercontent.com/assets/2600677/9797193/ee2a3416-57c7-11e5-87f2-1e2602dccbb2.png">
From what I could tell from the bug description it looks like this link was pretty much pointless due to the "Add to Firefox" button below it so I removed it. 