### PR TITLE
Remove 'side-load' from developer pages (bug 1186369)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -538,9 +538,10 @@ class NewAddonForm(AddonUploadForm):
     is_sideload = forms.BooleanField(
         initial=False,
         required=False,
-        label=_lazy(u'This add-on will be side-loaded via application '
-                    u'installers.'),
-        help_text=_lazy(u'Add-ons that are side-loaded will be code reviewed '
+        label=_lazy(u'This add-on will be bundled with an application '
+                    u'installer.'),
+        help_text=_lazy(u'Add-ons that are bundled with application '
+                        u'installers will be code reviewed '
                         u'by Mozilla before they are signed and are held to a '
                         u'higher quality standard.'))
 

--- a/apps/devhub/templates/devhub/includes/addon_details.html
+++ b/apps/devhub/templates/devhub/includes/addon_details.html
@@ -54,7 +54,8 @@
                           _("Your add-on is displayed in our gallery and users are
                              receiving automatic updates.")
                           if addon.is_listed else
-                          _("Your add-on has been signed and can be side-loaded.")) }}
+                          _("Your add-on has been signed and can be bundled with an
+                             application installer.")) }}
       </a>
     {% elif addon.status == amo.STATUS_DISABLED %}
       <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload">
@@ -81,7 +82,8 @@
                              Some features are unavailable to your add-on.")
                           if addon.is_listed else
                           _('You will receive an email when the full review is
-                             complete, making your add-on side-loadable.')) }}
+                             complete, making you able to bundle your add-on with an
+                             application installer.')) }}
       </a>
     {% elif addon.status == amo.STATUS_PURGATORY %}
       <a href="{{ addon.get_dev_url('versions') }}">


### PR DESCRIPTION
This is a follow patch to bug 1186369 to eliminate the term "side-loading". Following up with developers showed that "side-loading" is not a known term and using that term leads to an increased submission of unnecessary workload to the full review queue.

r?