### PR TITLE
Set the locale to UTF8 to fix file system encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM mozillamarketplace/centos-mysql-mkt:0.2
 
+# Set the locale. This is mainly so that tests can write non-ascii files to
+# disk.
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
 # Fix multilib issues when installing openssl-devel.
 RUN yum install -y --enablerepo=centosplus libselinux-devel && yum clean all
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,6 +97,22 @@ persisted, and so won't survive after the container is finished.
     via the `Dockerfile`. Commits to master will result in the Dockerfile being
     rebuilt on the docker hub.
 
+Hacking on the Docker image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to test out changes to the Olympia Docker image locally, use the
+normal `Docker commands <https://docs.docker.com/reference/commandline/cli/>`_
+such as this to build a new image::
+
+    cd olympia
+    docker build -t addons/olympia .
+    docker-compose up -d
+
+After you've tested your new image, simply commit to master and the
+image will be published to Docker Hub for other developers to use after
+they pull image changes.
+
+
 Full Installation (deprecated)
 ------------------------------
 Using :ref:`Docker <install-with-docker>` is the recommended and


### PR DESCRIPTION
The main thing this fixes are a few failures in `lib/crypto/tests.py` which were the result of Python treating file system encoding as ASCII.