### PR TITLE
Add --noinput parameter for ES wipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ populate_data:
 	python manage.py generate_addons --app android $(NUM_ADDONS)
 	python manage.py generate_addons --app seamonkey $(NUM_ADDONS)
 	python manage.py generate_themes $(NUM_THEMES)
-	python manage.py reindex --wipe --force
+	python manage.py reindex --wipe --force --noinput
 
 update_code:
 	git checkout master && git pull


### PR DESCRIPTION
This is needed so we don't fall over using docker: 

```
python manage.py reindex --wipe --force
14:06:19 py.warnings:WARNING /opt/rh/python27/root/usr/lib/python2.7/site-packages/celery/task/sets.py:23: CDeprecationWarning:
    celery.task.sets and TaskSet is deprecated and scheduled for removal in
    version 4.0. Please use "group" instead (see the Canvas section in the userguide)

  """)
 :/opt/rh/python27/root/usr/lib/python2.7/site-packages/celery/utils/__init__.py:93
Starting the reindexation
Are you sure you want to wipe all AMO Elasticsearch indexes? (yes/no): Traceback (most recent call last):
  File "manage.py", line 13, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/code/lib/es/management/commands/reindex.py", line 143, in handle
    confirm = raw_input('Are you sure you want to wipe all AMO '
EOFError
make[1]: *** [populate_data] Error 1
make[1]: Leaving directory `/code'
make: *** [initialize_docker] Error 2
```