### PR TITLE
Install addons-validator and configure it's path. Fixes #881

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ ENV CLEANCSS_BIN /srv/olympia-node/node_modules/clean-css/bin/cleancss
 ENV LESS_BIN /srv/olympia-node/node_modules/less/bin/lessc
 ENV STYLUS_BIN /srv/olympia-node/node_modules/stylus/bin/stylus
 ENV UGLIFY_BIN /srv/olympia-node/node_modules/uglify-js/bin/uglifyjs
-ENV VALIDATOR_BIN /srv/olympia-node/node_modules/addons-validator/addons-validator
+ENV VALIDATOR_BIN /srv/olympia-node/node_modules/addons-validator/bin/addons-validator

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,3 +61,4 @@ ENV CLEANCSS_BIN /srv/olympia-node/node_modules/clean-css/bin/cleancss
 ENV LESS_BIN /srv/olympia-node/node_modules/less/bin/lessc
 ENV STYLUS_BIN /srv/olympia-node/node_modules/stylus/bin/stylus
 ENV UGLIFY_BIN /srv/olympia-node/node_modules/uglify-js/bin/uglifyjs
+ENV VALIDATOR_BIN /srv/olympia-node/node_modules/addons-validator/addons-validator

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "less": "1.3.x",
     "stylus": "0.32.x",
     "uglify-js": "2.4.x",
-    "addons-validator": "0.0.7"
+    "addons-validator": "0.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean-css": "2.0.x",
     "less": "1.3.x",
     "stylus": "0.32.x",
-    "uglify-js": "2.4.x"
+    "uglify-js": "2.4.x",
+    "addons-validator": "0.0.7"
   }
 }

--- a/settings.py
+++ b/settings.py
@@ -54,10 +54,15 @@ ALLOW_SELF_REVIEWS = True
 # will be the path to the `stylus` and `lessc` executables.
 STYLUS_BIN = os.getenv('STYLUS_BIN', path('node_modules/stylus/bin/stylus'))
 LESS_BIN = os.getenv('LESS_BIN', path('node_modules/less/bin/lessc'))
-CLEANCSS_BIN = os.getenv('CLEANCSS_BIN',
-                         path('node_modules/clean-css/bin/cleancss'))
-UGLIFY_BIN = os.getenv('UGLIFY_BIN',
-                       path('node_modules/uglify-js/bin/uglifyjs'))
+CLEANCSS_BIN = os.getenv(
+    'CLEANCSS_BIN',
+    path('node_modules/clean-css/bin/cleancss'))
+UGLIFY_BIN = os.getenv(
+    'UGLIFY_BIN',
+    path('node_modules/uglify-js/bin/uglifyjs'))
+VALIDATOR_BIN = os.getenv(
+    'VALIDATOR_BIN',
+    path('node_modules/addons-validator/bin/addons-validator'))
 
 # Locally we typically don't run more than 1 elasticsearch node. So we set
 # replicas to zero.


### PR DESCRIPTION
Pleae do not merge yet, the addons-validator requires a nodejs version that's not present in our current docker / production systems.

This depends on all the work going on in https://github.com/mozilla/olympia/pull/963