### PR TITLE
Upgrade to `.on()` instead of `.delegate()`

### DIFF
--- a/static/js/zamboni/collections.js
+++ b/static/js/zamboni/collections.js
@@ -660,8 +660,8 @@ $(document).ready(function () {
                     $widget.setWidth(410);
                     $widget.setPos(ct);
                     $("#id_name").focus();
-                    $widget.delegate('#collections-new-cancel', 'click', loadList)
-                           .delegate('#add-to-collection form', 'submit', handleSubmit);
+                    $('#collections-new-cancel').on('click', loadList);
+                    $('#add-to-collection form').on('submit', handleSubmit);
                 });
             };
 


### PR DESCRIPTION
Fixes Bug 1208406; https://bugzilla.mozilla.org/show_bug.cgi?id=1208406

See http://api.jquery.com/delegate/ -- .on is now preferred.