### PR TITLE
use set instead of list for better performance

### DIFF
--- a/olympia.py
+++ b/olympia.py
@@ -17,12 +17,12 @@ def update_system_path():
 
     ROOT = os.path.dirname(os.path.abspath(__file__))
 
-    prev_sys_path = list(sys.path)
+    prev_sys_path = set(sys.path)
 
     site.addsitedir(os.path.join(ROOT, 'apps'))
 
     # Move the new items to the front of sys.path.
-    sys.path.sort(key=lambda name: name in prev_sys_path)
+    sys.path.sort(key=prev_sys_path.__contains__)
 
 
 def filter_warnings():


### PR DESCRIPTION
Instead of creating a copy of `sys.path` as a list, we can create
a `set`, which offers constant time lookup during sorting.