### PR TITLE
Fix rabbitmq and redis images to use our prod-like versions.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ nginx:
     - web:web
 
 memcached:
-  image: memcached
+  image: memcached:1.4.24
 
 mysqld:
   image: mysql:5.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ nginx:
     - web:web
 
 memcached:
-  image: memcached:1.4.24
+  image: memcached:1.4
 
 mysqld:
   image: mysql:5.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,10 +51,10 @@ elasticsearch:
   image: elasticsearch:1.3
 
 redis:
-  image: redis
+  image: redis:2.8
 
 rabbitmq:
-  image: rabbitmq
+  image: rabbitmq:3.5
   hostname: olympia
   expose:
     - "5672:5672"


### PR DESCRIPTION
We're actually using rabbitmq 3.5.3-1 and redis 2.8.23 in production but I think this comes pretty close.

@jasonthomas what version do we use for memcached? I suppose something like either 1.4.5 or 1.4.2?