### PR TITLE
Fix rabbitmq container configuration, use correct 'expose' format.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ rabbitmq:
   image: rabbitmq:3.5
   hostname: olympia
   expose:
-    - "5672:5672"
+    - "5672"
   environment:
     - RABBITMQ_DEFAULT_USER=olympia
     - RABBITMQ_DEFAULT_PASS=olympia


### PR DESCRIPTION
This is raised by a new validation for `expose` in docker-compose 1.5.2:

```
ERROR: Validation failed in file './docker-compose.yml', reason(s):
Service 'rabbitmq' configuration key 'expose' '0' is invalid: should be of the format 'PORT[/PROTOCOL]'
```

https://github.com/docker/compose/blob/master/CHANGELOG.md