### PR TITLE
Prevent password reset from 500'ing if there's an incorrect b64 padding (bug #929)

### DIFF
--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -809,6 +809,12 @@ class TestReset(UserViewBase):
                                      'new_password2': 'password1'})
         eq_(res.status_code, 302)
 
+    def test_reset_incorrect_padding(self):
+        """Fixes #929. Even if the b64 padding is incorrect, don't 500."""
+        token = ["1kql8", "2xg-9f90e30ba5bda600910d"]
+        res = self.client.get(reverse('users.pwreset_confirm', args=token))
+        assert not res.context['validlink']
+
 
 class TestLogout(UserViewBase):
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -668,7 +668,7 @@ def password_reset_confirm(request, uidb64=None, token=None):
     try:
         uid_int = urlsafe_base64_decode(uidb64)
         user = UserProfile.objects.get(id=uid_int)
-    except (ValueError, UserProfile.DoesNotExist):
+    except (ValueError, UserProfile.DoesNotExist, TypeError):
         pass
 
     if user is not None and default_token_generator.check_token(user, token):


### PR DESCRIPTION
Fixes #929