### PR TITLE
Allow add-ons with long GUIDs with the allow-long-addon-guid waffle switch (bug 1203915)

### DIFF
--- a/apps/devhub/tests/test_views_validation.py
+++ b/apps/devhub/tests/test_views_validation.py
@@ -99,6 +99,14 @@ class TestUploadErrors(BaseUploadTest):
         expected = 'Add-on ID must be 64 characters or less.'
         assert exc.exception.message == expected
 
+    def test_long_uuid(self):
+        """An add-on uuid may be more than 64 chars, see bug 1203915."""
+        self.create_switch('allow-long-addon-guid')
+        long_guid = (u'this_guid_is_longer_than_the_limit_of_64_chars_see_'
+                     u'bug_1201176_but_should_not_fail_see_bug_1203915@xpi')
+        xpi_info = check_xpi_info({'guid': long_guid, 'version': '1.0'})
+        assert xpi_info['guid'] == long_guid
+
 
 class TestFileValidation(amo.tests.TestCase):
     fixtures = ['base/users', 'devhub/addon-validation-1']

--- a/apps/files/utils.py
+++ b/apps/files/utils.py
@@ -23,6 +23,7 @@ from django.core.cache import cache
 from django.core.files.storage import default_storage as storage
 
 import rdflib
+import waffle
 from tower import ugettext as _
 
 import amo
@@ -459,7 +460,7 @@ def check_xpi_info(xpi_info, addon=None):
     guid = xpi_info['guid']
     if not guid:
         raise forms.ValidationError(_("Could not find an add-on ID."))
-    if len(guid) > 64:
+    if not waffle.switch_is_active('allow-long-addon-guid') and len(guid) > 64:
         raise forms.ValidationError(
             _("Add-on ID must be 64 characters or less."))
     if addon and addon.guid != guid:

--- a/migrations/828-allow-long-addon-guid-switch.sql
+++ b/migrations/828-allow-long-addon-guid-switch.sql
@@ -1,0 +1,4 @@
+INSERT INTO
+    waffle_switch (name, active, created, modified, note)
+VALUES
+    ('allow-long-addon-guid', 0, NOW(), NOW(), 'Allow submission of add-ons with a GUID longer than 64 chars (bug 1203915)');


### PR DESCRIPTION
Fixes [bug 1203915](https://bugzilla.mozilla.org/show_bug.cgi?id=1203915)