### PR TITLE
Use on() in place of live() impala/global

### DIFF
--- a/static/js/impala/global.js
+++ b/static/js/impala/global.js
@@ -181,7 +181,7 @@ function initBanners(delegate) {
 // AJAX form submit
 
 $(function() {
-  $('form.ajax-submit, .ajax-submit form').live('submit', function() {
+  $('document').on('submit', 'form.ajax-submit, .ajax-submit form', function() {
       var $form = $(this),
           $parent = $form.is('.ajax-submit') ? $form : $form.closest('.ajax-submit'),
           params = $form.serializeArray();


### PR DESCRIPTION
Fixes #1201 

Looks to be deprecated code because the view using this has a missing template.