### PR TITLE
only allow json renderer fixes #1047

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1477,3 +1477,12 @@ JWT_AUTH = {
     # clocks are off.
     'JWT_LEEWAY': 5,
 }
+
+REST_FRAMEWORK = {
+    # Set this because the default is to also include:
+    #   'rest_framework.renderers.BrowsableAPIRenderer'
+    # Which it will try to use if the client accepts text/html.
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
+}


### PR DESCRIPTION
* fixes #1047
* to test DEBUG must be set to False

send a request
```
curl http://amo.dev/api/v3/accounts/profile/ -H "Authorization: JWT `node ~/s/sign.js`" -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8" 
<?xml version="1.0" encoding="utf-8" ?>
      <error>Server Error</error>
```
What happened is that it tried to render the response using:
```
 'rest_framework.renderers.BrowsableAPIRenderer',
```
Which causes the template error. It does that because `text/html` is in the Accept.

If you apply the settings, you instead get:

```
{"username": "andy", "display_name": "",...
```
Because it goes down to `*/*` in the `Accept`. Finally by doing this if we don't accept `application/json` we get:

```
curl http://amo.dev/api/v3/accounts/profile/ -H "Authorization: JWT `node ~/s/sign.js`" -H "Accept: image/webp" -I
HTTP/1.1 406 NOT ACCEPTABLE
```
