### PR TITLE
Don't double escape when using amo.helpers.page_title (issue #1062)

### DIFF
--- a/apps/amo/helpers.py
+++ b/apps/amo/helpers.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.forms import CheckboxInput
 from django.utils import translation
 from django.utils.encoding import smart_unicode
+from django.utils.html import format_html
 from django.template import defaultfilters
 
 import caching.base as caching
@@ -255,7 +256,10 @@ def login_link(context):
 def page_title(context, title):
     title = smart_unicode(title)
     base_title = page_name(context['request'].APP)
-    return u'%s :: %s' % (title, base_title)
+    # The following line doesn't use string formatting because we want to
+    # preserve the type of `title` in case it's a jinja2 `Markup` (safe,
+    # escaped) object.
+    return format_html(u'{} :: {}', title, base_title)
 
 
 @register.function

--- a/apps/amo/tests/test_helpers.py
+++ b/apps/amo/tests/test_helpers.py
@@ -81,6 +81,17 @@ def test_page_title():
                 'x': encoding.smart_str(u'\u05d0\u05d5\u05e1\u05e3')})
 
 
+def test_page_title_markup():
+    """If the title passed to page_title is a jinja2 Markup object, don't cast
+    it back to a string or it'll get double escaped. See issue #1062."""
+    request = Mock()
+    request.APP = amo.FIREFOX
+    # Markup isn't double escaped.
+    res = render(
+        '{{ page_title("{0}"|fe("It\'s all text")) }}', {'request': request})
+    assert res == 'It&#39;s all text :: Add-ons for Firefox'
+
+
 class TestBreadcrumbs(amo.tests.BaseTestCase):
 
     def setUp(self):

--- a/apps/bandwagon/templates/bandwagon/delete.html
+++ b/apps/bandwagon/templates/bandwagon/delete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}
 {# L10n: %s is the name of the collection. #}
-{{ page_title(_('Delete {0}')|f(collection.name)) }}
+{{ page_title(_('Delete {0}')|fe(collection.name)) }}
 {% endblock %}
 
 {% block content %}

--- a/apps/bandwagon/templates/bandwagon/edit.html
+++ b/apps/bandwagon/templates/bandwagon/edit.html
@@ -2,7 +2,7 @@
 
 {% block title %}
 {# L10n: {0} is the name of the collection. #}
-{{ page_title(_('Edit {0}')|f(collection.name)) }}
+{{ page_title(_('Edit {0}')|fe(collection.name)) }}
 {% endblock %}
 {% set owner = (collection.owned_by(user) or is_admin) %}
 


### PR DESCRIPTION
Fixes #1062