### PR TITLE
Never load jquery twice on the same page (bug 1038301)

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -591,8 +591,6 @@ MINIFY_BUNDLES = {
     'js': {
         # JS files common to the entire site (pre-impala).
         'common': (
-            'js/lib/jquery-1.9.1.js',
-            'js/lib/jquery-migrate-1.2.1.min.js',
             'js/lib/underscore.js',
             'js/zamboni/browser.js',
             'js/amo2009/addons.js',


### PR DESCRIPTION
Fixes [bug 1038301](https://bugzilla.mozilla.org/show_bug.cgi?id=1038301)

Supersedes #597 

Check https://github.com/mozilla/olympia/pull/597#issuecomment-149483236 for the rationale behind this change.