### PR TITLE
Add missing English names for sources

### DIFF
--- a/static/js/impala/stats/csv_keys.js
+++ b/static/js/impala/stats/csv_keys.js
@@ -41,6 +41,8 @@ var csv_keys = {
     sources: {
         "null"                  : gettext('Unknown'),
         'api'                   : gettext('Add-ons Manager'),
+        'discovery-promo'       : gettext('Add-ons Manager Discovery Pane Promo'),
+        'ss'                    : gettext('Search Suggestions'),
         'search'                : gettext('Search Results'),
         'homepagepromo'         : gettext('Homepage Promo'),
         'hp-btn-promo'          : gettext('Homepage Promo'),
@@ -64,6 +66,9 @@ var csv_keys = {
         'dp-dl-dependencies'    : gettext('Dependencies'),
         'dp-hc-upsell'          : gettext('Upsell'),
         'dp-dl-upsell'          : gettext('Upsell'),
+        'developers'            : gettext('Meet the Developer'),
+        'userprofile'           : gettext('User Profile'),
+        'version-history'       : gettext('Version History'),
 
         'sharingapi'            : gettext('Sharing'),
         'category'              : gettext('Category Pages'),


### PR DESCRIPTION
These download sources don't have human-readable names in the statistics.