### PR TITLE
track stats about addon/file status values

### DIFF
--- a/apps/amo/models.py
+++ b/apps/amo/models.py
@@ -240,6 +240,11 @@ class OnChangeMixin(object):
                     new_instance.save(_signal=False)
             TheModel.on_change(watch_status)
 
+        ``old_atr`` will be a dict of the old instance attributes.
+        ``new_attr`` will be a dict of the new instance attributes, including
+        any that had not been changed by the operation that triggered the
+        callback (such as an update only of one field).
+
         .. note::
 
             Any call to instance.save() or instance.update() within a callback


### PR DESCRIPTION
This begins to address some stats needed like:
* how many addons have been submitted?
* how many addons are waiting for review?