### PR TITLE
Fixed regression for outerHeight (bug 1208425)

### DIFF
--- a/static/js/impala/footer.js
+++ b/static/js/impala/footer.js
@@ -4,7 +4,7 @@
         $win = $(window);
     function stickyFooter() {
         // Stick the footer to the bottom when there's head(foot)room.
-        $footer.toggleClass('sticky', $win.height() - $footer.outerHeight() > $page.outerHeight());
+        $footer.toggleClass('sticky', $win.height() - $footer.outerHeight(false) > $page.outerHeight(false));
     }
     stickyFooter();
     $win.resize(_.debounce(stickyFooter, 200));

--- a/static/js/impala/search.js
+++ b/static/js/impala/search.js
@@ -117,7 +117,7 @@
 
             // The loading throbber is absolutely positioned atop the
             // search results, so we do this to ensure a max-margin of sorts.
-            if ($container.outerHeight() > 300) {
+            if ($container.outerHeight(false) > 300) {
                 cls += ' tall';
             }
 

--- a/static/js/zamboni/files.js
+++ b/static/js/zamboni/files.js
@@ -209,7 +209,7 @@ jQuery.fn.numberInput = function(increment) {
         var $self = $(this);
         $self.addClass("number-combo-input");
 
-        var height = $self.outerHeight() / 2;
+        var height = $self.outerHeight(false) / 2;
 
         var $dom = $('<span>', { 'class': 'number-combo' })
                      .append($('<a>', { 'class': 'number-combo-button-down',
@@ -690,7 +690,7 @@ function bind_viewer(nodes) {
             } else {
                 /* Unfortunately, jQuery does not provide anything
                    comparable to clientHeight, which we can't do without */
-                var offset = $sel.position().top + $sel.outerHeight() - $cont[0].clientHeight;
+                var offset = $sel.position().top + $sel.outerHeight(false) - $cont[0].clientHeight;
                 if (offset > 0) {
                     $cont.scrollTop($cont.scrollTop() + offset);
                 }

--- a/static/js/zamboni/mobile/general.js
+++ b/static/js/zamboni/mobile/general.js
@@ -88,7 +88,7 @@ $(function() {
             current = $strip.find(".selected a").attr("href");
         if (isManaged) {
             if (isSlider)
-                $managed.css("height", $managed.find(current).outerHeight() + "px");
+                $managed.css("height", $managed.find(current).outerHeight(false) + "px");
         } else {
             $managed = $(document.body);
         }
@@ -106,7 +106,7 @@ $(function() {
                 $tgt.blur();
                 if (isManaged && isSlider && $pane.index() >= 0) {
                     $managed.css(prop, ($pane.index() * -100) + "%");
-                    $managed.css("height", $pane.outerHeight() + "px");
+                    $managed.css("height", $pane.outerHeight(false) + "px");
                 }
             }
             $window.trigger('resize');

--- a/static/js/zamboni/themes_review.js
+++ b/static/js/zamboni/themes_review.js
@@ -94,7 +94,7 @@
 
                 $.each(themes, function(i, obj) {
                     var elem = $(obj.element);
-                    obj.top = elem.offset().top + elem.outerHeight()/2;
+                    obj.top = elem.offset().top + elem.outerHeight(false)/2;
                 });
             }
 


### PR DESCRIPTION
The issue in [1208425](https://bugzilla.mozilla.org/show_bug.cgi?id=1208425) seems to stem from 1.9 return an unexpected value for outerHeight when you don't pass a boolean value. After some find | sed-ing this should fix all of those regressions.