### PR TITLE
Fix broken autocomplete in addon editing (bug 1214598)

### DIFF
--- a/static/js/impala/formset.js
+++ b/static/js/impala/formset.js
@@ -170,6 +170,25 @@ $.zAutoFormset = function(o) {
         }
     }
 
+    function _renderItem(ul, item) {
+        if (!findItem(item).visible) {
+            var $a = $(format('<a><img src="{0}" alt="">{1}</a>',
+                              [item.icons['32'], item.name]));
+            return $('<li>').data('item.autocomplete', item)
+                            .append($a).appendTo(ul);
+        }
+    }
+
+    function _renderItemData(ul, item) {
+        var rendered = _renderItem( ul, item );
+
+        // We are overwriting `_renderItem` in some places and return
+        // nothing in case of duplicate filtering.
+        if (rendered) {
+            rendered.data("ui-autocomplete-item", item);
+        }
+    }
+
     if (autocomplete) {
         autocomplete();
     } else {
@@ -193,13 +212,12 @@ $.zAutoFormset = function(o) {
                     added();
                 }
             }
-        }).data('autocomplete')._renderItem = function(ul, item) {
-            if (!findItem(item).visible) {
-                var $a = $(format('<a><img src="{0}" alt="">{1}</a>',
-                                  [item.icons['32'], item.name]));
-                return $('<li>').data('item.autocomplete', item)
-                                .append($a).appendTo(ul);
-            }
+        }).data('uiAutocomplete')._renderMenu = function(ul, items) {
+            // Overwrite _renderMenu to patch in our custom `_renderItemData`
+            // and `_renderItem` to allow for our custom list-filter.
+            $.each(items, function(index, item) {
+                _renderItemData(ul, item);
+            });
         };
     }
 


### PR DESCRIPTION
* The autocomplete object get's registered as 'uiAutocomplete' instead of the referenced name 'autocomplete'
* Fixed autocomplete to allow an overwritten `_renderItem` to return nothing

Regarding the last point, I'm not really happy with the location of the fix, I could easily overwrite the menu-rendering in the formset.js if that'd be better.