### PR TITLE
Don't display a red warning if there are unsupported platforms on add-on submission (issue #993)

### DIFF
--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -541,13 +541,9 @@
                                 $(platforms_selector + ' label').addClass('platform-disabled');
                             }
                             if (excluded) {
-                                var msg = gettext('Some platforms are not available for this type of add-on.');
                                 if ($('.platform input[type=checkbox]').length === $('.platform input[type=checkbox]:disabled').length) {
                                     msg = gettext('Sorry, no supported platform has been found.');
                                 }
-                                $('.platform').prepend(
-                                    format('<ul class="errorlist"><li>{0}</li></ul>',
-                                           msg));
                             }
                         }
                     }


### PR DESCRIPTION
This fixes #993 by simply removing the message.