### PR TITLE
Auto sign unlisted extensions even if validation fails (bug 1229197)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -624,12 +624,15 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
 
     @property
     def automated_signing(self):
-        # We allow automated signing for add-ons which are not listed, and
-        # have not asked for side-loading privileges (full review).
+        # We allow automated signing for add-ons which are not listed.
         # Beta versions are a special case for listed add-ons, and are dealt
         # with on a file-by-file basis.
-        return not (self.is_listed or
-                    self.status in (amo.STATUS_NOMINATED, amo.STATUS_PUBLIC))
+        return not self.is_listed
+
+    @property
+    def is_sideload(self):
+        # An add-on can side-load if it has been fully reviewed.
+        return self.status in (amo.STATUS_NOMINATED, amo.STATUS_PUBLIC)
 
     @amo.cached_property(writable=True)
     def listed_authors(self):

--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -613,6 +613,18 @@ class EXPERIMENT_SIGNED(_LOG):
     keep = True
 
 
+class UNLISTED_SIGNED_VALIDATION_PASSED(_LOG):
+    id = 135
+    format = _(u'{file} was signed.')
+    keep = True
+
+
+class UNLISTED_SIGNED_VALIDATION_FAILED(_LOG):
+    id = 136
+    format = _(u'{file} was signed.')
+    keep = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.

--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -625,6 +625,18 @@ class UNLISTED_SIGNED_VALIDATION_FAILED(_LOG):
     keep = True
 
 
+class UNLISTED_SIDELOAD_SIGNED_VALIDATION_PASSED(_LOG):
+    id = 137
+    format = _(u'{file} was signed.')
+    keep = True
+
+
+class UNLISTED_SIDELOAD_SIGNED_VALIDATION_FAILED(_LOG):
+    id = 138
+    format = _(u'{file} was signed.')
+    keep = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.

--- a/apps/devhub/templates/devhub/addons/submit/upload.html
+++ b/apps/devhub/templates/devhub/addons/submit/upload.html
@@ -74,13 +74,6 @@
       </div>
     </div>
     {% endif %}
-    <div id="manual-review" class="hidden">
-      <p class="error">{{ _("Looks like your add-on requires a manual review before it can be signed.") }}</p>
-      <label for="{{ new_addon_form.is_manual_review.auto_id }}">
-        {{ new_addon_form.is_manual_review }}
-        {{ new_addon_form.is_manual_review.label }}
-      </label>
-    </div>
     <div class="submission-buttons addon-submission-field">
       <button class="addon-upload-dependant" id="submit-upload-file-finish" disabled=disabled type="submit">
         {{ _('Continue') }}

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -72,15 +72,6 @@
       </div>
       {% endif %}
     </div>
-    {% if not addon.is_listed %}
-      <div id="manual-review" class="hidden">
-        <p class="error">{{ _("Looks like your add-on requires a manual review before it can be signed.") }}</p>
-        <label for="{{ new_file_form.is_manual_review.auto_id }}">
-          {{ new_file_form.is_manual_review }}
-          {{ new_file_form.is_manual_review.label }}
-        </label>
-      </div>
-    {% endif %}
 
     <div class="upload-status-button-add">
       <button class="addon-upload-dependant button" id="upload-file-finish" disabled>{{ action_label }}</button>

--- a/apps/devhub/tests/test_views_validation.py
+++ b/apps/devhub/tests/test_views_validation.py
@@ -451,7 +451,7 @@ class TestUploadURLs(amo.tests.TestCase):
         self.expect_validation(listed=False, automated_signing=True)
 
         self.upload_addon(listed=False, status=amo.STATUS_PUBLIC)
-        self.expect_validation(listed=False, automated_signing=False)
+        self.expect_validation(listed=False, automated_signing=True)
 
 
 class TestValidateFile(BaseUploadTest):

--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -689,7 +689,7 @@ class ReviewAddon(ReviewBase):
     def set_data(self, data):
         self.data = data
 
-    def process_public(self):
+    def process_public(self, auto_validation=False):
         """Set an addon to public."""
         if self.review_type == 'preliminary':
             raise AssertionError('Preliminary addons cannot be made public.')
@@ -712,6 +712,8 @@ class ReviewAddon(ReviewBase):
         subject = u'Mozilla Add-ons: %s %s Fully Reviewed'
         if not self.addon.is_listed:
             template = u'unlisted_to_reviewed'
+            if auto_validation:
+                template = u'unlisted_to_reviewed_auto'
             subject = u'Mozilla Add-ons: %s %s signed and ready to download'
         self.notify_email(template, subject)
 
@@ -719,7 +721,7 @@ class ReviewAddon(ReviewBase):
         log.info(u'Sending email for %s' % (self.addon))
 
         # Assign reviewer incentive scores.
-        if self.request:
+        if self.request and not auto_validation:
             ReviewerScore.award_points(self.request.user, self.addon, status)
 
     def process_sandbox(self):
@@ -806,7 +808,7 @@ class ReviewFiles(ReviewBase):
         if 'addon_files' in data:
             self.files = data['addon_files']
 
-    def process_public(self):
+    def process_public(self, auto_validation=False):
         """Set an addons files to public."""
         if self.review_type == 'preliminary':
             raise AssertionError('Preliminary addons cannot be made public.')
@@ -825,6 +827,8 @@ class ReviewFiles(ReviewBase):
         subject = u'Mozilla Add-ons: %s %s Fully Reviewed'
         if not self.addon.is_listed:
             template = u'unlisted_to_reviewed'
+            if auto_validation:
+                template = u'unlisted_to_reviewed_auto'
             subject = u'Mozilla Add-ons: %s %s signed and ready to download'
         self.notify_email(template, subject)
 
@@ -833,7 +837,7 @@ class ReviewFiles(ReviewBase):
         log.info(u'Sending email for %s' % (self.addon))
 
         # Assign reviewer incentive scores.
-        if self.request:
+        if self.request and not auto_validation:
             ReviewerScore.award_points(self.request.user, self.addon, status)
 
     def process_sandbox(self):

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -324,7 +324,7 @@
                 $isSideloadCheckbox.attr('checked', false);
                 $submitAddonProgress.removeClass('unlisted');
               } else {  // It's an unlisted add-on.
-                if (isSideload()) {  // It's a sideload add-on, not eligible for automated signing.
+                if (isSideload()) {  // It's a sideload add-on.
                   $upload_field.attr('data-upload-url', $upload_field.data('upload-url-sideload'));
                 } else {
                   $upload_field.attr('data-upload-url', $upload_field.data('upload-url-unlisted'));
@@ -433,11 +433,7 @@
                     // Specific messages for unlisted addons.
                     var isSideload = $('#id_is_sideload').is(':checked') || $newForm.data('addon-is-sideload');
                     if (isUnlisted()) {
-                      if (isSideload) {
-                        $("<p>").text(gettext("Your submission will go through a manual review.")).appendTo(upload_results);
-                      } else {
-                        $("<p>").text(gettext("Your submission will be automatically signed.")).appendTo(upload_results);
-                      }
+                      $("<p>").text(gettext("Your submission will be automatically signed.")).appendTo(upload_results);
                     } else {  // This is a listed add-on.
                       if (results.beta) {
                         function updateBetaStatus() {

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -310,7 +310,6 @@
             // parameter.
             var $betaWarningLabel = $('span.beta-warning');
             var $isSideloadLabel = $('label[for=id_is_sideload]');
-            var $isManualReview = $('#manual-review');
             var $submitAddonProgress = $('.submit-addon-progress');
             function updateListedStatus() {
               if (!isUnlisted()) {  // It's a listed add-on.
@@ -339,7 +338,6 @@
               $('.addon-upload-failure-dependant').attr({'disabled': true,
                                                          'checked': false});
               $('.upload-status').remove();
-              $isManualReview.hide();
             }
             $isUnlistedCheckbox.bind('change', updateListedStatus);
             $isSideloadCheckbox.bind('change', updateListedStatus);
@@ -438,14 +436,7 @@
                       if (isSideload) {
                         $("<p>").text(gettext("Your submission will go through a manual review.")).appendTo(upload_results);
                       } else {
-                        if (v.passed_auto_validation) {
-                          $("<p>").text(gettext("Your submission passed validation and will be automatically signed.")).appendTo(upload_results);
-                          $('#manual-review').hide().addClass('hidden');
-                        } else {
-                          // If unlisted and not sideload and failed validation, disable submit until checkbox checked.
-                          $('.addon-upload-dependant').attr('disabled', true);
-                          $('#manual-review').show().removeClass('hidden');
-                        }
+                        $("<p>").text(gettext("Your submission will be automatically signed.")).appendTo(upload_results);
                       }
                     } else {  // This is a listed add-on.
                       if (results.beta) {


### PR DESCRIPTION
Fixes [bug 1229197](https://bugzilla.mozilla.org/show_bug.cgi?id=1229197)