### PR TITLE
Give a 503 when in read-only for signing (see #1050)

### DIFF
--- a/apps/signing/tests/test_views.py
+++ b/apps/signing/tests/test_views.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta
 
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 
 import mock
 from rest_framework.response import Response
@@ -67,6 +68,12 @@ class TestUploadVersion(BaseUploadVersionCase):
         # Use self.client.put so that we don't add the authorization header.
         response = self.client.put(self.url(self.guid, '12.5'))
         assert response.status_code == 401
+
+    @override_settings(READ_ONLY=True)
+    def test_read_only_mode(self):
+        response = self.put(self.url(self.guid, '12.5'))
+        assert response.status_code == 503
+        assert 'website maintenance' in response.data['error']
 
     @mock.patch('devhub.views.auto_sign_version')
     def test_addon_does_not_exist(self, sign_version):

--- a/docs/topics/api/common-responses.rst
+++ b/docs/topics/api/common-responses.rst
@@ -1,0 +1,14 @@
+====================
+Common API Responses
+====================
+
+There are some common API responses that you can expect to receive at times.
+
+.. http:get:: /api/v3/...
+
+    :statuscode 401: Authentication is required or failed.
+    :statuscode 403: You are not permitted to perform this action.
+    :statuscode 404: The requested resource could not be found.
+    :statuscode 500: An unknown error occurred.
+    :statuscode 503:
+        The site is in maintenance mode and this operation is not permitted.

--- a/docs/topics/api/index.rst
+++ b/docs/topics/api/index.rst
@@ -26,6 +26,7 @@ get started using the API.
 .. toctree::
    :maxdepth: 2
 
+   common-responses
    auth
    accounts
    signing


### PR DESCRIPTION
This just gives a 503 on the upload version API since I think that's the only one we care about now and I wanted this to be small.

This is related to #1050.