### PR TITLE
Parse the WebExtension's manifest on submission (bug 1217358)

### DIFF
--- a/apps/files/tests/test_utils_.py
+++ b/apps/files/tests/test_utils_.py
@@ -1,5 +1,4 @@
 import json
-from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -10,7 +9,8 @@ import amo.tests
 from addons.models import Addon
 from applications.models import AppVersion
 from files.models import File
-from files.utils import find_jetpacks, is_beta, PackageJSONExtractor
+from files.utils import (find_jetpacks, is_beta, ManifestJSONExtractor,
+                         PackageJSONExtractor)
 from versions.models import Version
 
 
@@ -119,81 +119,76 @@ class TestFindJetpacks(amo.tests.TestCase):
 
 class TestPackageJSONExtractor(amo.tests.TestCase):
 
-    @contextmanager
-    def extractor(self, base_data):
-        with NamedTemporaryFile() as f:
-            f.write(json.dumps(base_data))
-            f.flush()
-            yield PackageJSONExtractor(f.name)
+    def parse(self, base_data):
+        return PackageJSONExtractor('/fake_path',
+                                    json.dumps(base_data)).parse()
 
     def create_appversion(self, name, version):
         return AppVersion.objects.create(application=amo.APPS[name].id,
                                          version=version)
 
+    def test_instanciate_without_data(self):
+        """Without data, we load the data from the file path."""
+        data = {'id': 'some-id'}
+        with NamedTemporaryFile() as file_:
+            file_.write(json.dumps(data))
+            file_.flush()
+            mje = ManifestJSONExtractor(file_.name)
+            assert mje.data == data
+
     def test_guid(self):
         """Use id for the guid."""
-        with self.extractor({'id': 'some-id'}) as extractor:
-            eq_(extractor.parse()['guid'], 'some-id')
+        assert self.parse({'id': 'some-id'})['guid'] == 'some-id'
 
     def test_name_for_guid_if_no_id(self):
         """Use the name for the guid if there is no id."""
-        with self.extractor({'name': 'addon-name'}) as extractor:
-            eq_(extractor.parse()['guid'], 'addon-name')
+        assert self.parse({'name': 'addon-name'})['guid'] == 'addon-name'
 
     def test_type(self):
         """Package.json addons are always ADDON_EXTENSION."""
-        with self.extractor({}) as extractor:
-            eq_(extractor.parse()['type'], amo.ADDON_EXTENSION)
+        assert self.parse({})['type'] == amo.ADDON_EXTENSION
 
     def test_no_restart(self):
         """Package.json addons are always no-restart."""
-        with self.extractor({}) as extractor:
-            eq_(extractor.parse()['no_restart'], True)
+        assert self.parse({})['no_restart'] == True
 
     def test_name_from_title_with_name(self):
         """Use the title for the name."""
         data = {'title': 'The Addon Title', 'name': 'the-addon-name'}
-        with self.extractor(data) as extractor:
-            eq_(extractor.parse()['name'], 'The Addon Title')
+        assert self.parse(data)['name'] == 'The Addon Title'
 
     def test_name_from_name_without_title(self):
         """Use the name for the name if there is no title."""
-        with self.extractor({'name': 'the-addon-name'}) as extractor:
-            eq_(extractor.parse()['name'], 'the-addon-name')
+        assert (
+            self.parse({'name': 'the-addon-name'})['name'] == 'the-addon-name')
 
     def test_version(self):
         """Use version for the version."""
-        with self.extractor({'version': '23.0.1'}) as extractor:
-            eq_(extractor.parse()['version'], '23.0.1')
+        assert self.parse({'version': '23.0.1'})['version'] == '23.0.1'
 
     def test_homepage(self):
         """Use homepage for the homepage."""
-        with self.extractor({'homepage': 'http://my-addon.org'}) as extractor:
-            eq_(extractor.parse()['homepage'], 'http://my-addon.org')
+        assert (
+            self.parse({'homepage': 'http://my-addon.org'})['homepage'] ==
+            'http://my-addon.org')
 
     def test_summary(self):
         """Use description for the summary."""
-        with self.extractor({'description': 'An addon.'}) as extractor:
-            eq_(extractor.parse()['summary'], 'An addon.')
+        assert (
+            self.parse({'description': 'An addon.'})['summary'] == 'An addon.')
 
     def test_apps(self):
         """Use engines for apps."""
         firefox_version = self.create_appversion('firefox', '33.0a1')
         thunderbird_version = self.create_appversion('thunderbird', '33.0a1')
-        data = {
-            'engines': {
-                'firefox': '>=33.0a1',
-                'thunderbird': '>=33.0a1',
-            },
-        }
-        with self.extractor(data) as extractor:
-            apps = extractor.parse()['apps']
-            apps_dict = dict((app.appdata.short, app) for app in apps)
-            assert sorted(apps_dict.keys()) == ['firefox', 'thunderbird']
-            assert apps_dict['firefox'].min == firefox_version
-            assert apps_dict['firefox'].max == firefox_version
-            assert apps_dict['thunderbird'].min == thunderbird_version
-            assert apps_dict['thunderbird'].max == thunderbird_version
+        data = {'engines': {'firefox': '>=33.0a1', 'thunderbird': '>=33.0a1'}}
+        apps = self.parse(data)['apps']
+        apps_dict = dict((app.appdata.short, app) for app in apps)
+        assert sorted(apps_dict.keys()) == ['firefox', 'thunderbird']
+        assert apps_dict['firefox'].min == firefox_version
+        assert apps_dict['firefox'].max == firefox_version
+        assert apps_dict['thunderbird'].min == thunderbird_version
+        assert apps_dict['thunderbird'].max == thunderbird_version
 
     def test_unknown_apps_are_ignored(self):
         """Unknown engines get ignored."""
@@ -206,10 +201,9 @@ class TestPackageJSONExtractor(amo.tests.TestCase):
                 'node': '>=0.10',
             },
         }
-        with self.extractor(data) as extractor:
-            apps = extractor.parse()['apps']
-            engines = [app.appdata.short for app in apps]
-            assert sorted(engines) == ['firefox', 'thunderbird']  # Not node.
+        apps = self.parse(data)['apps']
+        engines = [app.appdata.short for app in apps]
+        assert sorted(engines) == ['firefox', 'thunderbird']  # Not node.
 
     def test_invalid_app_versions_are_ignored(self):
         """Valid engines with invalid versions are ignored."""
@@ -220,12 +214,11 @@ class TestPackageJSONExtractor(amo.tests.TestCase):
                 'fennec': '>=33.0a1',
             },
         }
-        with self.extractor(data) as extractor:
-            apps = extractor.parse()['apps']
-            eq_(len(apps), 1)
-            eq_(apps[0].appdata.short, 'firefox')
-            eq_(apps[0].min, firefox_version)
-            eq_(apps[0].max, firefox_version)
+        apps = self.parse(data)['apps']
+        assert len(apps) == 1
+        assert apps[0].appdata.short == 'firefox'
+        assert apps[0].min == firefox_version
+        assert apps[0].max == firefox_version
 
     def test_fennec_is_treated_as_android(self):
         """Treat the fennec engine as android."""
@@ -236,8 +229,106 @@ class TestPackageJSONExtractor(amo.tests.TestCase):
                 'node': '>=0.10',
             },
         }
-        with self.extractor(data) as extractor:
-            apps = extractor.parse()['apps']
-            eq_(apps[0].appdata.short, 'android')
-            eq_(apps[0].min, android_version)
-            eq_(apps[0].max, android_version)
+        apps = self.parse(data)['apps']
+        assert apps[0].appdata.short == 'android'
+        assert apps[0].min == android_version
+        assert apps[0].max == android_version
+
+
+class TestManifestJSONExtractor(amo.tests.TestCase):
+
+    def parse(self, base_data):
+        return ManifestJSONExtractor('/fake_path',
+                                     json.dumps(base_data)).parse()
+
+    def create_appversion(self, name, version):
+        return AppVersion.objects.create(application=amo.APPS[name].id,
+                                         version=version)
+
+    def test_instanciate_without_data(self):
+        """Without data, we load the data from the file path."""
+        data = {'id': 'some-id'}
+        with NamedTemporaryFile() as file_:
+            file_.write(json.dumps(data))
+            file_.flush()
+            pje = PackageJSONExtractor(file_.name)
+            assert pje.data == data
+
+    def test_guid(self):
+        """Use applications>gecko>id for the guid."""
+        assert self.parse(
+            {'applications': {
+                'gecko': {
+                    'id': 'some-id'}}})['guid'] == 'some-id'
+
+    def test_name_for_guid_if_no_id(self):
+        """Use the name for the guid if there is no id."""
+        assert self.parse({'name': 'addon-name'})['guid'] == 'addon-name'
+
+    def test_type(self):
+        """Package.json addons are always ADDON_EXTENSION."""
+        assert self.parse({})['type'] == amo.ADDON_EXTENSION
+
+    def test_no_restart(self):
+        """Package.json addons are always no-restart."""
+        assert self.parse({})['no_restart'] == True
+
+    def test_name(self):
+        """Use name for the name."""
+        assert self.parse({'name': 'addon-name'})['name'] == 'addon-name'
+
+    def test_version(self):
+        """Use version for the version."""
+        assert self.parse({'version': '23.0.1'})['version'] == '23.0.1'
+
+    def test_homepage(self):
+        """Use homepage_url for the homepage."""
+        assert (
+            self.parse({'homepage_url': 'http://my-addon.org'})['homepage'] ==
+            'http://my-addon.org')
+
+    def test_summary(self):
+        """Use description for the summary."""
+        assert (
+            self.parse({'description': 'An addon.'})['summary'] == 'An addon.')
+
+    def test_apps_use_provided_versions(self):
+        """Use the min and max versions if provided."""
+        firefox_min_version = self.create_appversion('firefox', '30.0')
+        firefox_max_version = self.create_appversion('firefox', '30.*')
+        self.create_appversion('firefox', '42.0')  # Default AppVersions.
+        self.create_appversion('firefox', '42.*')
+        data = {
+            'applications': {
+                'gecko': {
+                    'strict_min_version': '>=30.0',
+                    'strict_max_version': '=30.*'}}}
+        apps = self.parse(data)['apps']
+        assert len(apps) == 1  # Only Firefox for now.
+        app = apps[0]
+        assert app.appdata == amo.FIREFOX
+        assert app.min == firefox_min_version
+        assert app.max == firefox_max_version
+
+    def test_apps_use_default_versions_if_none_provided(self):
+        """Use the default min and max versions if none provided."""
+        # Default AppVersions.
+        firefox_min_version = self.create_appversion('firefox', '42.0')
+        firefox_max_version = self.create_appversion('firefox', '42.*')
+        data = {'applications': {'gecko': {'id': 'some-id'}}}
+        apps = self.parse(data)['apps']
+        assert len(apps) == 1  # Only Firefox for now.
+        app = apps[0]
+        assert app.appdata == amo.FIREFOX
+        assert app.min == firefox_min_version
+        assert app.max == firefox_max_version
+
+    def test_invalid_app_versions_are_ignored(self):
+        """Invalid versions are ignored."""
+        data = {
+            'applications': {
+                'gecko': {
+                    # Not created, so are seen as invalid.
+                    'strict_min_version': '>=30.0',
+                    'strict_max_version': '=30.*'}}}
+        assert not self.parse(data)['apps']


### PR DESCRIPTION
Fixes [bug 1217358](https://bugzilla.mozilla.org/show_bug.cgi?id=1217358)

To allow the submission for real, we need [bug 1217810](https://bugzilla.mozilla.org/show_bug.cgi?id=1217810). This PR is only about parsing the new manifest.json format.