### PR TITLE
Disable collections folder in robots.txt (bug 1210603)

### DIFF
--- a/apps/amo/templates/amo/robots.html
+++ b/apps/amo/templates/amo/robots.html
@@ -17,6 +17,7 @@ Disallow: /{{ a.short }}{{ remora_url('downloads', lang='', app='') }}/
 
 Disallow: /{{ l }}/{{ a.short }}{{ url('search.search', add_prefix=False) }}
 Disallow: /{{ l }}/{{ a.short }}{{ url('password_reset_form', add_prefix=False) }}
+Disallow: /{{ l }}/{{ a.short }}{{ url('collections.list', add_prefix=False) }}
 {% endfor %}
 
 {% endfor %}

--- a/apps/amo/tests/test_views.py
+++ b/apps/amo/tests/test_views.py
@@ -390,3 +390,13 @@ class TestContribute(amo.tests.TestCase):
         res = self.client.get('/contribute.json')
         eq_(res.status_code, 200)
         eq_(res._headers['content-type'], ('Content-Type', 'application/json'))
+
+
+class TestRobots(amo.tests.TestCase):
+
+    def test_disable_collections(self):
+        """Make sure /en-US/firefox/collections/ gets disabled"""
+        url = reverse('collections.list')
+        response = self.client.get('/robots.txt')
+        eq_(response.status_code, 200)
+        assert 'Disallow: %s' % url in response.content

--- a/apps/amo/tests/test_views.py
+++ b/apps/amo/tests/test_views.py
@@ -5,6 +5,7 @@ import urllib
 
 from django import test
 from django.conf import settings
+from django.test.utils import override_settings
 
 import commonware.log
 from lxml import etree
@@ -394,6 +395,7 @@ class TestContribute(amo.tests.TestCase):
 
 class TestRobots(amo.tests.TestCase):
 
+    @override_settings(ENGAGE_ROBOTS=True)
     def test_disable_collections(self):
         """Make sure /en-US/firefox/collections/ gets disabled"""
         url = reverse('collections.list')


### PR DESCRIPTION
Example robots.txt output: https://gist.github.com/EnTeQuAk/38e6f08e7ee65b03b18f

This should disable everything under /collections/* as well.