### PR TITLE
Fix addon install following 'more guillotine' 279a4aaac5e5 (#1148)

### DIFF
--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -192,6 +192,7 @@ var installButton = function() {
             $this.find('.button[data-hash]').each(function() {
                 hashes[$(this).attr('href')] = $(this).attr('data-hash');
             });
+            var hash = hashes[installer.attr('href')];
 
             var f = _.haskey(z.button.after, after) ? z.button.after[after] : _.identity,
                 callback = _.bind(f, self),


### PR DESCRIPTION
Fixes #1148

Thanks @diox for spotting that this was caused by
[a bad cleanup](https://github.com/mozilla/olympia/commit/279a4aaac5e5c45cec9560c7a4f48485191eb4a7#commitcomment-15266127)