### PR TITLE
Remove name for rabbitmq to fix validation error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,6 @@ redis:
 rabbitmq:
   image: rabbitmq
   hostname: olympia
-  name: olympia
   expose:
     - "5672:5672"
   environment:


### PR DESCRIPTION
Related to #962

r? @mstriemer 

Seems docker-compose 1.5.1 has remove `name` from the JSON schema for the docker-compose.yml. It doesn't appear to be changing the container name - so I'm not sure what name used to do or does currently. 

This seems to work. But @mstriemer if you have a good test I can run to make sure the queue is functioning I'm happy to test this further.

I did have some issues with error messages relating to volumes but I suspect that's unrelated since my oympia env hadn't been updated for a while. I am however now running the latest of docker-machine (which includes docker-compose 1.5.1 on OSX) and the docker server is updated to match the client.