### PR TITLE
Remove the 'admin override' parameter for auto signing

### DIFF
--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -2786,8 +2786,7 @@ class TestAddVersion(AddVersionTest):
         version = self.addon.versions.get(version='0.1')
         eq_(len(version.all_files), 2)
         mock_auto_sign_file.assert_has_calls(
-            [mock.call(f, is_beta=False, admin_override=False)
-             for f in version.all_files])
+            [mock.call(f, is_beta=False) for f in version.all_files])
 
     def test_with_source(self):
         tdir = temp.gettempdir()

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1216,7 +1216,7 @@ def check_validation_override(request, form, addon, version):
         helper.actions['super']['method']()
 
 
-def auto_sign_file(file_, is_beta=False, admin_override=False):
+def auto_sign_file(file_, is_beta=False):
     """If the file should be automatically reviewed and signed, do it."""
     addon = file_.version.addon
     validation = file_.validation
@@ -1287,9 +1287,8 @@ def version_add(request, addon_id, addon):
     url = reverse('devhub.versions.edit',
                   args=[addon.slug, str(version.id)])
 
-    override = form.cleaned_data.get('admin_override_validation')
     # Sign all the files submitted, one for each platform.
-    auto_sign_version(version, is_beta=is_beta, admin_override=override)
+    auto_sign_version(version, is_beta=is_beta)
 
     return dict(url=url)
 
@@ -1316,8 +1315,7 @@ def version_add_file(request, addon_id, addon, version_id):
     file_form = forms.FileFormSet(prefix='files', queryset=version.files.all())
     form = [f for f in file_form.forms if f.instance == new_file]
 
-    override = new_file_form.cleaned_data.get('admin_override_validation')
-    auto_sign_file(new_file, is_beta=is_beta, admin_override=override)
+    auto_sign_file(new_file, is_beta=is_beta)
 
     return render(request, 'devhub/includes/version_file.html',
                   {'form': form[0], 'addon': addon})


### PR DESCRIPTION
Auto signing files doesn't need to know about "admin override". Putting a file
as "admin override" doesn't make it automatically signed. This parameter was
added in a previous version to allow auto-signing of submitted beta files that
were admin overriden, but since we auto-sign all the beta versions, we don't
need it anymore.

See https://github.com/mozilla/olympia/commit/46f4b6fdf56c32ea41a7c086961f2768cf5ee3a7 (bug 1172690).