### PR TITLE
Remove information about 10 days cooldown before requesting full review (bug 1200790)

### DIFF
--- a/apps/devhub/templates/devhub/addons/submit/select-review.html
+++ b/apps/devhub/templates/devhub/addons/submit/select-review.html
@@ -55,7 +55,6 @@
         <li>{{ _('Review should take place within 3 days') }}</li>
         <li>{{ _('Some feature limitations') }}</li>
         <li>{{ _('Binary and obfuscated add-ons ineligible') }}</li>
-        <li>{{ _('Cannot request Full Review for 10 days') }}</li>
       </ul>
       <p class="submit-buttons">
         <button type="submit" name="review_type" value="{{ amo.STATUS_UNREVIEWED }}">


### PR DESCRIPTION
Follow up to [bug 1200790](https://bugzilla.mozilla.org/show_bug.cgi?id=1200790) and PR #709 

This is how it looks without the line:
<img width="723" alt="screen shot 2015-10-05 at 14 30 29" src="https://cloud.githubusercontent.com/assets/167767/10280491/f41d18c0-6b6d-11e5-85be-d06b1ee23d4f.png">
