### PR TITLE
Fix tests that require sasl on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mozillamarketplace/centos-mysql-mkt:0.2
 
 # Fix multilib issues when installing openssl-devel.
-RUN yum install -y --enablerepo=centosplus libselinux-devel
+RUN yum install -y --enablerepo=centosplus libselinux-devel && yum clean all
 
 ADD docker-mysql.repo /etc/yum.repos.d/mysql.repo
 
@@ -20,12 +20,16 @@ RUN yum update -y \
 
 # The version in the above image is ancient, and does not support the
 # --no-binary flag used in our requirements files.
-RUN pip install -U pip
+# We also need to install wheels.
+RUN pip install -U pip wheel
 
 COPY requirements /pip/requirements/
 RUN cd /pip && \
     pip install --build ./build --cache-dir ./cache \
-	--no-deps -r requirements/docker.txt && \
+        --find-links https://pyrepo.addons.mozilla.org/wheelhouse/ \
+        --find-links https://pyrepo.addons.mozilla.org/ \
+        --no-index --no-deps \
+        -r requirements/docker.txt && \
     rm -r build cache
 
 RUN mkdir /code


### PR DESCRIPTION
CentOS only supports glibc 2.12 but the sasl import was failing with:

    ImportError: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /opt/rh/python27/root/usr/lib64/python2.7/site-packages/_saslwrapper.so)

This patch will now fetch the wheel for CentOS which makes the test failures go away. To do this, the pip install command had to link to our Mozilla repo. This is better anyway since PyPI can go down and also poses some security concerns.

This patch also adds `&& yum clean` which saves a surprising amount of disk space in the image.