### PR TITLE
Add Whimsy static install page for mozorg get involved tests.

### DIFF
--- a/static/html/mozorg/whimsy.html
+++ b/static/html/mozorg/whimsy.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+  Static HTML page to be used in an iframe that can
+  install an add-on directly from pages on mozilla.org.
+-->
+<head>
+  <meta charset="utf-8">
+  <title>Whimsy Add-on Button</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+    }
+
+    #install-link {
+      background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAQAAAD8fJRsAAAAPklEQVR4AWP4D4Wv/oMAkITyKZD4Cpb4iiSBA+CWePkfAn+CeEASxmdY+R8CH4LEgSSMTwt/bPk/EQi3wCUAcebY97QtnxsAAAAASUVORK5CYII=) top 12px left 16px no-repeat, linear-gradient(#84C63C, #489615) repeat scroll 0% 0% #489615;
+      border-radius: 6px;
+      box-shadow: 0px 3px rgba(0, 0, 0, 0.1), 0px -4px rgba(0, 0, 0, 0.1) inset;
+      color: #FFF;
+      display: inline-block;
+      font: bold 16px "Trebuchet MS",sans-serif;
+      margin-top: 8px;
+      padding: 8px 16px 12px 38px;
+      text-align: center;
+      text-decoration: none;
+      text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.5);
+    }
+
+    #install-link:active {
+      box-shadow: none;
+      margin-top: 11px;
+    }
+
+    #icon-container {
+      float: left;
+      width: 80px;
+      text-align: center;
+    }
+
+    #content {
+      color: #3C3C3C;
+      font: message-box;
+      font-size: 12px;
+      padding-left: 80px;
+    }
+
+    #content p {
+      display: table-cell;
+      vertical-align: middle;
+      height: 40px;
+    }
+  </style>
+</head>
+<body>
+
+<a href="#" id="install-link">Add to Firefox</a>
+
+<script>
+(function() {
+  'use strict';
+
+  var installLink = document.getElementById('install-link');
+
+  installLink.addEventListener('click', function(e) {
+    e.preventDefault();
+
+    // notify parent window of button click
+    parent.postMessage({
+      action: 'install',
+      addon: 'whimsy'
+    }, '*');
+
+    var xpiUrl = 'https://addons.mozilla.org/firefox/downloads/latest/563374/addon-563374-latest.xpi?src=fx-get-involved'
+
+    InstallTrigger.install({
+      Whimsy:  {
+        URL: xpiUrl,
+        IconURL: 'https://addons.cdn.mozilla.net/user-media/addon_icons/563/563374-64.png?modified=1430919845',
+        toString: function() {
+          return xpiUrl;
+        }
+      }
+    });
+  }, false);
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Quick summary:

We're going to be running a couple test iterations on the [get involved page](https://www.mozilla.org/en-US/contribute/signup/). These tests will list 6 specific tasks for the user to complete. One of these tasks will be to install Whimsy and, optionally, go to AMO, sign in/up, and review the add-on.

We'd like the user to be able to install without leaving the flow, hence this static page.

Very similar to the pages created for Fx 35.0.1 firstrun tests in #440.