### PR TITLE
review pop-up has title and removed detail link (bug 1203116)

### DIFF
--- a/apps/addons/templates/addons/impala/review_add_box.html
+++ b/apps/addons/templates/addons/impala/review_add_box.html
@@ -16,6 +16,7 @@
     <form method="post" action="{{ url('addons.reviews.add', addon.slug) }}">
       {% set attrs = {} if user.is_authenticated() else {'disabled': 'disabled'} %}
       {{ csrf() }}
+      {{ field(review_form.title, _('Title:'), **attrs) }}
       {{ field(review_form.body, _('Review:'), **attrs) }}
       {{ field(review_form.rating, _('Rating:'), **attrs) }}
       <p><input type="submit" value="{{ _('Submit review') }}" {{ attrs|xmlattr }}></p>
@@ -40,10 +41,6 @@
         </p>
       {% endif %}
       <p><a href="{{ remora_url('/pages/review_guide') }}" target="_blank">{{ _('Review Guidelines') }}</a></p>
-      <p>
-        <a href="{{ url('addons.reviews.add', addon.slug) }}"
-           id="detail-review-link">{{ _('Detailed Review') }}</a>
-      </p>
     </div>
 
   </div>{# /#review-box #}

--- a/apps/addons/templates/addons/review_add_box.html
+++ b/apps/addons/templates/addons/review_add_box.html
@@ -14,6 +14,7 @@
     <form disabled method="post" action="{{ url('addons.reviews.add', addon.slug) }}">
       {% set attrs = {} if user.is_authenticated() else {'disabled': 'disabled'} %}
       {{ csrf() }}
+      {{ field(review_form.title, _('Title:'), **attrs) }}
       {{ field(review_form.body, _('Review:'), **attrs) }}
       {{ field(review_form.rating, _('Rating:'), **attrs) }}
       <input type="submit" value="{{ _('Submit review') }}" {{ attrs|xmlattr }}>
@@ -36,10 +37,6 @@
       </p>
       {% endif %}
       <p><a href="{{ remora_url('/pages/review_guide') }}" target="_blank">{{ _('Review Guidelines') }}</a></p>
-      <p>
-        <a href="{{ url('addons.reviews.add', addon.slug) }}">
-          {{ _('Detailed Review') }}</a>
-      </p>
     </div>
 
   </div>{# /#review-box #}

--- a/apps/addons/tests/test_views.py
+++ b/apps/addons/tests/test_views.py
@@ -755,14 +755,6 @@ class TestDetailPage(amo.tests.TestCase):
         response = self.client.get(self.url)
         eq_(response.status_code, 404)
 
-    def test_detailed_review_link(self):
-        self.client.login(username='regular@mozilla.com', password='password')
-        r = self.client.get(reverse('addons.detail', args=['a3615']))
-        doc = pq(r.content)
-        href = doc('#review-box a[href*="reviews/add"]').attr('href')
-        assert href.endswith(reverse('addons.reviews.add', args=['a3615'])), (
-            href)
-
     def test_no_listed_authors(self):
         r = self.client.get(reverse('addons.detail', args=['a59']))
         # We shouldn't show an avatar since this has no listed_authors.

--- a/static/css/impala/reviews.less
+++ b/static/css/impala/reviews.less
@@ -270,10 +270,16 @@
 
     form {
         width: 50%;
-        height: 212px;
+        height: 260px;
         float: left;
         padding: 0 10px 0 0;
         margin-right: 1em;
+
+        input[type="text"] {
+           width: 100%;
+           font-size: 16px;
+           box-sizing: border-box;
+        }
     }
     textarea {
         height: 100px;


### PR DESCRIPTION
Was:
<img width="623" alt="screen shot 2015-09-10 at 3 40 57 pm" src="https://cloud.githubusercontent.com/assets/2600677/9798964/5cdb5b60-57d2-11e5-9ae9-d1e5d75d689f.png">
Now is:
<img width="625" alt="screen shot 2015-09-10 at 3 40 38 pm" src="https://cloud.githubusercontent.com/assets/2600677/9798968/62435a6c-57d2-11e5-9436-d8b39718fb5d.png">
Title seems to appear in the comment when filled in the review form box. 