### PR TITLE
JWT token auth for signing API (bug 1210889)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,4 @@ reindex:
 	python manage.py reindex $(ARGS)
 
 flake8:
-	flake8 --ignore=E265,E266 --exclude=services,wsgi,docs,node_modules,build*.py .
+	flake8 --ignore=E265,E266 --exclude=services,wsgi,docs,node_modules,.npm,build*.py .

--- a/apps/amo/tests/dynamic_urls.py
+++ b/apps/amo/tests/dynamic_urls.py
@@ -1,0 +1,3 @@
+# In an effort to make the tests more readable, this is populated at the
+# start of each test. See amo/tests/__init__.py:WithDynamicEndpoints
+urlpatterns = None

--- a/apps/api/jwt_auth/handlers.py
+++ b/apps/api/jwt_auth/handlers.py
@@ -1,0 +1,87 @@
+"""
+Implementations of django-rest-framework-jwt callbacks.
+
+AMO uses JWT tokens in a different way. Notes:
+* Each add-on dev creates JWT headers using their APIKey key/secret pair.
+* We do not support JWT generation in any of our API endpoints. It's up to
+  developers to generate their own JWTs.
+* Our JWT header auth is intended for script-to-service at the moment.
+* We are not signing entire requests like you normally would with a JWT
+  because the signing API needs to accept a file upload and files might be
+  large.
+
+See https://github.com/GetBlimp/django-rest-framework-jwt/ for more info.
+"""
+from datetime import datetime
+import logging
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+
+import jwt
+from rest_framework_jwt.settings import api_settings
+
+from apps.api.models import APIKey
+
+log = logging.getLogger('z.jwt')
+
+
+def jwt_payload_handler(user, issuer):
+    issued_at = datetime.utcnow()
+    return {
+        # The JWT issuer must match the 'key' field of APIKey
+        'iss': issuer,
+        'iat': issued_at,
+        'exp': issued_at + api_settings.JWT_EXPIRATION_DELTA,
+    }
+
+
+def jwt_encode_handler(payload, secret):
+    token = jwt.encode(payload, secret, api_settings.JWT_ALGORITHM)
+    return token.decode('utf-8')
+
+
+def jwt_decode_handler(token, get_api_key=APIKey.get_jwt_key):
+    token_data = jwt.decode(token, verify=False)
+    if 'iss' not in token_data:
+        log.info('No issuer in JWT auth token: {}'.format(token_data))
+        raise jwt.DecodeError('invalid JWT')
+
+    try:
+        api_key = get_api_key(key=token_data['iss'])
+    except ObjectDoesNotExist, exc:
+        log.info('No API key for JWT issuer: {}'.format(token_data['iss']))
+        raise jwt.DecodeError('unknown JWT issuer')
+
+    # TODO: add nonce checking to prevent replays. bug 1213354.
+
+    options = {
+        'verify_signature': True,
+        'verify_exp': True,
+        'verify_nbf': False,
+        'verify_iat': True,
+        'verify_aud': False,
+        'require_exp': True,
+        'require_iat': True,
+        'require_nbf': False,
+    }
+    try:
+        payload = jwt.decode(
+            token,
+            api_key.secret,
+            verify=True,
+            options=options,
+            leeway=api_settings.JWT_LEEWAY,
+            algorithms=[api_settings.JWT_ALGORITHM]
+        )
+    except Exception, exc:
+        log.info(u'Exception during JWT authentication: '
+                 u'{e.__class__.__name__}: {e}'.format(e=exc))
+        raise
+
+    if payload['exp'] - payload['iat'] > settings.MAX_JWT_AUTH_TOKEN_LIFETIME:
+        log.info('JWT auth: expiration is too long; '
+                 'iss={iss}, iat={iat}, exp={exp}'.format(**payload))
+        raise jwt.DecodeError('Declared expiration was too long')
+
+    return payload

--- a/apps/api/jwt_auth/views.py
+++ b/apps/api/jwt_auth/views.py
@@ -1,0 +1,58 @@
+from rest_framework import exceptions
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+
+from apps.api.models import APIKey
+
+
+class JWTKeyAuthentication(JSONWebTokenAuthentication):
+    """
+    DRF authentication class for JWT header auth.
+
+    This extends the django-rest-framework-jwt auth class to get the
+    shared JWT secret from our APIKey database model. Each user (an add-on
+    developer) can have one or more API keys. The JWT is issued with their
+    public ID and is signed with their secret.
+
+    **IMPORTANT**
+
+    Please note that unlike typical JWT usage, this authenticator only
+    signs and verifies that the user is who they say they are. It does
+    not sign and verify the *entire request*. In other words, when you use
+    this authentication method you cannot prove that the request was made
+    by the authenticated user.
+    """
+
+    def authenticate_credentials(self, payload):
+        """
+        Returns a verified AMO user who is active and allowed to make API
+        requests.
+        """
+        try:
+            api_key = APIKey.get_jwt_key(key=payload['iss'])
+        except APIKey.DoesNotExist:
+            msg = 'Invalid API Key.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        if api_key.user.deleted:
+            msg = 'User account is disabled.'
+            raise exceptions.AuthenticationFailed(msg)
+        if not api_key.user.read_dev_agreement:
+            msg = 'User has not read developer agreement.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        return api_key.user
+
+
+class JWTProtectedView(APIView):
+    """
+    Base class to protect any API view by way of JWT headers.
+
+    As mentioned in the authentication class, this only verifies that the
+    user is who they say they are, it does not verify that the request came
+    from that user. It's like Oauth 2.0 but without any need to store
+    tokens in the database (because we can just verify the JWT signature).
+    """
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [JWTKeyAuthentication]

--- a/apps/api/tests/assets/test-api-key.txt
+++ b/apps/api/tests/assets/test-api-key.txt
@@ -1,0 +1,1 @@
+this is dummy content for a test key that will never be used in production

--- a/apps/api/tests/test_jwt_auth.py
+++ b/apps/api/tests/test_jwt_auth.py
@@ -1,0 +1,219 @@
+from datetime import datetime, timedelta
+import json
+
+from django.conf import settings
+from django.test import RequestFactory
+
+import jwt
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.response import Response
+from rest_framework_jwt.settings import api_settings
+
+from amo.tests import TestCase, WithDynamicEndpoints
+from apps.api.jwt_auth import handlers
+from apps.api.jwt_auth.views import JWTKeyAuthentication, JWTProtectedView
+from apps.api.models import APIKey, SYMMETRIC_JWT_TYPE
+from apps.users.models import UserProfile
+
+
+class ProtectedView(JWTProtectedView):
+    """
+    This is an example of a view that would be protected by JWT token auth.
+    """
+    def get(self, request):
+        return Response('some get response')
+
+    def post(self, request):
+        return Response({'user_pk': request.user.pk})
+
+
+class JWTAuthTester(TestCase):
+    fixtures = ['base/addon_3615']
+
+    def create_api_key(self, user, key='some-user-key',
+                       secret='some-shared-secret', **kw):
+        return APIKey.objects.create(type=SYMMETRIC_JWT_TYPE,
+                                     user=user, key=key, secret=secret,
+                                     **kw)
+
+    def auth_token_payload(self, user, issuer):
+        jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+        return jwt_payload_handler(user, issuer)
+
+    def encode_token_payload(self, payload, secret):
+        jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+        return jwt_encode_handler(payload, secret)
+
+    def create_auth_token(self, user, issuer, secret):
+        payload = self.auth_token_payload(user, issuer)
+        return self.encode_token_payload(payload, secret)
+
+
+class TestJWTProtectedView(WithDynamicEndpoints, JWTAuthTester):
+
+    def setUp(self):
+        super(TestJWTProtectedView, self).setUp()
+        self.endpoint(ProtectedView)
+        self.client.logout()  # just to be sure!
+
+    def request(self, method, *args, **kw):
+        handler = getattr(self.client, method)
+        return handler('/en-US/firefox/dynamic-endpoint', *args, **kw)
+
+    def jwt_request(self, token, method, *args, **kw):
+        return self.request(method,
+                            HTTP_AUTHORIZATION='JWT {}'.format(token),
+                            *args, **kw)
+
+    def test_get_requires_auth(self):
+        res = self.request('get')
+        assert res.status_code == 401, res.content
+
+    def test_post_requires_auth(self):
+        res = self.request('post', {})
+        assert res.status_code == 401, res.content
+
+    def test_can_post_with_jwt_header(self):
+        user = UserProfile.objects.get(email='del@icio.us')
+        api_key = self.create_api_key(user)
+        token = self.create_auth_token(api_key.user, api_key.key,
+                                       api_key.secret)
+        res = self.jwt_request(token, 'post', {})
+
+        assert res.status_code == 200, res.content
+        data = json.loads(res.content)
+        assert data['user_pk'] == user.pk
+
+
+class TestJWTAuthHandlers(JWTAuthTester):
+
+    def setUp(self):
+        super(TestJWTAuthHandlers, self).setUp()
+        self.user = UserProfile.objects.get(email='del@icio.us')
+
+    def test_decode_unknown_issuer(self):
+        token = self.create_auth_token(self.user, 'non-existant-issuer',
+                                       'some-secret')
+        with self.assertRaises(jwt.DecodeError) as ctx:
+            handlers.jwt_decode_handler(token)
+
+        assert ctx.exception.message == 'unknown JWT issuer'
+
+    def test_decode_token_without_issuer(self):
+        payload = self.auth_token_payload(self.user, 'some-issuer')
+        del payload['iss']
+        token = self.encode_token_payload(payload, 'some-secret')
+        with self.assertRaises(jwt.DecodeError) as ctx:
+            handlers.jwt_decode_handler(token)
+
+        assert ctx.exception.message == 'invalid JWT'
+
+    def test_decode_garbage_token(self):
+        with self.assertRaises(jwt.DecodeError) as ctx:
+            handlers.jwt_decode_handler('}}garbage{{')
+
+        assert ctx.exception.message == 'Not enough segments'
+
+    def test_decode_invalid_non_ascii_token(self):
+        with self.assertRaises(jwt.DecodeError) as ctx:
+            handlers.jwt_decode_handler(u'Ivan Krsti\u0107')
+
+        assert ctx.exception.message == 'Not enough segments'
+
+    def test_incorrect_signature(self):
+        api_key = self.create_api_key(self.user)
+        token = self.create_auth_token(api_key.user, api_key.key,
+                                       api_key.secret)
+
+        decoy_api_key = self.create_api_key(
+            self.user, key='another-issuer', secret='another-secret')
+
+        with self.assertRaises(jwt.DecodeError) as ctx:
+            handlers.jwt_decode_handler(
+                token, get_api_key=lambda **k: decoy_api_key)
+
+        assert ctx.exception.message == 'Signature verification failed'
+
+    def test_expired_token(self):
+        api_key = self.create_api_key(self.user)
+        payload = self.auth_token_payload(self.user, api_key.key)
+        payload['exp'] = (datetime.utcnow() -
+                          api_settings.JWT_EXPIRATION_DELTA -
+                          timedelta(seconds=10))
+        token = self.encode_token_payload(payload, api_key.secret)
+
+        with self.assertRaises(jwt.ExpiredSignatureError):
+            handlers.jwt_decode_handler(token)
+
+    def test_missing_issued_at_time(self):
+        api_key = self.create_api_key(self.user)
+        payload = self.auth_token_payload(self.user, api_key.key)
+        del payload['iat']
+        token = self.encode_token_payload(payload, api_key.secret)
+
+        with self.assertRaises(jwt.MissingRequiredClaimError):
+            handlers.jwt_decode_handler(token)
+
+    def test_missing_expiration(self):
+        api_key = self.create_api_key(self.user)
+        payload = self.auth_token_payload(self.user, api_key.key)
+        del payload['exp']
+        token = self.encode_token_payload(payload, api_key.secret)
+
+        with self.assertRaises(jwt.MissingRequiredClaimError):
+            handlers.jwt_decode_handler(token)
+
+    def test_disallow_long_expirations(self):
+        api_key = self.create_api_key(self.user)
+        payload = self.auth_token_payload(self.user, api_key.key)
+        payload['exp'] = (
+            datetime.utcnow() +
+            timedelta(seconds=settings.MAX_JWT_AUTH_TOKEN_LIFETIME) +
+            timedelta(seconds=1)
+        )
+        token = self.encode_token_payload(payload, api_key.secret)
+
+        with self.assertRaises(jwt.DecodeError) as ctx:
+            handlers.jwt_decode_handler(token)
+
+        assert ctx.exception.message == 'Declared expiration was too long'
+
+
+class TestJWTKeyAuthentication(JWTAuthTester):
+
+    def setUp(self):
+        super(TestJWTKeyAuthentication, self).setUp()
+        self.factory = RequestFactory()
+        self.auth = JWTKeyAuthentication()
+        self.user = UserProfile.objects.get(email='del@icio.us')
+
+    def request(self, token):
+        return self.factory.get('/', HTTP_AUTHORIZATION='JWT {}'.format(token))
+
+    def _create_token(self):
+        api_key = self.create_api_key(self.user)
+        return self.create_auth_token(api_key.user, api_key.key,
+                                      api_key.secret)
+
+    def test_get_user(self):
+        user, _ = self.auth.authenticate(self.request(self._create_token()))
+        assert user == self.user
+
+    def test_unknown_issuer(self):
+        api_key = self.create_api_key(self.user)
+        payload = self.auth_token_payload(self.user, api_key.key)
+        payload['iss'] = 'non-existant-issuer'
+        token = self.encode_token_payload(payload, api_key.secret)
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(self.request(token))
+
+    def test_deleted_user(self):
+        self.user.update(deleted=True)
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(self.request(self._create_token()))
+
+    def test_user_has_not_read_agreement(self):
+        self.user.update(read_dev_agreement=None)
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(self.request(self._create_token()))

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Django settings for olympia project.
 
+import datetime
 import logging
 import os
 import socket
@@ -401,6 +402,7 @@ INSTALLED_APPS = (
     'zadmin',
 
     # Third party apps
+    'aesfield',
     'django_extensions',
     'raven.contrib.django',
     'piston',
@@ -1432,3 +1434,35 @@ STATICFILES_DIRS = (
     JINGO_MINIFY_ROOT
 )
 NETAPP_STORAGE = TMP_PATH
+
+
+# These are key files that must be present on disk to encrypt/decrypt certain
+# database fields.
+AES_KEYS = {
+    #'api_key:secret': os.path.join(ROOT, 'path', 'to', 'file.key'),
+}
+
+# Time in seconds for how long a JWT auth token can live.
+# When developers are creating auth tokens they cannot set the expiration any
+# longer than this.
+MAX_JWT_AUTH_TOKEN_LIFETIME = 60
+
+
+# django-rest-framework-jwt settings:
+JWT_AUTH = {
+    # We don't want to refresh tokens right now. Refreshing a token is when
+    # you accept a request with a valid token and return a new one with a
+    # longer expiration.
+    'JWT_ALLOW_REFRESH': False,
+
+    # JWTs are only valid for one minute. Note that this setting only applies
+    # to token creation which we don't do (yet?).
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(
+        seconds=MAX_JWT_AUTH_TOKEN_LIFETIME),
+
+    'JWT_ENCODE_HANDLER': 'apps.api.jwt_auth.handlers.jwt_encode_handler',
+    'JWT_DECODE_HANDLER': 'apps.api.jwt_auth.handlers.jwt_decode_handler',
+    'JWT_PAYLOAD_HANDLER': 'apps.api.jwt_auth.handlers.jwt_payload_handler',
+    'JWT_ALGORITHM': 'HS256',
+    'JWT_LEEWAY': 0,
+}

--- a/migrations/830-create-api-key.sql
+++ b/migrations/830-create-api-key.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `api_key` (
+    `id` int(11) UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    `user_id` int(11) NOT NULL,
+    `type` int(11) UNSIGNED NOT NULL DEFAULT 1,
+    `key` varchar(255) NOT NULL UNIQUE,
+    `secret` LONGTEXT NOT NULL
+) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
+
+ALTER TABLE `api_key` ADD CONSTRAINT `api_key_user_id`
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -19,6 +19,7 @@ defusedxml==0.4.1
 dennis==0.4.2
 Django==1.6.11
 dj-database-url==0.2.2
+django-aesfield==0.1.2
 django-cache-nuggets==0.1.1
 django-cronjobs==0.2.3
 django_csp==2.0.3
@@ -30,7 +31,7 @@ django-quieter-formset==0.4
 django-raven-heka==0.3
 django-recaptcha-mozilla==0.0.1
 djangorestframework==2.3.12
-#django-session-csrf==0.6
+djangorestframework-jwt==1.7.2
 django-statsd-mozilla==0.3.10
 django-storages==1.1.8
 django-waffle==0.9.2
@@ -51,6 +52,7 @@ kombu==3.0.26
 heka-py==0.30.3
 heka-py-cef==0.3.1
 heka-py-raven==0.6
+m2secret==0.1.1
 mock==1.0.1
 monolith.client==0.9
 moz-addon-packager==1.0.1
@@ -65,6 +67,7 @@ pyhs2==0.4.1
 polib==1.0.3
 protobuf==2.5.0
 pyasn1==0.1.7
+PyJWT==1.4.0
 PyMySQL==0.5
 pyquery==0.4
 python-dateutil==1.5

--- a/settings.py
+++ b/settings.py
@@ -102,6 +102,12 @@ DEBUG_TOOLBAR_CONFIG = {
     "SHOW_TOOLBAR_CALLBACK": "settings.show_toolbar_callback",
 }
 
+AES_KEYS = {
+    'api_key:secret': os.path.join(ROOT, 'apps', 'api', 'tests', 'assets',
+                                   'test-api-key.txt'),
+}
+
+
 # If you have settings you want to overload, put them in a local_settings.py.
 try:
     from local_settings import *  # noqa


### PR DESCRIPTION
This sets the foundation for JWT token auth. The rationale for using header tokens is in the bug (and linked discussion).

TODO:
* [ ] add a bunch of docstrings :)