### PR TITLE
We want to sign for MOBILE not ANDROID (bug 1185789)

### DIFF
--- a/lib/crypto/packaged.py
+++ b/lib/crypto/packaged.py
@@ -35,12 +35,12 @@ def supports_firefox(file_obj):
     if not file_obj.binary_components and not file_obj.strict_compatibility:
         # Version is "default to compatible".
         return apps.filter(
-            max__application__in=[amo.FIREFOX.id, amo.ANDROID.id],
+            max__application__in=[amo.FIREFOX.id, amo.MOBILE.id],
             max__version_int__gte=version_int(settings.MIN_D2C_VERSION))
     else:
         # Version isn't "default to compatible".
         return apps.filter(
-            max__application__in=[amo.FIREFOX.id, amo.ANDROID.id],
+            max__application__in=[amo.FIREFOX.id, amo.MOBILE.id],
             max__version_int__gte=version_int(settings.MIN_NOT_D2C_VERSION))
 
 

--- a/lib/crypto/tests.py
+++ b/lib/crypto/tests.py
@@ -96,7 +96,7 @@ class TestPackaged(amo.tests.TestCase):
         max_appversion = self.version.apps.first().max
 
         # Old, and not default to compatible.
-        max_appversion.update(application=amo.ANDROID.id,
+        max_appversion.update(application=amo.MOBILE.id,
                               version=settings.MIN_D2C_VERSION,
                               version_int=version_int(
                                   settings.MIN_D2C_VERSION))
@@ -121,7 +121,7 @@ class TestPackaged(amo.tests.TestCase):
         max_appversion = self.version.apps.first().max
 
         # Old, and default to compatible.
-        max_appversion.update(application=amo.ANDROID.id,
+        max_appversion.update(application=amo.MOBILE.id,
                               version=settings.MIN_D2C_VERSION,
                               version_int=version_int(
                                   settings.MIN_D2C_VERSION))
@@ -146,7 +146,7 @@ class TestPackaged(amo.tests.TestCase):
         max_appversion = self.version.apps.first().max
 
         # Recent, not default to compatible.
-        max_appversion.update(application=amo.ANDROID.id,
+        max_appversion.update(application=amo.MOBILE.id,
                               version=settings.MIN_NOT_D2C_VERSION,
                               version_int=version_int(
                                   settings.MIN_NOT_D2C_VERSION))


### PR DESCRIPTION
Fixes [bug 1185789](https://bugzilla.mozilla.org/show_bug.cgi?id=1185789) (again)

This is a follow-up to PR #766: it seems we want to sign for the `amo.MOBILE`
application, not the `amo.ANDROID` application, despite the name.