### PR TITLE
Be more liberal in accepting uploaded files (bug 1222608)

### DIFF
--- a/apps/devhub/tasks.py
+++ b/apps/devhub/tasks.py
@@ -67,7 +67,9 @@ def validate_and_submit(addon, file_, listed=None):
 def submit_file(addon_pk, file_pk):
     addon = Addon.unfiltered.get(pk=addon_pk)
     file_ = FileUpload.objects.get(pk=file_pk)
-    if file_.passed_all_validations:
+    if (file_.passed_all_validations and
+            not addon.fileupload_set.filter(
+                created__gt=file_.created, version=file_.version).exists()):
         # Import loop.
         from devhub.views import auto_sign_version
 

--- a/apps/signing/tests/test_views.py
+++ b/apps/signing/tests/test_views.py
@@ -124,6 +124,17 @@ class TestUploadVersion(BaseUploadVersionCase):
         assert response.status_code == 409
         assert response.data['error'] == 'Version already exists.'
 
+    def test_version_failed_review(self):
+        self.create_version('3.0')
+        version = Version.objects.get(addon__guid=self.guid, version='3.0')
+        version.update(reviewed=datetime.today())
+        version.files.get().update(reviewed=datetime.today(),
+                                   status=amo.STATUS_DISABLED)
+
+        response = self.put(self.url(self.guid, '3.0'))
+        assert response.status_code == 202
+        assert 'processed' in response.data
+
 
 class TestCheckVersion(BaseUploadVersionCase):
 

--- a/apps/signing/views.py
+++ b/apps/signing/views.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from tower import ugettext as _
 
+import amo
 from addons.models import Addon
 from api.jwt_auth.views import JWTProtectedView
 from devhub.views import handle_upload
@@ -60,7 +61,9 @@ class VersionView(JWTProtectedView):
                 {'error': _('Version does not match install.rdf.')},
                 status=status.HTTP_400_BAD_REQUEST)
         elif (addon is not None and
-                addon.versions.filter(version=version_string).exists()):
+                addon.versions.filter(
+                    version=version_string,
+                    files__status__in=amo.REVIEWED_STATUSES).exists()):
             return Response({'error': _('Version already exists.')},
                             status=status.HTTP_409_CONFLICT)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1222608

There are two commits here because there are two distinct changes:

1. New versions are accepted until one of them passes review.
2. When a `FileUpload` passes validation it will only result in a `Version` if it is the most recent upload for this addon and version.