### PR TITLE
Improve collections ajax list performance. (bug 1211692)

### DIFF
--- a/apps/bandwagon/models.py
+++ b/apps/bandwagon/models.py
@@ -48,7 +48,11 @@ class TopTags(object):
 class CollectionQuerySet(caching.CachingQuerySet):
 
     def with_has_addon(self, addon_id):
-        """Annotate a collection with a `has_addon` property related to `addon_id`"""
+        """Add a `has_addon` property to each collection.
+
+        `has_addon` will be `True` if `addon_id` exists in that
+        particular collection.
+        """
         has_addon = """
             select 1 from addons_collections as ac
                 where ac.addon_id = %s and ac.collection_id = collections.id

--- a/apps/bandwagon/models.py
+++ b/apps/bandwagon/models.py
@@ -45,10 +45,25 @@ class TopTags(object):
         cache.set(self.key(obj), value, two_days)
 
 
+class CollectionQuerySet(caching.CachingQuerySet):
+
+    def with_has_addon(self, addon_id):
+        """Annotate a collection with a `has_addon` property related to `addon_id`"""
+        has_addon = """
+            select 1 from addons_collections as ac
+                where ac.addon_id = %s and ac.collection_id = collections.id
+                limit 1"""
+
+        return self.extra(
+            select={'has_addon': has_addon},
+            select_params=(addon_id,))
+
+
 class CollectionManager(amo.models.ManagerBase):
 
     def get_query_set(self):
         qs = super(CollectionManager, self).get_query_set()
+        qs = qs._clone(klass=CollectionQuerySet)
         return qs.transform(Collection.transformer)
 
     def manual(self):

--- a/apps/bandwagon/tests/test_models.py
+++ b/apps/bandwagon/tests/test_models.py
@@ -222,7 +222,10 @@ class TestCollectionQuerySet(amo.tests.TestCase):
         collection = Collection.objects.create(author=user)
         addon = Addon.objects.all()[0]
 
-        qset = Collection.objects.filter(pk=collection.id).with_has_addon(addon.id)
+        qset = (
+            Collection.objects
+            .filter(pk=collection.id)
+            .with_has_addon(addon.id))
 
         assert not qset.first().has_addon
 

--- a/apps/bandwagon/tests/test_models.py
+++ b/apps/bandwagon/tests/test_models.py
@@ -214,6 +214,23 @@ class TestCollections(amo.tests.TestCase):
         eq_(c.can_view_stats(fake_request), True)
 
 
+class TestCollectionQuerySet(amo.tests.TestCase):
+    fixtures = ('base/addon_3615',)
+
+    def test_with_has_addon(self):
+        user = UserProfile.objects.create(username='uhhh', email='uh@hh')
+        collection = Collection.objects.create(author=user)
+        addon = Addon.objects.all()[0]
+
+        qset = Collection.objects.filter(pk=collection.id).with_has_addon(addon.id)
+
+        assert not qset.first().has_addon
+
+        collection.add_addon(addon)
+
+        assert qset.first().has_addon
+
+
 class TestRecommendations(amo.tests.TestCase):
     fixtures = ['base/addon-recs']
     ids = [5299, 1843, 2464, 7661, 5369]

--- a/apps/bandwagon/views.py
+++ b/apps/bandwagon/views.py
@@ -369,7 +369,8 @@ def ajax_list(request):
     except (KeyError, ValueError):
         return http.HttpResponseBadRequest()
 
-    collections = (Collection.objects
+    collections = (
+        Collection.objects
         .publishable_by(request.amo_user)
         .with_has_addon(addon_id))
 

--- a/apps/bandwagon/views.py
+++ b/apps/bandwagon/views.py
@@ -369,16 +369,9 @@ def ajax_list(request):
     except (KeyError, ValueError):
         return http.HttpResponseBadRequest()
 
-    # Get collections associated with this user
-    has_addon = """
-        select 1 from addons_collections as ac
-            where ac.addon_id = %s and ac.collection_id = collections.id
-            limit 1"""
-
-    collections = Collection.objects.publishable_by(request.amo_user) \
-        .extra(
-            select={'has_addon': has_addon},
-            select_params=(addon_id,))
+    collections = (Collection.objects
+        .publishable_by(request.amo_user)
+        .with_has_addon(addon_id))
 
     return render(request, 'bandwagon/ajax_list.html',
                   {'collections': collections})

--- a/apps/bandwagon/views.py
+++ b/apps/bandwagon/views.py
@@ -372,7 +372,7 @@ def ajax_list(request):
     # Get collections associated with this user
     has_addon = """
         select 1 from addons_collections as ac
-            where ac.addon_id = %s and ac.collection_id = collections.id
+            where ac.addon_id = %d and ac.collection_id = collections.id
             limit 1"""
 
     collections = Collection.objects.publishable_by(request.amo_user) \

--- a/apps/bandwagon/views.py
+++ b/apps/bandwagon/views.py
@@ -372,7 +372,7 @@ def ajax_list(request):
     # Get collections associated with this user
     has_addon = """
         select 1 from addons_collections as ac
-            where ac.addon_id = %d and ac.collection_id = collections.id
+            where ac.addon_id = %s and ac.collection_id = collections.id
             limit 1"""
 
     collections = Collection.objects.publishable_by(request.amo_user) \


### PR DESCRIPTION
This uses a simple extra query to check if the addon exists in a collection or not. This avoids the for-loop and thus n queries on a (possibly) huge list of addon ids.

Please feel free to open the discussion if a raw-select is appropriate here. Since it's now super-fast I'd say yes.
