### PR TITLE
Fix orphaned add-ons on submit error (bug 1119331)

### DIFF
--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1404,6 +1404,7 @@ def submit(request, step):
 
 @login_required
 @submit_step(2)
+@transaction.commit_on_success
 def submit_addon(request, step):
     if request.user.read_dev_agreement is None:
         return redirect(_step_url(1))


### PR DESCRIPTION
When an exception was raised somewhere in the submission flow, the add-on was
saved to the DB but without an owner. The next time someone
tried to upload the add-on, they saw 'Duplicate add-on ID' or 'name is
already in use'. The transaction fixes it. I was able to manually reproduce it
by causing a ValueError before adding the transaction.

See https://github.com/mozilla/olympia/issues/1140 for an example of the type of error that was putting submitted add-ons in an orphaned state.