### PR TITLE
Add info about side-loading requiring full review (bug 1211422)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/select-review.html
+++ b/apps/devhub/templates/devhub/addons/submit/select-review.html
@@ -30,6 +30,7 @@
       </p>
       <ul>
         <li>{{ _('Appropriate for polished add-ons') }}</li>
+        <li>{{ _('Required if add-on is bundled in an installer') }}</li>
         <li>{{ _('Review should take place within 10 days') }}</li>
         <li>{{ _('Review of subsequent versions within 5 days') }}</li>
         <li>{{ _('Warning-free installation and no feature limitations') }}</li>


### PR DESCRIPTION
Fixes [bug 1211422](https://bugzilla.mozilla.org/show_bug.cgi?id=1211422)

Here's how it looks with the new line:
<img width="722" alt="screen shot 2015-10-05 at 14 33 35" src="https://cloud.githubusercontent.com/assets/167767/10280531/1b0defae-6b6e-11e5-831f-c9cab3ea3d91.png">
