### PR TITLE
Add base font color

### DIFF
--- a/static/css/impala/site.less
+++ b/static/css/impala/site.less
@@ -8,6 +8,11 @@ html, body {
     height: 100%;
 }
 
+body {
+    background-color: #fff;
+    color: #000;
+}
+
 #main-wrapper {
     background: #fff url(../../img/zamboni/global/bg-header.png) repeat-x;
     border-top: 2px solid #fff;


### PR DESCRIPTION
If the user uses a dark theme, the text can be illegible. When changing a background color, the font color should be changed too.

![screen shot 2016-01-02 at 04 14 07](https://cloud.githubusercontent.com/assets/705123/12073069/288b0664-b108-11e5-95ff-c6d896fb4789.png)
