### PR TITLE
Another go at: Disable selecting files for a review in the editor tools (bug 1197261)

### DIFF
--- a/apps/addons/management/commands/approve_addons.py
+++ b/apps/addons/management/commands/approve_addons.py
@@ -52,10 +52,7 @@ def get_files(addon_guids):
     # under review, or add-ons that are under review.
     files = []
     for addon in addons:
-        for file_ in addon.latest_version.files.all():
-            if (file_.status in amo.UNDER_REVIEW_STATUSES or
-                    addon.status in amo.UNDER_REVIEW_STATUSES):
-                files.append(file_)
+        files += addon.latest_version.unreviewed_files
     return files
 
 

--- a/apps/addons/tests/test_commands.py
+++ b/apps/addons/tests/test_commands.py
@@ -87,17 +87,32 @@ def test_approve_addons_get_files_bad_guid():
     assert approve_addons.get_files(['foo']) == [addon1_file]
 
 
+def id_function(fixture_value):
+    """Convert a param from the use_case fixture to a nicer name.
+
+    By default, the name (used in the test generated from the parameterized
+    fixture) will use the fixture name and a number.
+    Eg: test_foo[use_case0]
+
+    Providing explicit 'ids' (either as strings, or as a function) will use
+    those names instead. Here the name will be something like
+    test_foo[public-unreviewed-full], for the status values, and if the file is
+    unreviewed.
+    """
+    addon_status, file_status, review_type = fixture_value
+    return '{0}-{1}-{2}'.format(amo.STATUS_CHOICES_API[addon_status],
+                                amo.STATUS_CHOICES_API[file_status],
+                                review_type)
+
+
 @pytest.fixture(
     params=[(amo.STATUS_UNREVIEWED, amo.STATUS_UNREVIEWED, 'prelim'),
             (amo.STATUS_LITE, amo.STATUS_UNREVIEWED, 'prelim'),
             (amo.STATUS_NOMINATED, amo.STATUS_UNREVIEWED, 'full'),
             (amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED, 'full'),
             (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE, 'full')],
-    ids=['1-1-prelim',  # Those are used to build better test names, for the
-         '8-1-prelim',  # tests using this fixture, eg:
-         '3-1-full',    # > test_approve_addons_get_files[1-1-prelim]
-         '4-1-full',    # instead of simply:
-         '9-8-full'])   # > test_approve_addons_get_files[usecase0]
+    # ids are used to build better names for the tests using this fixture.
+    ids=id_function)
 def use_case(request, db):
     """This fixture will return quadruples for different use cases.
 

--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -449,7 +449,7 @@ class ReviewHelper:
         self.handler = None
         self.required = {}
         self.addon = addon
-        self.all_files = version.files.all() if version else []
+        self.version = version
         self.get_review_type(request, addon, version)
         self.actions = self.get_actions(request, addon)
 
@@ -584,7 +584,7 @@ class ReviewBase(object):
         self.addon = addon
         self.version = version
         self.review_type = review_type
-        self.files = None
+        self.files = self.version.unreviewed_files if self.version else []
 
     def set_addon(self, **kw):
         """Alters addon and sets reviewed timestamp on version."""
@@ -688,7 +688,6 @@ class ReviewAddon(ReviewBase):
 
     def set_data(self, data):
         self.data = data
-        self.files = self.version.files.all()
 
     def process_public(self):
         """Set an addon to public."""
@@ -807,7 +806,8 @@ class ReviewFiles(ReviewBase):
 
     def set_data(self, data):
         self.data = data
-        self.files = data.get('addon_files', None)
+        if 'addon_files' in data:
+            self.files = data['addon_files']
 
     def process_public(self):
         """Set an addons files to public."""

--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -163,25 +163,17 @@
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle"
-           data-value="{{ actions_minimal|join("|") }}"{% if allow_unchecking_files %} data-uncheckable="1"{% endif %}>
-        <label for="id_addon_files"><strong>{{ form.addon_files.label }}</strong></label>
+           data-value="{{ actions_minimal|join("|") }}">
+        <label><strong>{{ _('Files:') }}</strong></label>
         <ul>
-            {% for pk, label in form.fields.get('addon_files').choices %}
-            <li>
-              <label for="file-{{ pk }}"{% if pk in form.addon_files_disabled %} class="light"{% endif %}>
-                <input id="file-{{ pk }}" type="checkbox" value="{{ pk }}" name="addon_files"
-                       {% if pk in form.addon_files_disabled %}disabled=""{% endif %} />
-                {{ label }}
-              </label>
-            </li>
-            {% endfor %}
+          {% for file in form.unreviewed_files %}
+          <li>
+            <strong>{{ file.get_platform_display() }}</strong> &middot;
+            {{ file.filename }} &middot;
+            {{ file_review_status(addon, file) }}
+          </li>
+          {% endfor %}
         </ul>
-
-        <div id="review-actions-files-warning">
-          {{ _('Notice: Only review more than one file if you have tested <strong>every</strong> file you select.') }}
-        </div>
-
-        {{ form.addon_files.errors }}
       </div>
 
       <div class="review-actions-section review-actions-tested data-toggle"

--- a/apps/editors/tests/test_helpers.py
+++ b/apps/editors/tests/test_helpers.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.django_db
 
 REVIEW_ADDON_STATUSES = (amo.STATUS_NOMINATED, amo.STATUS_LITE_AND_NOMINATED,
                          amo.STATUS_UNREVIEWED)
-REVIEW_FILES_STATUSES = (amo.STATUS_BETA, amo.STATUS_NULL, amo.STATUS_PUBLIC,
+REVIEW_FILES_STATUSES = (amo.STATUS_PUBLIC,
                          amo.STATUS_DISABLED, amo.STATUS_LITE)
 
 
@@ -720,7 +720,7 @@ class TestReviewHelper(amo.tests.TestCase):
 
     @patch('editors.helpers.sign_file')
     def test_preliminary_to_sandbox(self, sign_mock):
-        for status in helpers.PRELIMINARY_STATUSES:
+        for status in [amo.STATUS_UNREVIEWED, amo.STATUS_LITE_AND_NOMINATED]:
             self.setup_data(status)
             self.helper.handler.process_sandbox()
 
@@ -737,7 +737,7 @@ class TestReviewHelper(amo.tests.TestCase):
 
     @patch('editors.helpers.sign_file')
     def test_preliminary_to_sandbox_unlisted(self, sign_mock):
-        for status in helpers.PRELIMINARY_STATUSES:
+        for status in [amo.STATUS_UNREVIEWED, amo.STATUS_LITE_AND_NOMINATED]:
             self.setup_data(status, is_listed=False)
             self.helper.handler.process_sandbox()
 
@@ -807,7 +807,7 @@ class TestReviewHelper(amo.tests.TestCase):
 
     @patch('editors.helpers.sign_file')
     def test_pending_to_public(self, sign_mock):
-        for status in helpers.PENDING_STATUSES:
+        for status in [amo.STATUS_NOMINATED, amo.STATUS_LITE_AND_NOMINATED]:
             self.setup_data(status)
             self.create_paths()
             self.helper.handler.process_public()
@@ -829,7 +829,7 @@ class TestReviewHelper(amo.tests.TestCase):
 
     @patch('editors.helpers.sign_file')
     def test_pending_to_public_unlisted(self, sign_mock):
-        for status in helpers.PENDING_STATUSES:
+        for status in [amo.STATUS_NOMINATED, amo.STATUS_LITE_AND_NOMINATED]:
             self.setup_data(status, is_listed=False)
             self.create_paths()
             self.helper.handler.process_public()
@@ -851,7 +851,7 @@ class TestReviewHelper(amo.tests.TestCase):
 
     @patch('editors.helpers.sign_file')
     def test_pending_to_sandbox(self, sign_mock):
-        for status in helpers.PENDING_STATUSES:
+        for status in amo.UNDER_REVIEW_STATUSES:
             self.setup_data(status)
             self.helper.handler.process_sandbox()
 
@@ -868,7 +868,7 @@ class TestReviewHelper(amo.tests.TestCase):
 
     @patch('editors.helpers.sign_file')
     def test_pending_to_sandbox_unlisted(self, sign_mock):
-        for status in helpers.PENDING_STATUSES:
+        for status in amo.UNDER_REVIEW_STATUSES:
             self.setup_data(status, is_listed=False)
             self.helper.handler.process_sandbox()
 
@@ -946,7 +946,7 @@ class TestReviewHelper(amo.tests.TestCase):
                                                % (status, process))
 
     def test_preliminary_review_time_set(self):
-        for status in REVIEW_FILES_STATUSES:
+        for status in amo.UNDER_REVIEW_STATUSES:
             for process in ['process_sandbox', 'process_preliminary']:
                 self.file.update(reviewed=None)
                 self.setup_data(status)

--- a/apps/editors/tests/test_review_scenarios.py
+++ b/apps/editors/tests/test_review_scenarios.py
@@ -1,0 +1,132 @@
+"""Real life review scenarios.
+
+For different add-on and file statuses, test reviewing them, and make sure then
+end up in the correct state.
+"""
+import pytest
+
+import amo
+import amo.tests
+from addons.models import Addon
+from editors import helpers
+from files.models import File
+from versions.models import Version
+
+
+@pytest.fixture
+def mock_request(rf, db):  # rf is a RequestFactory provided by pytest-django.
+    request = rf.get('/')
+    request.user = request.amo_user = amo.tests.user_factory()
+    return request
+
+
+@pytest.fixture
+def addon_with_files(db):
+    """Return an add-on with one version and four files.
+
+    By default the add-on is public, and the files are: beta, disabled,
+    unreviewed, unreviewed.
+    """
+    addon = Addon.objects.create()
+    version = Version.objects.create(addon=addon)
+    for status in [amo.STATUS_BETA, amo.STATUS_DISABLED, amo.STATUS_UNREVIEWED,
+                   amo.STATUS_UNREVIEWED]:
+        File.objects.create(version=version, status=status)
+    return addon
+
+
+@pytest.mark.parametrize(
+    'review_action,addon_status,file_status,review_class,review_type,'
+    'final_addon_status,final_file_status',
+    [
+        # New addon request full.
+        # scenario0: should succeed, files approved.
+        ('process_public', amo.STATUS_NOMINATED, amo.STATUS_UNREVIEWED,
+         helpers.ReviewAddon, 'nominated', amo.STATUS_PUBLIC,
+         amo.STATUS_PUBLIC),
+        # scenario1: should succeed, files rejected.
+        ('process_sandbox', amo.STATUS_NOMINATED, amo.STATUS_UNREVIEWED,
+         helpers.ReviewAddon, 'nominated', amo.STATUS_NULL,
+         amo.STATUS_DISABLED),
+        # scenario2: should succeed, files approved.
+        ('process_preliminary', amo.STATUS_NOMINATED, amo.STATUS_UNREVIEWED,
+         helpers.ReviewAddon, 'nominated', amo.STATUS_LITE, amo.STATUS_LITE),
+
+        # New addon request prelim.
+        # scenario3: should fail, no change.
+        ('process_public', amo.STATUS_UNREVIEWED, amo.STATUS_UNREVIEWED,
+         helpers.ReviewAddon, 'preliminary', amo.STATUS_UNREVIEWED,
+         amo.STATUS_UNREVIEWED),
+        # scenario4: Should succeed, files rejected.
+        ('process_sandbox', amo.STATUS_UNREVIEWED, amo.STATUS_UNREVIEWED,
+         helpers.ReviewAddon, 'preliminary', amo.STATUS_NULL,
+         amo.STATUS_DISABLED),
+        # scenario5: should succeed, files approved.
+        ('process_preliminary', amo.STATUS_UNREVIEWED, amo.STATUS_UNREVIEWED,
+         helpers.ReviewAddon, 'preliminary', amo.STATUS_LITE, amo.STATUS_LITE),
+
+        # Prelim addon request full.
+        # scenario6: should succeed, files approved.
+        ('process_public', amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE,
+         helpers.ReviewAddon, 'nominated', amo.STATUS_PUBLIC,
+         amo.STATUS_PUBLIC),
+        # scenario7: should succeed, files rejected.
+        ('process_sandbox', amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE,
+         helpers.ReviewAddon, 'nominated', amo.STATUS_NULL,
+         amo.STATUS_DISABLED),
+        # scenario8: Should succeed, files approved.
+        ('process_preliminary', amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE,
+         helpers.ReviewAddon, 'nominated', amo.STATUS_LITE, amo.STATUS_LITE),
+
+        # Full addon with a new file.
+        # scenario9: should succeed, files approved.
+        ('process_public', amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'pending', amo.STATUS_PUBLIC, amo.STATUS_PUBLIC),
+        # scenario10: should succeed, files rejected.
+        ('process_sandbox', amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'pending', amo.STATUS_UNREVIEWED,
+         amo.STATUS_DISABLED),
+        # scenario11: should succeed, files approved.
+        ('process_preliminary', amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'pending', amo.STATUS_LITE, amo.STATUS_LITE),
+
+        # Prelim addon with a new file.
+        # scenario12: should fail, no change.
+        ('process_public', amo.STATUS_LITE, amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'preliminary', amo.STATUS_LITE,
+         amo.STATUS_UNREVIEWED),
+        # scenario13: should succeed, files rejected.
+        ('process_sandbox', amo.STATUS_LITE, amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'preliminary', amo.STATUS_LITE,
+         amo.STATUS_DISABLED),
+        # scenario14: should succeed, files approved.
+        ('process_preliminary', amo.STATUS_LITE, amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'preliminary', amo.STATUS_LITE, amo.STATUS_LITE),
+    ])
+def test_review_scenario(mock_request, addon_with_files, review_action,
+                         addon_status, file_status, review_class, review_type,
+                         final_addon_status, final_file_status):
+    # Setup the addon and files.
+    addon = addon_with_files
+    addon.update(status=addon_status)
+    version = addon.versions.get()
+    version.files.filter(status=amo.STATUS_NULL).update(status=file_status)
+    # Get the review helper.
+    helper = helpers.ReviewHelper(mock_request, addon, version)
+    assert isinstance(helper.handler, review_class)
+    helper.get_review_type(mock_request, addon, version)
+    assert helper.review_type == review_type
+    helper.set_data({'comments': 'testing review scenarios'})
+    # Run the action (process_public, process_sandbox, process_preliminary).
+    try:
+        getattr(helper.handler, review_action)()
+    except AssertionError:
+        # Some scenarios are expected to fail. We don't need to check it here,
+        # the scenario has the final statuses, and those are the ones we want
+        # to check.
+        pass
+    # Check the final statuses.
+    assert addon.reload().status == final_addon_status
+    assert list(version.files.values_list('status', flat=True)) == (
+        [amo.STATUS_BETA, amo.STATUS_DISABLED, final_file_status,
+         final_file_status])

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1820,11 +1820,10 @@ class ReviewBase(QueueTest):
         return Addon.objects.get(pk=self.addon.pk)
 
     def get_dict(self, **kw):
-        files = [self.version.files.all()[0].pk]
-        d = {'operating_systems': 'win', 'applications': 'something',
-             'comments': 'something', 'addon_files': files}
-        d.update(kw)
-        return d
+        data = {'operating_systems': 'win', 'applications': 'something',
+                'comments': 'something'}
+        data.update(kw)
+        return data
 
 
 class TestReview(ReviewBase):
@@ -2007,11 +2006,10 @@ class TestReview(ReviewBase):
             v.update(created=v.created + timedelta(days=i))
 
             if 'action' in version:
-                d = dict(action=version['action'], operating_systems='win',
-                         applications='something',
-                         comments=version['comments'],
-                         addon_files=[v.files.all()[0].pk])
-                self.client.post(self.url, d)
+                data = dict(action=version['action'], operating_systems='win',
+                            applications='something',
+                            comments=version['comments'])
+                self.client.post(self.url, data)
                 v.delete()
 
     @patch('editors.helpers.sign_file')
@@ -2094,19 +2092,15 @@ class TestReview(ReviewBase):
         eq_(doc('th').eq(1).text(), 'Comment')
         eq_(doc('.history-comment').text(), 'hello sailor')
 
-    @patch('editors.helpers.sign_file')
-    def test_files_in_item_history(self, mock_sign):
+    def test_files_in_item_history(self):
         data = {'action': 'public', 'operating_systems': 'win',
-                'applications': 'something', 'comments': 'something',
-                'addon_files': [self.version.files.all()[0].pk]}
+                'applications': 'something', 'comments': 'something'}
         self.client.post(self.url, data)
 
         r = self.client.get(self.url)
         items = pq(r.content)('#review-files .files .file-info')
         eq_(items.length, 1)
         eq_(items.find('a.editors-install').text(), 'All Platforms')
-
-        assert mock_sign.called
 
     def test_no_items(self):
         r = self.client.get(self.url)
@@ -2287,10 +2281,9 @@ class TestReview(ReviewBase):
     @patch('editors.helpers.sign_file')
     def review_version(self, version, url, mock_sign):
         version.files.all()[0].update(status=amo.STATUS_UNREVIEWED)
-        d = dict(action='prelim', operating_systems='win',
-                 applications='something', comments='something',
-                 addon_files=[version.files.all()[0].pk])
-        self.client.post(url, d)
+        data = dict(action='prelim', operating_systems='win',
+                    applications='something', comments='something')
+        self.client.post(url, data)
 
         assert mock_sign.called
 
@@ -2555,33 +2548,6 @@ class TestReviewPreliminary(ReviewBase):
         eq_(response.context['form'].errors['comments'][0],
             'This field is required.')
 
-    def test_prelim_from_lite_no_files(self):
-        self.addon.update(status=amo.STATUS_LITE)
-        data = self.prelim_dict()
-        del data['addon_files']
-        response = self.client.post(self.url, data)
-        eq_(response.context['form'].errors['addon_files'][0],
-            'You must select some files.')
-
-    def test_prelim_from_lite_wrong(self):
-        self.addon.update(status=amo.STATUS_LITE)
-        response = self.client.post(self.url, self.prelim_dict())
-        eq_(response.context['form'].errors['addon_files'][0],
-            'File Public.xpi is not pending review.')
-
-    def test_prelim_from_lite_wrong_two(self):
-        self.addon.update(status=amo.STATUS_LITE)
-        data = self.prelim_dict()
-        f = self.version.files.all()[0]
-
-        statuses = dict(File.STATUS_CHOICES)  # Shallow copy.
-        del statuses[amo.STATUS_BETA], statuses[amo.STATUS_UNREVIEWED]
-        for status in statuses:
-            f.update(status=status)
-            response = self.client.post(self.url, data)
-            eq_(response.context['form'].errors['addon_files'][0],
-                'File Public.xpi is not pending review.')
-
     def test_prelim_from_lite_files(self):
         self.addon.update(status=amo.STATUS_LITE)
         self.client.post(self.url, self.prelim_dict())
@@ -2603,7 +2569,6 @@ class TestReviewPreliminary(ReviewBase):
         file_.save()
         self.addon.update(status=amo.STATUS_LITE)
         data = self.prelim_dict()
-        data['addon_files'] = [file_.pk]
         self.client.post(self.url, data)
         eq_([amo.STATUS_DISABLED, amo.STATUS_LITE],
             [f.status for f in self.version.files.all().order_by('status')])
@@ -2618,22 +2583,21 @@ class TestReviewPending(ReviewBase):
         self.addon.update(status=amo.STATUS_PUBLIC)
 
     def pending_dict(self):
-        files = list(self.version.files.values_list('id', flat=True))
-        return self.get_dict(action='public', addon_files=files)
+        return self.get_dict(action='public')
 
     @patch('editors.helpers.sign_file')
     def test_pending_to_public(self, mock_sign):
         statuses = (self.version.files.values_list('status', flat=True)
                     .order_by('status'))
-        eq_(list(statuses), [amo.STATUS_UNREVIEWED, amo.STATUS_LITE])
+        assert list(statuses) == [amo.STATUS_UNREVIEWED, amo.STATUS_LITE]
 
-        r = self.client.post(self.url, self.pending_dict())
-        eq_(self.get_addon().status, amo.STATUS_PUBLIC)
-        self.assertRedirects(r, reverse('editors.queue_pending'))
+        response = self.client.post(self.url, self.pending_dict())
+        assert self.get_addon().status == amo.STATUS_PUBLIC
+        self.assertRedirects(response, reverse('editors.queue_pending'))
 
         statuses = (self.version.files.values_list('status', flat=True)
                     .order_by('status'))
-        eq_(list(statuses), [amo.STATUS_PUBLIC] * 2)
+        assert list(statuses) == [amo.STATUS_PUBLIC, amo.STATUS_LITE]
 
         assert mock_sign.called
 
@@ -2652,17 +2616,51 @@ class TestReviewPending(ReviewBase):
 
         statuses = (self.version.files.values_list('status', flat=True)
                     .order_by('status'))
-        assert list(statuses) == [amo.STATUS_PUBLIC] * 2
+        assert list(statuses) == [amo.STATUS_PUBLIC, amo.STATUS_LITE]
 
         assert mock_sign.called
 
-    def test_disabled_file(self):
-        obj = File.objects.create(version=self.version,
-                                  status=amo.STATUS_DISABLED)
+    def test_display_only_unreviewed_files(self):
+        """Only the currently unreviewed files are displayed."""
+        self.file.update(filename='somefilename.xpi')
+        reviewed = File.objects.create(version=self.version,
+                                       status=amo.STATUS_PUBLIC,
+                                       filename='file_reviewed.xpi')
+        disabled = File.objects.create(version=self.version,
+                                       status=amo.STATUS_DISABLED,
+                                       filename='file_disabled.xpi')
+        unreviewed = File.objects.create(version=self.version,
+                                         status=amo.STATUS_UNREVIEWED,
+                                         filename='file_unreviewed.xpi')
         response = self.client.get(self.url, self.pending_dict())
         doc = pq(response.content)
-        assert 'disabled' in doc('#file-%s' % obj.pk)[0].keys()
-        assert 'disabled' not in doc('#file-%s' % self.file.pk)[0].keys()
+        assert len(doc('.review-actions-files ul li')) == 2
+        assert reviewed.filename not in response.content
+        assert disabled.filename not in response.content
+        assert unreviewed.filename in response.content
+        assert self.file.filename in response.content
+
+    @patch('editors.helpers.sign_file')
+    def test_review_unreviewed_files(self, mock_sign):
+        """Review all the unreviewed files when submitting a review."""
+        reviewed = File.objects.create(version=self.version,
+                                       status=amo.STATUS_PUBLIC)
+        disabled = File.objects.create(version=self.version,
+                                       status=amo.STATUS_DISABLED)
+        unreviewed = File.objects.create(version=self.version,
+                                         status=amo.STATUS_UNREVIEWED)
+        self.login_as_admin()
+        response = self.client.post(self.url, self.pending_dict())
+        self.assertRedirects(response,
+                             reverse('editors.queue_pending'))
+
+        assert self.addon.reload().status == amo.STATUS_PUBLIC
+        assert reviewed.reload().status == amo.STATUS_PUBLIC
+        assert disabled.reload().status == amo.STATUS_DISABLED
+        assert unreviewed.reload().status == amo.STATUS_PUBLIC
+        assert self.file.reload().status == amo.STATUS_PUBLIC
+
+        assert mock_sign.called
 
 
 class TestEditorMOTD(EditorTest):

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -558,8 +558,8 @@ def review(request, addon):
     form = forms.get_review_form(request.POST or None, request=request,
                                  addon=addon, version=version)
 
-    queue_type = (form.helper.review_type if form.helper.review_type
-                  != 'preliminary' else 'prelim')
+    queue_type = ('prelim' if form.helper.review_type == 'preliminary'
+                  else form.helper.review_type)
     if addon.is_listed:
         redirect_url = reverse('editors.queue_%s' % queue_type)
     else:
@@ -603,9 +603,6 @@ def review(request, addon):
 
     # The actions we should show a minimal form from.
     actions_minimal = [k for (k, a) in actions if not a.get('minimal')]
-
-    # We only allow the user to check/uncheck files for "pending"
-    allow_unchecking_files = form.helper.review_type == "pending"
 
     versions = (Version.objects.filter(addon=addon)
                                .exclude(files__status=amo.STATUS_BETA)
@@ -671,7 +668,6 @@ def review(request, addon):
                   pager=pager, num_pages=num_pages, count=count, flags=flags,
                   form=form, canned=canned, is_admin=is_admin,
                   show_diff=show_diff,
-                  allow_unchecking_files=allow_unchecking_files,
                   actions=actions, actions_minimal=actions_minimal,
                   whiteboard_form=forms.WhiteboardForm(instance=addon),
                   user_changes=user_changes_log,

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -488,6 +488,20 @@ class Version(amo.models.OnChangeMixin, amo.models.ModelBase):
     def is_listed(self):
         return self.addon.is_listed
 
+    @property
+    def unreviewed_files(self):
+        """A File is unreviewed if:
+        - its status is in amo.UNDER_REVIEW_STATUSES or
+        - its addon status is in amo.UNDER_REVIEW_STATUSES
+          and its status is either in amo.UNDER_REVIEW_STATUSES or
+          amo.STATUS_LITE
+        """
+        under_review_or_lite = amo.UNDER_REVIEW_STATUSES + (amo.STATUS_LITE,)
+        return self.files.filter(
+            models.Q(status__in=amo.UNDER_REVIEW_STATUSES) |
+            models.Q(version__addon__status__in=amo.UNDER_REVIEW_STATUSES,
+                     status__in=under_review_or_lite))
+
 
 @Version.on_change
 def watch_source(old_attr={}, new_attr={}, instance=None, sender=None, **kw):

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -488,6 +488,58 @@ class TestVersion(amo.tests.TestCase):
         assert uploaded_name.endswith(u'crosswarpex-확장-0.1-src.tar.gz')
 
 
+@pytest.mark.parametrize("addon_status,file_status,is_unreviewed", [
+    (amo.STATUS_UNREVIEWED, amo.STATUS_UNREVIEWED, True),
+    (amo.STATUS_UNREVIEWED, amo.STATUS_LITE, True),
+    (amo.STATUS_UNREVIEWED, amo.STATUS_LITE_AND_NOMINATED, True),
+    (amo.STATUS_UNREVIEWED, amo.STATUS_NOMINATED, True),
+    (amo.STATUS_UNREVIEWED, amo.STATUS_PUBLIC, False),
+    (amo.STATUS_UNREVIEWED, amo.STATUS_DISABLED, False),
+    (amo.STATUS_UNREVIEWED, amo.STATUS_BETA, False),
+    (amo.STATUS_LITE, amo.STATUS_UNREVIEWED, True),
+    (amo.STATUS_LITE, amo.STATUS_LITE, False),
+    (amo.STATUS_LITE, amo.STATUS_LITE_AND_NOMINATED, True),
+    (amo.STATUS_LITE, amo.STATUS_NOMINATED, True),
+    (amo.STATUS_LITE, amo.STATUS_PUBLIC, False),
+    (amo.STATUS_LITE, amo.STATUS_DISABLED, False),
+    (amo.STATUS_LITE, amo.STATUS_BETA, False),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_UNREVIEWED, True),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE, True),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE_AND_NOMINATED, True),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_NOMINATED, True),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_PUBLIC, False),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_DISABLED, False),
+    (amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_BETA, False),
+    (amo.STATUS_NOMINATED, amo.STATUS_UNREVIEWED, True),
+    (amo.STATUS_NOMINATED, amo.STATUS_LITE, True),
+    (amo.STATUS_NOMINATED, amo.STATUS_LITE_AND_NOMINATED, True),
+    (amo.STATUS_NOMINATED, amo.STATUS_NOMINATED, True),
+    (amo.STATUS_NOMINATED, amo.STATUS_PUBLIC, False),
+    (amo.STATUS_NOMINATED, amo.STATUS_DISABLED, False),
+    (amo.STATUS_NOMINATED, amo.STATUS_BETA, False),
+    (amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED, True),
+    (amo.STATUS_PUBLIC, amo.STATUS_LITE, False),
+    (amo.STATUS_PUBLIC, amo.STATUS_LITE_AND_NOMINATED, True),
+    (amo.STATUS_PUBLIC, amo.STATUS_NOMINATED, True),
+    (amo.STATUS_PUBLIC, amo.STATUS_PUBLIC, False),
+    (amo.STATUS_PUBLIC, amo.STATUS_DISABLED, False),
+    (amo.STATUS_PUBLIC, amo.STATUS_BETA, False)])
+def test_unreviewed_files(db, addon_status, file_status, is_unreviewed):
+    """Files that need to be reviewed are returned by version.unreviewed_files.
+
+    Use cases are triples taken from the "use_case" fixture above.
+    """
+    addon = amo.tests.addon_factory(status=addon_status, guid='foo')
+    version = addon.latest_version
+    file_ = version.files.get()
+    file_.update(status=file_status)
+    # If the addon is public, and we change its only file to something else
+    # than public, it'll change to unreviewed.
+    addon.update(status=addon_status)
+    assert addon.reload().status == addon_status
+    assert file_.reload().status == file_status
+
+
 class TestViews(amo.tests.TestCase):
     fixtures = ['addons/eula+contrib-addon']
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --reuse-db --tb=native
+addopts = --reuse-db
 python_files=test*.py
 markers =
     es_tests: mark a test as an elasticsearch test.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,8 +4,8 @@
 execnet==1.2
 nose==1.3.4
 psutil==0.2.0
-py==1.4.26
-pytest==2.6.4
+py==1.4.30
+pytest==2.8.0
 pytest-cache==1.0
-pytest-django==2.7.0
-pytest-xdist==1.11
+pytest-django==2.8.0
+pytest-xdist==1.13.1

--- a/static/css/zamboni/editors.styl
+++ b/static/css/zamboni/editors.styl
@@ -822,10 +822,6 @@ div.editor-stats-table > div.editor-stats-dark {
     border-bottom: 1px solid #A5BFCE;
 }
 
-#review-actions-files-warning {
-    color: #B47100;
-}
-
 .review-actions-canned {
     text-align: right;
 }
@@ -854,6 +850,11 @@ div.editor-stats-table > div.editor-stats-dark {
 
 .review-actions-section label {
     font-weight: normal;
+}
+
+.review-actions-section ul {
+    list-style: disc;
+    padding-left: 20px;
 }
 
 .history-comment {

--- a/static/js/zamboni/editors.js
+++ b/static/js/zamboni/editors.js
@@ -78,8 +78,6 @@ function initReviewActions() {
         $data_toggle.hide();
         $data_toggle.filter('[data-value*="' + value + '"]').show();
 
-        toggle_input();
-
         /* Fade out canned responses */
         var label = $element.text().trim();
         groups.css('color', '#AAA');
@@ -99,28 +97,6 @@ function initReviewActions() {
     if(review_checked.length > 0) {
       showForm(review_checked.closest('li'), true);
     }
-
-    /* File checkboxes */
-    var $files_input = $('#review-actions .review-actions-files').find('input:enabled');
-
-    if($files_input.length == 1 || ! $('#review-actions .review-actions-files').attr('data-uncheckable')) {
-        // Add a dummy, disabled input
-        $files_input.prop('checked', true).hide();
-        $files_input.after($('<input>', {'type': 'checkbox', 'checked': true, 'disabled': true}));
-    }
-
-    function toggle_input(){
-        var $files_input = $('#review-actions .review-actions-files').find('input:enabled'),
-            $files_checked = $files_input.filter(':checked'),
-            disable_submit = $files_checked.length < 1 && $('.review-actions-files').is(':visible');
-
-        $('.review-actions-save input').prop('disabled', disable_submit);
-
-        // If it's not :visible, we can assume it's been replaced with a dummy :disabled input
-        $('#review-actions-files-warning').toggle($files_checked.filter(':enabled:visible').length > 1);
-    }
-
-    $files_input.change(toggle_input).each(toggle_input);
 
     /* Install Triggers */
 


### PR DESCRIPTION
Fixes [bug 1197261](https://bugzilla.mozilla.org/show_bug.cgi?id=1197261)

This is the third attempt, let's hope it's the good one. This time around:
- the Version model has a new property `unreviewed_files` which returns a queryset of all the files that are unreviewed
- the form doesn't have a files choice field anymore
- the template simply displays the list of unreviewed files in the version
- the review helpers will review all the unreviewed files in the version