### PR TITLE
Don't prefix frag with # (1208398)

### DIFF
--- a/static/js/zamboni/tabs.js
+++ b/static/js/zamboni/tabs.js
@@ -15,8 +15,8 @@ var Tabs = function(el) {
 Tabs.prototype = {
     init: function() {
         this.root.addClass('tab-wrapper');
-        this.tabMap = {}
-        this.panelMap = {}
+        this.tabMap = {};
+        this.panelMap = {};
         this.reset();
 
         this.select();
@@ -64,7 +64,7 @@ Tabs.prototype = {
         var panels = [];
         this.tabs.each(function() {
             var hash = self.getHash(this);
-            var panel = self.root.find('#' + hash)[0];
+            var panel = self.root.find(hash)[0];
             if (panel) {
                 self.tabMap[hash] = this;
                 self.panelMap[hash] = panel;


### PR DESCRIPTION
In Jquery 1.6 `find('##foo')` finds '#foo' even though the selector has two '#'. Following the upgrade the selector engine blows up on the invalid selector. In other words the upgrade uncovered a pre-existing bug.