### PR TITLE
Show account form after registering

### DIFF
--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -9,6 +9,7 @@ import mock
 from rest_framework.test import APITestCase
 
 from accounts import verify, views
+from amo.helpers import absolutify
 from amo.tests import create_switch, InitializeSessionMixin
 from api.tests.utils import APIAuthTestCase
 from users.models import UserProfile
@@ -517,7 +518,7 @@ class TestAuthorizeView(BaseAuthenticationView):
         response = self.client.get(
             self.url, {'code': 'codes!!', 'state': 'the-right-blob'})
         assert response.status_code == 302
-        assert response['location'] == 'http://testserver/'
+        assert response['location'] == absolutify(reverse('users.edit'))
         self.fxa_identify.assert_called_with('codes!!', config=FXA_CONFIG)
         assert not self.login_user.called
         self.register_user.assert_called_with(mock.ANY, identity)
@@ -533,7 +534,7 @@ class TestAuthorizeView(BaseAuthenticationView):
                 next_path=base64.urlsafe_b64encode('/go/here')),
         })
         assert response.status_code == 302
-        assert response['location'] == 'http://testserver/go/here'
+        assert response['location'] == absolutify(reverse('users.edit'))
         self.fxa_identify.assert_called_with('codes!!', config=FXA_CONFIG)
         assert not self.login_user.called
         self.register_user.assert_called_with(mock.ANY, identity)

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 
 from django.conf import settings
 from django.contrib.auth import login
+from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.utils.http import is_safe_url
@@ -155,9 +156,14 @@ class AuthorizeView(APIView):
     def get(self, request, user, identity, next_path):
         if user is None:
             register_user(request, identity)
+            path = reverse('users.edit')
+            log.info('Redirecting after register to: {}'.format(path))
+            return HttpResponseRedirect(path)
         else:
             login_user(request, user, identity)
-        return HttpResponseRedirect(next_path or '/')
+            next_path = next_path or '/'
+            log.info('Redirecting after login to: {}'.format(next_path))
+            return HttpResponseRedirect(next_path)
 
 
 class ProfileView(JWTProtectedView, generics.RetrieveAPIView):


### PR DESCRIPTION
Redirect the user to the edit account page after creating their account.

The demo also includes changes from #1436.

![fxa-register-three mov](https://cloud.githubusercontent.com/assets/211578/12098697/7a9764ce-b2e9-11e5-96f1-d19f85bddcca.gif)

This fixes #868.