### PR TITLE
Use serializable transactions in signing API task

### DIFF
--- a/apps/amo/decorators.py
+++ b/apps/amo/decorators.py
@@ -5,6 +5,7 @@ import json
 from django import http
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db import connection, transaction
 
 import commonware.log
 
@@ -238,3 +239,29 @@ def allow_mine(f):
             username = request.user.username
         return f(request, username, *args, **kw)
     return wrapper
+
+
+def atomic(fn):
+    """Set the transaction isolation level to SERIALIZABLE and then delegate
+    to transaction.atomic to run the specified code atomically. The
+    SERIALIZABLE level will run SELECTs in LOCK IN SHARE MODE when used in
+    conjunction with transaction.atomic.
+    Docs: https://dev.mysql.com/doc/refman/5.6/en/set-transaction.html.
+    """
+    # TODO: Make this the default for all transactions.
+    @functools.wraps(fn)
+    @write
+    def inner(*args, **kwargs):
+        cursor = connection.cursor()
+        cursor.execute('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')
+        with transaction.atomic():
+            return fn(*args, **kwargs)
+    # The non_atomic version is essentially just a non-decorated version of the
+    # function. This is just here to handle the fact that django's tests are
+    # run in a transaction and setting this will make mysql blow up. You can
+    # mock your function to the non-atomic version to make it run in a test.
+    #
+    #  with mock.patch('module.func', module.func.non_atomic):
+    #      test_something()
+    inner.non_atomic = fn
+    return inner

--- a/apps/devhub/tasks.py
+++ b/apps/devhub/tasks.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.files.storage import default_storage as storage
 from django.core.management import call_command
-from django.db import transaction
 
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.result import AsyncResult
@@ -22,7 +21,7 @@ from tower import ugettext as _
 import amo
 import validator
 from amo.celery import task
-from amo.decorators import write, set_modified_on
+from amo.decorators import atomic, set_modified_on, write
 from amo.utils import resize_image, send_html_mail_jinja
 from addons.models import Addon
 from applications.management.commands import dump_apps
@@ -76,8 +75,7 @@ def submit_file(addon_pk, file_pk):
                  'validation'.format(file_id=file_pk))
 
 
-@write
-@transaction.atomic
+@atomic
 def create_version_for_upload(addon, file_):
     if (addon.fileupload_set.filter(created__gt=file_.created,
                                     version=file_.version).exists()

--- a/apps/signing/tests/test_views.py
+++ b/apps/signing/tests/test_views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 import amo
 from addons.models import Addon, AddonUser
 from api.tests.utils import APIAuthTestCase
+from devhub import tasks
 from files.models import File, FileUpload
 from signing.views import VersionView
 from users.models import UserProfile
@@ -29,6 +30,10 @@ class BaseUploadVersionCase(SigningAPITestCase):
         super(BaseUploadVersionCase, self).setUp()
         self.guid = '{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}'
         self.view = VersionView.as_view()
+        patcher = mock.patch('devhub.tasks.create_version_for_upload',
+                             tasks.create_version_for_upload.non_atomic)
+        self.create_version_for_upload = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def url(self, guid, version, pk=None):
         args = [guid, version]


### PR DESCRIPTION
This adds a decorator to be used in place of `@transaction.atomic` that will first set the isolation level to `SERIALIZABLE` for the next transaction so that transactions work as you would expect. The isolation level to return to normal after the transaction ends.