### PR TITLE
Update django-cache-machine to possible performance problems.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -102,7 +102,7 @@ urllib3==1.9
 -e git+https://github.com/washort/nuggets.git@02798dfce84030fca64775eaf56e92400f394e4f#egg=nuggets
 -e git+https://github.com/fwenzel/django-mozilla-product-details@f5a3c3c846fb75e12ad890b22ed5375d5b85ccb4#egg=django-mozilla-product-details
 -e git+https://github.com/mozilla/django-session-csrf@f00ad913c62e139d36078e8a7e07dab65a021386#egg=django-session-csrf
--e git+https://github.com/washort/django-cache-machine@4690198122a96a88267323566dc18a5e0437681f#egg=django-cache-machine
+-e git+https://github.com/EnTeQuAk/django-cache-machine@1cac98a3e1dcc3cb654665cc67b6b15ab60d62c4#egg=django-cache-machine
 ## Forked.
 -e git+https://github.com/washort/django-piston-oauth2.git@c89afee6f98241eb7ef6df57d3d5156fabbfa759#egg=django-piston-oauth2
 -e git+https://github.com/andymckay/django-uuidfield.git@029dd1263794ec36c327617cd6c2346da81c8c33#egg=django-uuidfield


### PR DESCRIPTION
This refers to
https://github.com/EnTeQuAk/django-cache-machine/commit/b48e0460b7e53677f374aa6e6f7554784c9e023b
which might fix a few performance edge-cases regarding
cache-invalidation.

I don't know of anything specificly being slow but it's quite a simple
fix so we might want to try it.