### PR TITLE
Remove 'emailhidden' flag (bug 1214848)

### DIFF
--- a/apps/stats/models.py
+++ b/apps/stats/models.py
@@ -257,14 +257,6 @@ class Contribution(amo.models.ModelBase):
         from_email = settings.DEFAULT_FROM_EMAIL
         if self.addon.support_email:
             from_email = str(self.addon.support_email)
-        else:
-            try:
-                author = self.addon.listed_authors[0]
-                if author.email and not author.emailhidden:
-                    from_email = author.email
-            except (IndexError, TypeError):
-                # This shouldn't happen, but the default set above is still ok.
-                pass
 
         # We need the contributor's email.
         to_email = self.post_data['payer_email']

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -25,7 +25,7 @@ class UserAdmin(admin.ModelAdmin):
         }),
         ('Flags', {
             'fields': ('deleted', 'display_collections',
-                       'display_collections_fav', 'emailhidden',
+                       'display_collections_fav',
                        'notifycompat', 'notifyevents'),
         }),
         ('Admin', {

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -284,8 +284,7 @@ class UserRegisterForm(happyforms.ModelForm, UsernameMixin, PasswordMixin):
     class Meta:
         model = UserProfile
         fields = ('username', 'display_name', 'location', 'occupation',
-                  'password', 'password2', 'recaptcha', 'homepage', 'email',
-                  'emailhidden')
+                  'password', 'password2', 'recaptcha', 'homepage', 'email')
 
     def __init__(self, *args, **kwargs):
         super(UserRegisterForm, self).__init__(*args, **kwargs)

--- a/apps/users/templates/users/edit.html
+++ b/apps/users/templates/users/edit.html
@@ -39,13 +39,6 @@ data-default-locale="{{ request.LANG|lower }}"
               {{ form.email.errors }}
             </li>
             <li>
-              <label for="id_emailhidden" class="check">
-                {{ form.emailhidden }}
-                {{ _('Hide email address from other users') }}
-              </label>
-              {{ form.emailhidden.errors }}
-            </li>
-            <li>
               <a href="#acct-password" id="change-acct-password">
                 {{ _('Change Password') }}</a>
             </li>

--- a/apps/users/templates/users/register.html
+++ b/apps/users/templates/users/register.html
@@ -64,13 +64,6 @@
               {{ form.email }}
               {{ form.email.errors }}
             </li>
-            <li class="check">
-              <label for="id_emailhidden" class="check">
-                {{ form.emailhidden }}
-                {{ _('Hide email address from other users') }}
-              </label>
-              {{ form.emailhidden.errors }}
-            </li>
             <li{% if form.password.errors %} class="error"{% endif %}>
               <label for="id_password">{{ _('Password') }} {{ required() }}</label>
               {{ form.password }}

--- a/apps/users/templates/users/vcard.html
+++ b/apps/users/templates/users/vcard.html
@@ -24,12 +24,6 @@
           {{ profile.homepage }}</a></td>
       </tr>
     {% endif %}
-    {% if not profile.emailhidden %}
-      <tr>
-        <th>{{ _('Email address') }}</th>
-        <td>{{ emaillink(profile.email) }}</td>
-      </tr>
-    {% endif %}
     <tr>
       <th>{{ _('User since') }}</th>
       <td>{{ profile.created|datetime }}</td>


### PR DESCRIPTION
We're assuming and hiding email addresses everywhere by default now, thus removing the flag since most of our users hide their email address anyway.

This removes all occurrences in the code, the database flag will be dropped in a later iteration.