### PR TITLE
Move npm installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,11 @@ RUN cd /pip && \
         -r requirements/docker.txt && \
     rm -r build cache
 
+# Install the node_modules.
+RUN mkdir -p /srv/olympia-node
+ADD package.json /srv/olympia-node/package.json
+WORKDIR /srv/olympia-node
+RUN npm install
 
 COPY . /code
 WORKDIR /code
@@ -51,3 +56,8 @@ ENV HISTSIZE 50000
 ENV HISTIGNORE ls:exit:"cd .."
 # This prevents dupes but only in memory for the current session.
 ENV HISTCONTROL erasedups
+
+ENV CLEANCSS_BIN /srv/olympia-node/node_modules/clean-css/bin/cleancss
+ENV LESS_BIN /srv/olympia-node/node_modules/less/bin/lessc
+ENV STYLUS_BIN /srv/olympia-node/node_modules/stylus/bin/stylus
+ENV UGLIFY_BIN /srv/olympia-node/node_modules/uglify-js/bin/uglifyjs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help docs test test_es test_no_es test_force_db tdd test_failed initialize_db populate_data update_code update_deps update_db update_assets full_init full_update reindex flake8 update_docker initialize_docker update_npm_deps
+.PHONY: help docs test test_es test_no_es test_force_db tdd test_failed initialize_db populate_data update_code update_deps update_db update_assets full_init full_update reindex flake8 update_docker initialize_docker
 NUM_ADDONS=10
 NUM_THEMES=$(NUM_ADDONS)
 
@@ -18,8 +18,7 @@ help:
 	@echo "  initialize_db     to create a new database"
 	@echo "  populate_data     to populate a new database"
 	@echo "  update_code       to update the git repository"
-	@echo "  update_deps       to update the python and npm dependencies"
-	@echo "  update_npm_deps   to update only the npm dependencies"
+	@echo "  update_deps       to update the pythondependencies"
 	@echo "  update_db         to run the database migrations"
 	@echo "  initialize_docker to initialize a docker image"
 	@echo "  update_docker     to update a docker image"
@@ -72,16 +71,13 @@ populate_data:
 update_code:
 	git checkout master && git pull
 
-update_deps: update_npm_deps
+update_deps:
 	pip install --no-deps --exists-action=w -r requirements/dev.txt --find-links https://pyrepo.addons.mozilla.org/wheelhouse/ --find-links https://pyrepo.addons.mozilla.org/ --no-index
-
-update_npm_deps:
-	npm install
 
 update_db:
 	schematic migrations
 
-update_assets: update_npm_deps
+update_assets:
 	python manage.py compress_assets
 	python manage.py collectstatic --noinput
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,7 +104,7 @@ update your Docker image and database with any new requirements or migrations::
 
 Then from a shell on the running container run::
 
-    make update_docker  # Runs database migrations, installs npm modules, rebuilds assets.
+    make update_docker  # Runs database migrations and rebuilds assets.
 
 Please note that any command that would result in files added or modified
 outside of the `olympia` folder (eg modifying pip or npm dependencies) won't be

--- a/settings.py
+++ b/settings.py
@@ -53,10 +53,12 @@ ALLOW_SELF_REVIEWS = True
 
 # Assuming you did `npm install` (and not `-g`) like you were supposed to, this
 # will be the path to the `stylus` and `lessc` executables.
-STYLUS_BIN = path('node_modules/stylus/bin/stylus')
-LESS_BIN = path('node_modules/less/bin/lessc')
-CLEANCSS_BIN = path('node_modules/clean-css/bin/cleancss')
-UGLIFY_BIN = path('node_modules/uglify-js/bin/uglifyjs')
+STYLUS_BIN = os.getenv('STYLUS_BIN', path('node_modules/stylus/bin/stylus'))
+LESS_BIN = os.getenv('LESS_BIN', path('node_modules/less/bin/lessc'))
+CLEANCSS_BIN = os.getenv('CLEANCSS_BIN',
+                         path('node_modules/clean-css/bin/cleancss'))
+UGLIFY_BIN = os.getenv('UGLIFY_BIN',
+                       path('node_modules/uglify-js/bin/uglifyjs'))
 
 # Locally we typically don't run more than 1 elasticsearch node. So we set
 # replicas to zero.


### PR DESCRIPTION
* Move the npm installation to the dockerfile (this means npm install is run by the build process on the hub)
* Expose the various commands stylus/less etc via env vars and update the settings to use those.

Note: This uses the same approach that marketplace uses. This wouldn't work well for any npm files that need to be found in a node_modules dir. But we're not running any js that should need to do that AFAIK.

To test this you'll need to do the following:

* CD into your olympia checkout
* Nuke node_modules in your tree (just to ensure there's no deps being used from there)
* Build the image `docker build -t addons/olympia .`
* Run it with `docker-compose up -d`