### PR TITLE
Fixed styling regression on theme review (bug 1205267)

### DIFF
--- a/static/css/zamboni/zamboni.css
+++ b/static/css/zamboni/zamboni.css
@@ -2976,10 +2976,15 @@ h6.author, .author a {
 
 #review-box form {
     width: 48%;
-    height: 200px;
     float: left;
     padding: 0 10px 1em 0;
     margin-right: 1em;
+    margin-bottom: 0;
+}
+
+#review-box input {
+  box-sizing: border-box;
+  width: 100%;
 }
 
 #review-box textarea {


### PR DESCRIPTION
Was: 
<img width="656" alt="screen shot 2015-09-16 at 11 27 15 am" src="https://cloud.githubusercontent.com/assets/2600677/9909353/d7ab72f2-5c65-11e5-8c04-78a3b9e4de9c.png">


Now is:
<img width="650" alt="screen shot 2015-09-16 at 11 24 15 am" src="https://cloud.githubusercontent.com/assets/2600677/9909312/ad0b5792-5c65-11e5-9961-0e5c059d22d0.png">
