### PR TITLE
Disable selecting files for a review in the editor tools (bug 1197261)

### DIFF
--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -163,23 +163,18 @@
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle"
-           data-value="{{ actions_minimal|join("|") }}"{% if allow_unchecking_files %} data-uncheckable="1"{% endif %}>
+           data-value="{{ actions_minimal|join("|") }}">
         <label for="id_addon_files"><strong>{{ form.addon_files.label }}</strong></label>
         <ul>
             {% for pk, label in form.fields.get('addon_files').choices %}
             <li>
               <label for="file-{{ pk }}"{% if pk in form.addon_files_disabled %} class="light"{% endif %}>
-                <input id="file-{{ pk }}" type="checkbox" value="{{ pk }}" name="addon_files"
-                       {% if pk in form.addon_files_disabled %}disabled=""{% endif %} />
+                <input id="file-{{ pk }}" type="checkbox" value="{{ pk }}" name="addon_files" disabled checked />
                 {{ label }}
               </label>
             </li>
             {% endfor %}
         </ul>
-
-        <div id="review-actions-files-warning">
-          {{ _('Notice: Only review more than one file if you have tested <strong>every</strong> file you select.') }}
-        </div>
 
         {{ form.addon_files.errors }}
       </div>

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -2656,13 +2656,14 @@ class TestReviewPending(ReviewBase):
 
         assert mock_sign.called
 
-    def test_disabled_file(self):
+    def test_disabled_and_not_disabled_files_are_disabled(self):
+        """Files checkboxes aren't enabled, see bug 1197261."""
         obj = File.objects.create(version=self.version,
                                   status=amo.STATUS_DISABLED)
         response = self.client.get(self.url, self.pending_dict())
         doc = pq(response.content)
         assert 'disabled' in doc('#file-%s' % obj.pk)[0].keys()
-        assert 'disabled' not in doc('#file-%s' % self.file.pk)[0].keys()
+        assert 'disabled' in doc('#file-%s' % self.file.pk)[0].keys()
 
 
 class TestEditorMOTD(EditorTest):

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -604,9 +604,6 @@ def review(request, addon):
     # The actions we should show a minimal form from.
     actions_minimal = [k for (k, a) in actions if not a.get('minimal')]
 
-    # We only allow the user to check/uncheck files for "pending"
-    allow_unchecking_files = form.helper.review_type == "pending"
-
     versions = (Version.objects.filter(addon=addon)
                                .exclude(files__status=amo.STATUS_BETA)
                                .order_by('-created')
@@ -671,7 +668,6 @@ def review(request, addon):
                   pager=pager, num_pages=num_pages, count=count, flags=flags,
                   form=form, canned=canned, is_admin=is_admin,
                   show_diff=show_diff,
-                  allow_unchecking_files=allow_unchecking_files,
                   actions=actions, actions_minimal=actions_minimal,
                   whiteboard_form=forms.WhiteboardForm(instance=addon),
                   user_changes=user_changes_log,

--- a/static/css/zamboni/editors.styl
+++ b/static/css/zamboni/editors.styl
@@ -822,10 +822,6 @@ div.editor-stats-table > div.editor-stats-dark {
     border-bottom: 1px solid #A5BFCE;
 }
 
-#review-actions-files-warning {
-    color: #B47100;
-}
-
 .review-actions-canned {
     text-align: right;
 }

--- a/static/js/zamboni/editors.js
+++ b/static/js/zamboni/editors.js
@@ -78,8 +78,6 @@ function initReviewActions() {
         $data_toggle.hide();
         $data_toggle.filter('[data-value*="' + value + '"]').show();
 
-        toggle_input();
-
         /* Fade out canned responses */
         var label = $element.text().trim();
         groups.css('color', '#AAA');
@@ -99,28 +97,6 @@ function initReviewActions() {
     if(review_checked.length > 0) {
       showForm(review_checked.closest('li'), true);
     }
-
-    /* File checkboxes */
-    var $files_input = $('#review-actions .review-actions-files').find('input:enabled');
-
-    if($files_input.length == 1 || ! $('#review-actions .review-actions-files').attr('data-uncheckable')) {
-        // Add a dummy, disabled input
-        $files_input.prop('checked', true).hide();
-        $files_input.after($('<input>', {'type': 'checkbox', 'checked': true, 'disabled': true}));
-    }
-
-    function toggle_input(){
-        var $files_input = $('#review-actions .review-actions-files').find('input:enabled'),
-            $files_checked = $files_input.filter(':checked'),
-            disable_submit = $files_checked.length < 1 && $('.review-actions-files').is(':visible');
-
-        $('.review-actions-save input').prop('disabled', disable_submit);
-
-        // If it's not :visible, we can assume it's been replaced with a dummy :disabled input
-        $('#review-actions-files-warning').toggle($files_checked.filter(':enabled:visible').length > 1);
-    }
-
-    $files_input.change(toggle_input).each(toggle_input);
 
     /* Install Triggers */
 


### PR DESCRIPTION
Fixes [bug 1197261](https://bugzilla.mozilla.org/show_bug.cgi?id=1197261) (again)