### PR TITLE
Fix styling regression for login form (bug 1212989)

### DIFF
--- a/apps/devhub/templates/devhub/api/key.html
+++ b/apps/devhub/templates/devhub/api/key.html
@@ -17,13 +17,13 @@
           {{ _('Generate a new API key.') }}
         </legend>
         <ul>
-          <li clas="row">
-            <label for="jwtkey" class="row api-label">{{ _('API ID') }}</label>
-            <input type="text" name="jwtkey" value="{{ key }}" class="api-input" disabled />
+          <li class="row api-input">
+            <label for="jwtkey" class="row">{{ _('API ID') }}</label>
+            <input type="text" name="jwtkey" value="{{ key }}" disabled />
           </li>
-          <li clas="row">
-            <label for="jwtsecret" class="row api-label">{{ _('API Secret') }}</label>
-            <input type="text" name="jwtsecret" value="{{ secret }}" class="api-input" disabled />
+          <li class="row api-input">
+            <label for="jwtsecret" class="row">{{ _('API Secret') }}</label>
+            <input type="text" name="jwtsecret" value="{{ secret }}" disabled />
           </li>
         </ul>
       </fieldset>

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -555,6 +555,7 @@ MINIFY_BUNDLES = {
             'css/devhub/submission.less',
             'css/devhub/search.less',
             'css/devhub/refunds.less',
+            'css/impala/devhub-api.less',
         ),
         'zamboni/editors': (
             'css/zamboni/editors.styl',

--- a/static/css/impala/devhub-api.less
+++ b/static/css/impala/devhub-api.less
@@ -1,0 +1,11 @@
+.api-input {
+    input[type=text] {
+        box-shadow: none;
+        text-align: center;
+        font-size: 1.5em;
+    }
+    label {
+      font-weight: bold;
+      display: block;
+    }
+}

--- a/static/css/impala/forms.less
+++ b/static/css/impala/forms.less
@@ -242,15 +242,6 @@ textarea {
     input[type=color] {
         width: 80px;
     }
-    .api-label {
-      font-weight: bold;
-      display: block;
-    }
-    input[type=text] {
-      box-shadow: none;
-      text-align: center;
-      font-size: 1.5em;
-    }
     textarea {
         width: 400px;
         vertical-align: text-top;


### PR DESCRIPTION
was:
<img width="929" alt="screen shot 2015-10-08 at 2 50 52 pm" src="https://cloud.githubusercontent.com/assets/2600677/10399636/cb12f49c-6e81-11e5-80b7-c8dfb451b0d2.png">
Now is:
<img width="957" alt="screen shot 2015-10-09 at 12 33 10 pm" src="https://cloud.githubusercontent.com/assets/2600677/10399656/f67247be-6e81-11e5-9225-9beea5315422.png">
