### PR TITLE
Lock mysql image into 5.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ memcached:
   image: memcached
 
 mysqld:
-  image: mysql
+  image: mysql:5.6
   environment:
     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     - MYSQL_DATABASE='olympia'


### PR DESCRIPTION
The mysql:latest image just got bumped to 5.7 which we're not ready to run yet