### PR TITLE
Clear has_info_request on whiteboard and developer_comments (bug 1117329)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1596,6 +1596,19 @@ def watch_disabled(old_attr={}, new_attr={}, instance=None, sender=None, **kw):
             f.hide_disabled_file()
 
 
+@Addon.on_change
+def watch_developer_notes(old_attr={}, new_attr={}, instance=None, sender=None,
+                          **kw):
+    whiteboard_changed = (
+        new_attr.get('whiteboard') and
+        old_attr.get('whiteboard') != new_attr.get('whiteboard'))
+    developer_comments_changed = (new_attr.get('_developer_comments_cache') and
+                                  old_attr.get('_developer_comments_cache') !=
+                                  new_attr.get('_developer_comments_cache'))
+    if whiteboard_changed or developer_comments_changed:
+        instance.versions.update(has_info_request=False)
+
+
 def attach_categories(addons):
     """Put all of the add-on's categories into a category_ids list."""
     addon_dict = dict((a.id, a) for a in addons)

--- a/apps/editors/forms.py
+++ b/apps/editors/forms.py
@@ -269,6 +269,8 @@ class ReviewAddonForm(happyforms.Form):
                                             'email)'))
     adminflag = forms.BooleanField(required=False,
                                    label=_lazy(u'Clear Admin Review Flag'))
+    clear_info_request = forms.BooleanField(
+        required=False, label=_lazy(u'Clear more info requested flag'))
 
     def is_valid(self):
         result = super(ReviewAddonForm, self).is_valid()

--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -663,7 +663,10 @@ class ReviewBase(object):
                   Context(self.get_context_data()))
 
     def process_comment(self):
-        self.version.update(has_editor_comment=True)
+        kw = {'has_editor_comment': True}
+        if self.data.get('clear_info_request'):
+            kw['has_info_request'] = False
+        self.version.update(**kw)
         self.log_action(amo.LOG.COMMENT_VERSION)
 
 

--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -210,6 +210,15 @@
         {{ form.adminflag.errors }}
       </div>
       {% endif %}
+      {% if version.has_info_request %}
+      <div class="review-actions-section">
+        {{ form.clear_info_request }}
+        <label for="{{ form.clear_info_request.auto_id }}">
+          {{ form.clear_info_request.label }}
+        </label>
+        {{ form.clear_info_request.errors }}
+      </div>
+      {% endif %}
       <div class="review-actions-section review-actions-save">
         <span class="currently_viewing_warning">
           {% trans %}

--- a/apps/editors/tests/test_helpers.py
+++ b/apps/editors/tests/test_helpers.py
@@ -243,6 +243,21 @@ class TestReviewHelper(amo.tests.TestCase):
         self.helper.process()
         eq_(len(mail.outbox), 1)
 
+    def test_clear_has_info_request(self):
+        self.version.update(has_info_request=True)
+        assert self.version.has_info_request
+        self.helper.set_data({'action': 'comment', 'comments': 'foo',
+                              'clear_info_request': True})
+        self.helper.process()
+        assert not self.version.has_info_request
+
+    def test_do_not_clear_has_info_request(self):
+        self.version.update(has_info_request=True)
+        assert self.version.has_info_request
+        self.helper.set_data({'action': 'comment', 'comments': 'foo'})
+        self.helper.process()
+        assert self.version.has_info_request
+
     def test_action_details(self):
         for status in Addon.STATUS_CHOICES:
             self.addon.update(status=status)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1117329

This clears the `has_info_request` flag when the addon's `whiteboard` or `developer_comments` are updated`. Still need to check on new version upload and source package upload but those might be working already.