### PR TITLE
Change sysvar 'storage_engine' to 'default_storage_engine'.

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -86,7 +86,7 @@ NOBODY_EMAIL = 'nobody@mozilla.org'
 DATABASE_URL = os.environ.get('DATABASE_URL',
                               'mysql://root:@localhost/olympia')
 DATABASES = {'default': dj_database_url.parse(DATABASE_URL)}
-DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB',
+DATABASES['default']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB',
                                    'sql_mode': 'STRICT_ALL_TABLES'}
 DATABASES['default']['TEST_CHARSET'] = 'utf8'
 DATABASES['default']['TEST_COLLATION'] = 'utf8_general_ci'

--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -50,11 +50,11 @@ SYSLOG_CSP = "http_app_addons_dev_csp"
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'mysql_pool'
-DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
-DATABASES['slave']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['slave']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 DATABASES['slave']['sa_pool_key'] = 'slave'
 
 DATABASE_POOL_ARGS = {

--- a/sites/dev/settings_base.py
+++ b/sites/dev/settings_base.py
@@ -29,11 +29,11 @@ ADMINS = ()
 DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'mysql_pool'
-DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 DATABASES['slave'] = dj_database_url.parse(private.DATABASES_SLAVE_URL)
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
-DATABASES['slave']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['slave']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 DATABASES['slave']['sa_pool_key'] = 'slave'
 
 DATABASE_POOL_ARGS = {

--- a/sites/prod/settings_base.py
+++ b/sites/prod/settings_base.py
@@ -25,11 +25,11 @@ ADMINS = ()
 DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'mysql_pool'
-DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 DATABASES['slave'] = dj_database_url.parse(private.DATABASES_SLAVE_URL)
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
-DATABASES['slave']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['slave']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 DATABASE_POOL_ARGS = {
     'max_overflow': 10,

--- a/sites/stage/settings.py
+++ b/sites/stage/settings.py
@@ -49,11 +49,11 @@ SYSLOG_CSP = "http_app_addons_stage_csp"
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'mysql_pool'
-DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
-DATABASES['slave']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['slave']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 DATABASES['slave']['sa_pool_key'] = 'slave'
 
 DATABASE_POOL_ARGS = {

--- a/sites/stage/settings_base.py
+++ b/sites/stage/settings_base.py
@@ -27,11 +27,11 @@ ADMINS = ()
 DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'mysql_pool'
-DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 DATABASES['slave'] = dj_database_url.parse(private.DATABASES_SLAVE_URL)
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
-DATABASES['slave']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['slave']['OPTIONS'] = {'init_command': 'SET default_storage_engine=InnoDB'}
 
 SERVICES_DATABASE = dj_database_url.parse(private.SERVICES_DATABASE_URL)
 


### PR DESCRIPTION
The sysvar 'storage_engine' was removed in MySQL 5.7 and 'default_storage_engine' exists since at least MySQL 5.4 as a replacement.

I just ran into problems with this after pull latest docker-images:

```
OperationalError: (1193, "Unknown system variable 'storage_engine'")
```

Btw, what MySQL are we running on prod? With some luck 5.6+? If so, we're able to remove this line completely.