### PR TITLE
Require FxA state to match session (fixes #866)

### DIFF
--- a/apps/accounts/helpers.py
+++ b/apps/accounts/helpers.py
@@ -1,13 +1,25 @@
+import os
+
 from django.conf import settings
 
+import jinja2
 from jingo import register
 
 
 @register.function
-def fxa_config():
-    return {camel_case(key): value
-            for key, value in settings.FXA_CONFIG.iteritems()
-            if key != 'client_secret'}
+@jinja2.contextfunction
+def fxa_config(context):
+    request = context['request']
+    config = {camel_case(key): value
+              for key, value in settings.FXA_CONFIG.iteritems()
+              if key != 'client_secret'}
+    request.session.setdefault('fxa_state', generate_fxa_state())
+    config['state'] = request.session['fxa_state']
+    return config
+
+
+def generate_fxa_state():
+    return os.urandom(32).encode('hex')
 
 
 def camel_case(snake):

--- a/apps/accounts/tests/test_helpers.py
+++ b/apps/accounts/tests/test_helpers.py
@@ -1,5 +1,7 @@
 from django.test.utils import override_settings
 
+import mock
+
 from apps.accounts import helpers
 
 
@@ -10,8 +12,11 @@ from apps.accounts import helpers
     'a_different_thing': 'howdy, world!',
 })
 def test_fxa_config():
-    assert helpers.fxa_config() == {
+    context = mock.MagicMock()
+    context['request'].session = {'fxa_state': 'thestate!'}
+    assert helpers.fxa_config(context) == {
         'clientId': 'foo',
         'something': 'hello, world!',
+        'state': 'thestate!',
         'aDifferentThing': 'howdy, world!',
     }

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -65,6 +65,9 @@ def with_user(fn):
         data = request.GET if request.method == 'GET' else request.DATA
         if 'code' not in data:
             return Response({'error': 'No code provided.'}, status=422)
+        elif ('fxa_state' not in request.session or
+                request.session['fxa_state'] != data['state']):
+            return Response({'error': 'State mismatch.'}, status=400)
 
         try:
             identity = verify.fxa_identify(data['code'],

--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -16,11 +16,12 @@ from django.conf import settings
 from django.core.management import call_command
 from django.db.models.signals import post_save
 from django.forms.fields import Field
-from django.http import SimpleCookie
+from django.http import HttpRequest, SimpleCookie
 from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from django.conf import urls as django_urls
 from django.utils import translation
+from django.utils.importlib import import_module
 
 import mock
 import pytest
@@ -223,6 +224,30 @@ def mobile_test(f):
     return wrapper
 
 
+class InitializeSessionMixin(object):
+
+    def initialize_session(self, session_data):
+        # This is taken from django's login method.
+        # https://github.com/django/django/blob/9d915ac1be1e7b8cfea3c92f707a4aeff4e62583/django/test/client.py#L541
+        engine = import_module(settings.SESSION_ENGINE)
+        request = HttpRequest()
+        request.session = engine.SessionStore()
+        request.session.update(session_data)
+        # Save the session values.
+        request.session.save()
+        # Set the cookie to represent the session.
+        session_cookie = settings.SESSION_COOKIE_NAME
+        self.client.cookies[session_cookie] = request.session.session_key
+        cookie_data = {
+            'max-age': None,
+            'path': '/',
+            'domain': settings.SESSION_COOKIE_DOMAIN,
+            'secure': settings.SESSION_COOKIE_SECURE or None,
+            'expires': None,
+        }
+        self.client.cookies[session_cookie].update(cookie_data)
+
+
 class TestClient(Client):
 
     def __getattr__(self, name):
@@ -301,7 +326,7 @@ class BaseTestCase(test.TestCase):
         assert_url_equal(url, other, compare_host=compare_host)
 
 
-class TestCase(MockEsMixin, RedisTest, BaseTestCase):
+class TestCase(InitializeSessionMixin, MockEsMixin, RedisTest, BaseTestCase):
     """Base class for all amo tests."""
     client_class = TestClient
 

--- a/static/js/common/fxa-login.js
+++ b/static/js/common/fxa-login.js
@@ -17,7 +17,7 @@
 
         opts = opts || {};
         var authConfig = {
-            state: 'foo',
+            state: config.state,
             redirectUri: config.redirectUrl,
             scope: config.scope,
         };


### PR DESCRIPTION
I'm not crazy about how I'm setting the state data in the session but this seemed a lot simpler than writing a middleware. The user id is in the state just to invalidate it when the user logs in or out.

r? @kumar303 