### PR TITLE
Generate new API credentials (bug 1209222)

### DIFF
--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -109,6 +109,30 @@ class APIKey(models.Model):
         """
         return cls.objects.get(type=SYMMETRIC_JWT_TYPE, **query)
 
+    @classmethod
+    def new_jwt_credentials(cls, user, **attributes):
+        # This could get more fancy if we allow multiple keys per user.
+        key = 'user:{}'.format(user.pk)
+        return cls.objects.create(key=key, secret=cls.generate_secret(32),
+                                  type=SYMMETRIC_JWT_TYPE, user=user,
+                                  **attributes)
+
+    @staticmethod
+    def generate_secret(byte_length):
+        """Return a true random ascii string containing byte_length of randomness.
+
+        The resulting key is suitable for cryptogrpahy.
+        The key will be hex encoded which means it will be twice as long
+        as byte_length, i.e. 40 random bytes yields an 80 byte string.
+
+        byte_length must be at least 32.
+        """
+        if byte_length < 32:  # at least 256 bit
+            raise ValueError(
+                'um, {} is probably not long enough for cryptography'
+                .format(byte_length))
+        return os.urandom(byte_length).encode('hex')
+
 
 def generate():
     return os.urandom(64).encode('hex')

--- a/apps/api/tests/test_models.py
+++ b/apps/api/tests/test_models.py
@@ -1,0 +1,26 @@
+from amo.tests import TestCase
+from users.models import UserProfile
+
+from ..models import APIKey, SYMMETRIC_JWT_TYPE
+
+
+class TestAPIKey(TestCase):
+    fixtures = ['base/addon_3615']
+
+    def setUp(self):
+        super(TestAPIKey, self).setUp()
+        self.user = UserProfile.objects.get(email='del@icio.us')
+
+    def test_new_jwt_credentials(self):
+        credentials = APIKey.new_jwt_credentials(self.user)
+        assert credentials.user == self.user
+        assert credentials.type == SYMMETRIC_JWT_TYPE
+        assert credentials.key
+        assert credentials.secret
+
+    def test_generate_secret(self):
+        assert APIKey.generate_secret(32)  # check for exceptions
+
+    def test_generated_secret_must_be_long_enough(self):
+        with self.assertRaises(ValueError):
+            APIKey.generate_secret(31)

--- a/apps/devhub/templates/devhub/api/key.html
+++ b/apps/devhub/templates/devhub/api/key.html
@@ -14,21 +14,54 @@
       {{ csrf() }}
       <fieldset>
         <legend>
-          {{ _('Generate a new API key.') }}
+          {{ _('API Credentials') }}
         </legend>
-        <ul>
-          <li class="row api-input">
-            <label for="jwtkey" class="row">{{ _('API ID') }}</label>
-            <input type="text" name="jwtkey" value="{{ key }}" disabled />
-          </li>
-          <li class="row api-input">
-            <label for="jwtsecret" class="row">{{ _('API Secret') }}</label>
-            <input type="text" name="jwtsecret" value="{{ secret }}" disabled />
-          </li>
-        </ul>
+        {% if credentials %}
+          <ul class="api-credentials">
+            <li class="row api-input key-input">
+              <label for="jwtkey" class="row">{{ _('JWT issuer') }}</label>
+              <input type="text" name="jwtkey" value="{{ credentials.key }}" disabled />
+            </li>
+            <li class="row api-input">
+              <label for="jwtsecret" class="row">{{ _('JWT secret') }}</label>
+              <input type="text" name="jwtsecret" value="{{ credentials.secret }}" disabled />
+            </li>
+          </ul>
+          <p>
+          {% trans
+              jwt_url='https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html',
+              node_jwt_url='https://github.com/auth0/node-jsonwebtoken' %}
+            To make API requests, send a <a href="{{ jwt_url }}">JWT (JSON Web Token)</a> as the authorization header.
+            You'll need to generate a JWT for every request like in the following example using the
+            <a href="{{ node_jwt_url }}">node-jsonwebtoken</a> library.
+          {% endtrans %}
+          </p>
+          <p>
+            <code><pre>var jwt = require('jsonwebtoken');
+var secret = 'your-secret-key';  // store this securely.
+
+var token = jwt.sign({iss: '{{ credentials.key }}'}, secret, {
+  algorithm: 'HS256',  // HMAC-SHA256 signing algorithm
+  expiresIn: 60,  // one minute from now
+});
+
+var authorizationHeader = 'JWT ' + token;</pre></code>
+          </p>
+          <p>
+          {% trans docs_url='#' %}
+            Consult the <a href="{{ docs_url }}">documentation</a> for more details.
+          {% endtrans %}
+          </p>
+        {% else %}
+        <p>
+        {% trans %}
+          You don't have any API credentials yet.
+        {% endtrans %}
+        </p>
+        {% endif %}
       </fieldset>
       <div class="listing-footer">
-        <button class="button button prominent" type="submit">{{ _('Generate New Key') }}</button>
+        <button id="generate-key" class="button prominent" type="submit">{{ _('Generate New Credentials') }}</button>
       </div>
     </form>
   </div>

--- a/static/css/impala/devhub-api.less
+++ b/static/css/impala/devhub-api.less
@@ -1,11 +1,19 @@
+.api-credentials {
+    margin-bottom: 2em;
+}
+
 .api-input {
     input[type=text] {
         box-shadow: none;
-        text-align: center;
+        text-align: left;
         font-size: 1.5em;
+        width: 78%;
     }
     label {
       font-weight: bold;
       display: block;
+      width: 10%;
+      float: left;
+      padding: 0.4em;
     }
 }


### PR DESCRIPTION
The text on the API key page is still a placeholder. Some or all of it may be moved to the official docs, I'm not sure yet.

![screenshot 2015-10-13 10 53 25](https://cloud.githubusercontent.com/assets/55398/10460372/a2f5d446-7199-11e5-9b88-bb0f2cf3cb22.png)
