### PR TITLE
More names for download sources

### DIFF
--- a/static/js/impala/stats/csv_keys.js
+++ b/static/js/impala/stats/csv_keys.js
@@ -41,7 +41,9 @@ var csv_keys = {
     sources: {
         "null"                  : gettext('Unknown'),
         'api'                   : gettext('Add-ons Manager'),
-        'discovery-promo'       : gettext('Add-ons Manager Discovery Pane Promo'),
+        'discovery-promo'       : gettext('Add-ons Manager Promo'),
+        'discovery-featured'    : gettext('Add-ons Manager Featured'),
+        'discovery-learnmore'   : gettext('Add-ons Manager Learn More'),
         'ss'                    : gettext('Search Suggestions'),
         'search'                : gettext('Search Results'),
         'homepagepromo'         : gettext('Homepage Promo'),


### PR DESCRIPTION
Found some more sources in use. Having the words 'Discovery Pane' as well as the rest was unwieldy, so I removed it.