### PR TITLE
No longer use /wheelhouse from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN pip install -U pip wheel
 COPY requirements /pip/requirements/
 RUN cd /pip && \
     pip install --build ./build --cache-dir ./cache \
-        --find-links https://pyrepo.addons.mozilla.org/wheelhouse/ \
         --find-links https://pyrepo.addons.mozilla.org/ \
         --no-index --no-deps \
         -r requirements/docker.txt && \


### PR DESCRIPTION
This fixes a regression from https://github.com/mozilla/olympia/pull/743

For some reason, m2crypto was not getting installed right when the /wheelhouse wheel was used.