### PR TITLE
Remove fixed ID from migration adding 'Experiments:submit' group

### DIFF
--- a/migrations/838-perms-experiments.sql
+++ b/migrations/838-perms-experiments.sql
@@ -1,2 +1,2 @@
-INSERT INTO groups (id, name, rules, notes, created, modified) VALUES
-  (50052, 'Submit experiments (auto signed)', 'Experiments:submit', '', NOW(), NOW());
+INSERT INTO groups (name, rules, notes, created, modified) VALUES
+  ('Submit experiments (auto signed)', 'Experiments:submit', '', NOW(), NOW());


### PR DESCRIPTION
Stupid copy/paste from previous migration, which contained the ID.