### PR TITLE
Use things by default in docker

### DIFF
--- a/docs/topics/hacking/debugging.rst
+++ b/docs/topics/hacking/debugging.rst
@@ -53,8 +53,12 @@ The `Django Debug Toolbar`_ is very powerful and useful when viewing pages from
 the website, to check the view used, its parameters, the SQL queries, the
 templates rendered and their context...
 
-It should be enabled local development as long as ``settings.DEBUG`` is set to
-``True`` (which it is by default).
+To enable it add the following setting to your ``local_settings.py`` file (you
+may need to create it)::
+
+    DEBUG_TOOLBAR_CONFIG = {
+        "SHOW_TOOLBAR_CALLBACK": "settings.debug_toolbar_enabled",
+    }
 
 All being well it should look like this at the top-right of any web page on
 olympia:

--- a/settings.py
+++ b/settings.py
@@ -86,7 +86,12 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False  # Prevent DDT from patching the settings.
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
 
-def show_toolbar_callback(request):
+def debug_toolbar_disabled(request):
+    """Callback used by the Django Debug Toolbar to decide when to display."""
+    return False
+
+
+def debug_toolbar_enabled(request):
     """Callback used by the Django Debug Toolbar to decide when to display."""
     # We want to make sure to have the DEBUG value at runtime, not the one we
     # have in this specific settings file.
@@ -95,7 +100,7 @@ def show_toolbar_callback(request):
 
 
 DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": "settings.show_toolbar_callback",
+    "SHOW_TOOLBAR_CALLBACK": "settings.debug_toolbar_disabled",
 }
 
 AES_KEYS = {

--- a/settings.py
+++ b/settings.py
@@ -43,8 +43,7 @@ HAS_SYSLOG = False  # syslog is used if HAS_SYSLOG and NOT DEBUG.
 SESSION_COOKIE_SECURE = False
 SESSION_COOKIE_DOMAIN = None
 
-# Disables custom routing in settings.py so that tasks actually run.
-CELERY_ALWAYS_EAGER = True
+CELERY_ALWAYS_EAGER = False
 CELERY_ROUTES = {}
 
 # If you want to allow self-reviews for add-ons/apps, then enable this.
@@ -68,10 +67,7 @@ SITE_URL = 'http://localhost:8000'
 SERVICES_DOMAIN = 'localhost:8000'
 SERVICES_URL = 'http://%s' % SERVICES_DOMAIN
 
-# Turn off validation by default on development instances, until we have an
-# easy way to install a working copy of Spidermonkey. Real Soon Now(R).
-# No, really, though, soon.
-VALIDATE_ADDONS = False
+VALIDATE_ADDONS = True
 
 ADDON_COLLECTOR_ID = 1
 


### PR DESCRIPTION
This enables celery and validating add-ons by default. Removes `debug_toolbar` since it doesn't play nice with docker.