### PR TITLE
Upload a new version for an add-on (bug 1208561)

### DIFF
--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -145,4 +145,5 @@ urlpatterns = patterns(
     url(r'^(?P<api_version>\d+|\d+.\d+)/search/guid:(?P<guids>.*)',
         views.guid_search),
     url(r'^(?P<api_version>\d+|\d+.\d+)/', include(api_patterns)),
+    url(r'^v3/', include('signing.urls')),
 )

--- a/apps/signing/urls.py
+++ b/apps/signing/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^addons/(?P<guid>[^/]+)/versions/(?P<version>[^/]+)/$',
+        views.UploadAddonView.as_view(),
+        name='signing.upload_version'),
+]

--- a/apps/signing/views.py
+++ b/apps/signing/views.py
@@ -1,0 +1,46 @@
+from django import forms
+
+from rest_framework import status
+from rest_framework.response import Response
+from tower import ugettext as _
+
+from api.jwt_auth.views import JWTProtectedView
+from addons.models import Addon
+from devhub.views import handle_upload
+from files.utils import parse_addon
+
+
+class UploadAddonView(JWTProtectedView):
+
+    def put(self, request, guid, version):
+        try:
+            addon = Addon.unfiltered.get(guid=guid)
+        except Addon.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        if not addon.has_author(request.user):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            filedata = request.FILES['upload']
+        except KeyError:
+            return Response({"error": "No 'upload' file found."},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        # Verify that the guid and version match.
+        try:
+            pkg = parse_addon(filedata, addon)
+        except forms.ValidationError as e:
+            return Response({"error": e.message},
+                            status=status.HTTP_400_BAD_REQUEST)
+        if pkg['version'] != version:
+            return Response(
+                {"error": _("Version does not match install.rdf.")},
+                status=status.HTTP_400_BAD_REQUEST)
+        elif addon.versions.filter(version=version).exists():
+            return Response({"error": _("Version already exists.")},
+                            status=status.HTTP_409_CONFLICT)
+
+        file_upload = handle_upload(
+            filedata=filedata, user=request.user, addon=addon, submit=True)
+
+        return Response({'id': file_upload.pk})


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1208561

Just opening this up so I can verify all the tests pass and keep a todo list.

Todo
* [x] Add a new validation task that auto-submits on success.
* [x] Use the auto-submit task in `handle_upload`.
* [ ] Return  `423 LOCKED` if still validating.
* [x] Return `409 CONFLICT` if version already exists.
* [x] Verify the guid and version match the `install.rdf`.
* [ ] Tests.

Maybe
* [x] Return `403 FORBIDDEN` if the add-on exists but you don't own it.

Likely for later:
* [ ] Allow the developer to specify if validation failures can go to manual review.