### PR TITLE
Protect api key page with agreement (bug 1213054)

### DIFF
--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1129,6 +1129,7 @@ class TestSubmitBase(amo.tests.TestCase):
 class TestAPIAgreement(TestSubmitBase):
     def setUp(self):
         super(TestAPIAgreement, self).setUp()
+        self.user = UserProfile.objects.get(email='del@icio.us')
         self.create_switch('signing-api', db=True)
 
     def test_agreement_first(self):
@@ -1152,7 +1153,13 @@ class TestAPIKeyPage(amo.tests.TestCase):
     def setUp(self):
         super(TestAPIKeyPage, self).setUp()
         assert self.client.login(username='del@icio.us', password='password')
+        self.user = UserProfile.objects.get(email='del@icio.us')
         self.create_switch('signing-api', db=True)
+
+    def test_key_redirect(self):
+        self.user.update(read_dev_agreement=None)
+        response = self.client.get(reverse('devhub.api_key'))
+        self.assertRedirects(response, reverse('devhub.api_key_agreement'))
 
     def test_key_page(self):
         response = self.client.get(reverse('devhub.api_key'))

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1755,6 +1755,9 @@ def render_agreement(request, template, next_step, step=None):
 @login_required
 @waffle_switch('signing-api')
 def api_key(request):
+    if request.user.read_dev_agreement is None:
+        return redirect(reverse('devhub.api_key_agreement'))
+
     user_id = None
     secret = None
 


### PR DESCRIPTION
@kumar303 I'm a bit unfamiliar with normally protecting views like this in django but might a decorator be a better idea here or is this solution alright? I decided to go with this at first since it's the simpler of the two.