### PR TITLE
Run all write views in transactions

### DIFF
--- a/apps/addons/buttons.py
+++ b/apps/addons/buttons.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import render
 from django.views.decorators.cache import cache_page
 
@@ -233,11 +234,13 @@ class Link(object):
 
 # Cache it for a year.
 @cache_page(60 * 60 * 24 * 365)
+@non_atomic_requests
 def js(request):
     return render(request, 'addons/popups.html',
                   content_type='text/javascript')
 
 
+@non_atomic_requests
 def smorgasbord(request):
     """
     Gather many different kinds of tasty add-ons together.

--- a/apps/addons/views.py
+++ b/apps/addons/views.py
@@ -8,6 +8,7 @@ from operator import attrgetter
 from django import http
 from django.conf import settings
 from django.db.models import Q
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import (get_list_or_404, get_object_or_404, redirect,
                               render)
 from django.utils.translation import trans_real as translation
@@ -69,6 +70,7 @@ def author_addon_clicked(f):
 
 
 @addon_valid_disabled_pending_view
+@non_atomic_requests
 def addon_detail(request, addon):
     """Add-ons details page dispatcher."""
     if addon.is_deleted or (addon.is_pending() and not addon.is_persona()):
@@ -101,6 +103,7 @@ def addon_detail(request, addon):
 
 
 @vary_on_headers('X-Requested-With')
+@non_atomic_requests
 def extension_detail(request, addon):
     """Extensions details page."""
     # If current version is incompatible with this app, redirect.
@@ -143,6 +146,7 @@ def extension_detail(request, addon):
 
 
 @mobilized(extension_detail)
+@non_atomic_requests
 def extension_detail(request, addon):
     if not request.META.get('HTTP_USER_AGENT'):
         ios_user = False
@@ -160,6 +164,7 @@ def _category_personas(qs, limit):
 
 
 @mobile_template('addons/{mobile/}persona_detail.html')
+@non_atomic_requests
 def persona_detail(request, addon, template=None):
     """Details page for Personas."""
     if not (addon.is_public() or addon.is_pending()):
@@ -322,6 +327,7 @@ class HomepageFilter(BaseFilter):
     filter_new = BaseFilter.filter_created
 
 
+@non_atomic_requests
 def home(request):
     # Add-ons.
     base = Addon.objects.listed(request.APP).filter(type=amo.ADDON_EXTENSION)
@@ -345,6 +351,7 @@ def home(request):
 
 
 @mobilized(home)
+@non_atomic_requests
 def home(request):
     # Shuffle the list and get 3 items.
     def rand(xs):
@@ -374,6 +381,7 @@ def home(request):
                    'ios_user': ios_user})
 
 
+@non_atomic_requests
 def homepage_promos(request):
     from discovery.views import promos
     version, platform = request.GET.get('version'), request.GET.get('platform')
@@ -428,6 +436,7 @@ class CollectionPromoBox(object):
 
 
 @addon_view
+@non_atomic_requests
 def eula(request, addon, file_id=None):
     if not addon.eula:
         return http.HttpResponseRedirect(addon.get_url_path())
@@ -440,6 +449,7 @@ def eula(request, addon, file_id=None):
 
 
 @addon_view
+@non_atomic_requests
 def privacy(request, addon):
     if not addon.privacy_policy:
         return http.HttpResponseRedirect(addon.get_url_path())
@@ -448,6 +458,7 @@ def privacy(request, addon):
 
 
 @addon_view
+@non_atomic_requests
 def developers(request, addon, page):
     if addon.is_persona():
         raise http.Http404()
@@ -476,6 +487,7 @@ def developers(request, addon, page):
 @addon_view
 @anonymous_csrf_exempt
 @post_required
+@non_atomic_requests
 def contribute(request, addon):
     commentlimit = 255  # Enforce paypal-imposed comment length limit
 
@@ -552,6 +564,7 @@ def contribute(request, addon):
 
 @csrf_exempt
 @addon_view
+@non_atomic_requests
 def paypal_result(request, addon, status):
     uuid = request.GET.get('uuid')
     if not uuid:
@@ -567,12 +580,14 @@ def paypal_result(request, addon, status):
 
 
 @addon_view
+@non_atomic_requests
 def share(request, addon):
     """Add-on sharing"""
     return share_redirect(request, addon, addon.name, addon.summary)
 
 
 @addon_view
+@non_atomic_requests
 def license(request, addon, version=None):
     if version is not None:
         qs = addon.versions.filter(files__status__in=amo.VALID_STATUSES)
@@ -585,6 +600,7 @@ def license(request, addon, version=None):
                   dict(addon=addon, version=version))
 
 
+@non_atomic_requests
 def license_redirect(request, version):
     version = get_object_or_404(Version, pk=version)
     return redirect(version.license_url(), permanent=True)
@@ -592,6 +608,7 @@ def license_redirect(request, version):
 
 @session_csrf.anonymous_csrf_exempt
 @addon_view
+@non_atomic_requests
 def report_abuse(request, addon):
     form = AbuseForm(request.POST or None, request=request)
     if request.method == "POST" and form.is_valid():
@@ -604,6 +621,7 @@ def report_abuse(request, addon):
 
 
 @cache_control(max_age=60 * 60 * 24)
+@non_atomic_requests
 def persona_redirect(request, persona_id):
     if persona_id == 0:
         # Newer themes have persona_id == 0, doesn't mean anything.

--- a/apps/amo/feeds.py
+++ b/apps/amo/feeds.py
@@ -1,0 +1,16 @@
+from django.contrib.syndication.views import Feed
+from django.db.transaction import non_atomic_requests
+from django.utils.decorators import method_decorator
+
+
+class NonAtomicFeed(Feed):
+    """
+    A feed that does not use transactions.
+
+    Feeds are special because they don't inherit from generic Django class
+    views so you can't decorate dispatch().
+    """
+
+    @method_decorator(non_atomic_requests)
+    def __call__(self, *args, **kwargs):
+        return super(NonAtomicFeed, self).__call__(*args, **kwargs)

--- a/apps/amo/install.py
+++ b/apps/amo/install.py
@@ -1,6 +1,7 @@
 import json
 from jinja2 import Markup
 
+from django.db.transaction import non_atomic_requests
 from django.http import HttpResponsePermanentRedirect, HttpResponseNotFound
 from django.shortcuts import render
 from amo.utils import urlparams
@@ -133,6 +134,7 @@ addons = {
 }
 
 
+@non_atomic_requests
 def install(request):
     addon_id = request.GET.get('addon_id', None)
     if addon_id:

--- a/apps/amo/tests/test_views.py
+++ b/apps/amo/tests/test_views.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import json
+import random
 import urllib
 
 from django import test
 from django.conf import settings
+from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings
 
 import commonware.log
@@ -19,7 +21,7 @@ from access import acl
 from access.models import Group, GroupUser
 from addons.models import Addon, AddonUser
 from amo.pyquery_wrapper import PyQuery
-from amo.tests import check_links
+from amo.tests import check_links, WithDynamicEndpoints
 from amo.urlresolvers import reverse
 from users.models import UserProfile
 
@@ -402,3 +404,26 @@ class TestRobots(amo.tests.TestCase):
         response = self.client.get('/robots.txt')
         eq_(response.status_code, 200)
         assert 'Disallow: %s' % url in response.content
+
+
+class TestAtomicRequests(WithDynamicEndpoints, TransactionTestCase):
+
+    def setUp(self):
+        super(TestAtomicRequests, self).setUp()
+        self.slug = 'slug-{}'.format(random.randint(1, 1000))
+        self.endpoint(self.view)
+
+    def view(self, request):
+        Addon.objects.create(slug=self.slug)
+        raise RuntimeError(
+            'pretend this is an error that would roll back the transaction')
+
+    def test_exception_rolls_back_transaction(self):
+        qs = Addon.objects.filter(slug=self.slug)
+        try:
+            with self.assertRaises(RuntimeError):
+                self.client.get('/dynamic-endpoint', follow=True)
+            # Make sure the transaction was rolled back.
+            assert qs.count() == 0
+        finally:
+            qs.all().delete()

--- a/apps/amo/views.py
+++ b/apps/amo/views.py
@@ -4,6 +4,7 @@ import re
 
 from django import http
 from django.conf import settings
+from django.db.transaction import non_atomic_requests
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.utils.encoding import iri_to_uri
@@ -41,6 +42,7 @@ wmp_re = re.compile(
 
 
 @never_cache
+@non_atomic_requests
 def monitor(request, format=None):
 
     # For each check, a boolean pass/fail status to show in the template
@@ -73,6 +75,7 @@ def monitor(request, format=None):
     return render(request, 'services/monitor.html', ctx, status=status_code)
 
 
+@non_atomic_requests
 def robots(request):
     """Generate a robots.txt"""
     _service = (request.META['SERVER_NAME'] == settings.SERVICES_DOMAIN)
@@ -84,11 +87,13 @@ def robots(request):
     return HttpResponse(template, content_type="text/plain")
 
 
+@non_atomic_requests
 def contribute(request):
     path = os.path.join(settings.ROOT, 'contribute.json')
     return HttpResponse(open(path, 'rb'), content_type='application/json')
 
 
+@non_atomic_requests
 def handler403(request):
     if request.path_info.startswith('/api/'):
         # Pass over to handler403 view in api if api was targeted.
@@ -97,6 +102,7 @@ def handler403(request):
         return render(request, 'amo/403.html', status=403)
 
 
+@non_atomic_requests
 def handler404(request):
     if request.path_info.startswith('/api/'):
         # Pass over to handler404 view in api if api was targeted.
@@ -105,6 +111,7 @@ def handler404(request):
         return render(request, 'amo/404.html', status=404)
 
 
+@non_atomic_requests
 def handler500(request):
     if request.path_info.startswith('/api/'):
         # Pass over to handler500 view in api if api was targeted.
@@ -113,11 +120,13 @@ def handler500(request):
         return render(request, 'amo/500.html', status=500)
 
 
+@non_atomic_requests
 def csrf_failure(request, reason=''):
     return render(request, 'amo/403.html',
                   {'because_csrf': 'CSRF' in reason}, status=403)
 
 
+@non_atomic_requests
 def loaded(request):
     return http.HttpResponse('%s' % request.META['wsgi.loaded'],
                              content_type='text/plain')
@@ -125,6 +134,7 @@ def loaded(request):
 
 @csrf_exempt
 @require_POST
+@non_atomic_requests
 def cspreport(request):
     """Accept CSP reports and log them."""
     report = ('blocked-uri', 'violated-directive', 'original-policy')
@@ -150,6 +160,7 @@ def cspreport(request):
     return HttpResponse()
 
 
+@non_atomic_requests
 def plugin_check_redirect(request):
     return http.HttpResponseRedirect('%s?%s' % (
         settings.PFS_URL, iri_to_uri(request.META.get('QUERY_STRING', ''))))

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.conf.urls import include, patterns, url
+from django.db.transaction import non_atomic_requests
 
 import waffle
 from piston.resource import Resource
@@ -64,6 +65,7 @@ class SwitchToDRF(object):
         self.with_viewset = with_viewset
         self.only_detail = only_detail
 
+    @non_atomic_requests
     def __call__(self, *args, **kwargs):
         if waffle.switch_is_active('drf'):
             if self.with_viewset:

--- a/apps/applications/views.py
+++ b/apps/applications/views.py
@@ -1,10 +1,11 @@
-from django.contrib.syndication.views import Feed
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import render
 
 import caching.base as caching
 from tower import ugettext as _
 
 import amo
+from amo.feeds import NonAtomicFeed
 from amo.helpers import url, absolutify
 from .models import AppVersion
 
@@ -22,13 +23,14 @@ def get_versions(order=('application', 'version_int')):
     return caching.cached(f, 'getv' + ''.join(order))
 
 
+@non_atomic_requests
 def appversions(request):
     apps, versions = get_versions()
     return render(request, 'applications/appversions.html',
                   dict(apps=apps, versions=versions))
 
 
-class AppversionsFeed(Feed):
+class AppversionsFeed(NonAtomicFeed):
     # appversions aren't getting a created date so the sorting is kind of
     # wanky.  I blame fligtar.
 

--- a/apps/bandwagon/feeds.py
+++ b/apps/bandwagon/feeds.py
@@ -1,8 +1,8 @@
 from django import http
-from django.contrib.syndication.views import Feed
 
 from tower import ugettext as _
 
+from amo.feeds import NonAtomicFeed
 from amo.helpers import absolutify, page_name
 from amo.urlresolvers import reverse
 from access import acl
@@ -11,7 +11,7 @@ from browse.feeds import AddonFeedMixin
 from . import views
 
 
-class CollectionFeedMixin(Feed):
+class CollectionFeedMixin(NonAtomicFeed):
     """Common pieces for collections in a feed."""
 
     def item_link(self, c):
@@ -31,7 +31,7 @@ class CollectionFeedMixin(Feed):
         return c.created if sort == 'created' else c.modified
 
 
-class CollectionFeed(CollectionFeedMixin, Feed):
+class CollectionFeed(CollectionFeedMixin, NonAtomicFeed):
 
     request = None
 
@@ -54,7 +54,7 @@ class CollectionFeed(CollectionFeedMixin, Feed):
         return views.get_filter(self.request).qs[:20]
 
 
-class CollectionDetailFeed(AddonFeedMixin, Feed):
+class CollectionDetailFeed(AddonFeedMixin, NonAtomicFeed):
 
     def get_object(self, request, username, slug):
         self.request = request

--- a/apps/blocklist/views.py
+++ b/apps/blocklist/views.py
@@ -7,6 +7,7 @@ import time
 
 from django.core.cache import cache
 from django.db.models import Q, signals as db_signals
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, render
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import smart_str
@@ -22,6 +23,7 @@ App = collections.namedtuple('App', 'guid min max')
 BlItem = collections.namedtuple('BlItem', 'rows os modified block_id prefs')
 
 
+@non_atomic_requests
 def blocklist(request, apiver, app, appver):
     key = 'blocklist:%s:%s:%s' % (apiver, app, appver)
     # Use md5 to make sure the memcached key is clean.
@@ -127,6 +129,7 @@ def get_plugins(apiver, app, appver=None):
     return list(plugins)
 
 
+@non_atomic_requests
 def blocked_list(request, apiver=3):
     app = request.APP.guid
     objs = get_items(apiver, app)[1].values() + get_plugins(apiver, app)
@@ -135,6 +138,7 @@ def blocked_list(request, apiver=3):
 
 
 # The id is prefixed with [ip] so we know which model to use.
+@non_atomic_requests
 def blocked_detail(request, id):
     bltypes = dict((m._type, m) for m in (BlocklistItem, BlocklistPlugin))
     item = get_object_or_404(bltypes[id[0]], details=id[1:])

--- a/apps/browse/feeds.py
+++ b/apps/browse/feeds.py
@@ -1,11 +1,11 @@
-from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 
 from tower import ugettext as _
 
 import amo
-from amo.urlresolvers import reverse
+from amo.feeds import NonAtomicFeed
 from amo.helpers import absolutify, url, page_name
+from amo.urlresolvers import reverse
 from addons.models import Addon, Category
 from .views import addon_listing, SearchToolsFilter
 
@@ -46,7 +46,7 @@ class AddonFeedMixin(object):
         return absolutify(url_)
 
 
-class CategoriesRss(AddonFeedMixin, Feed):
+class CategoriesRss(AddonFeedMixin, NonAtomicFeed):
 
     def get_object(self, request, category_name=None):
         """
@@ -115,7 +115,7 @@ class ThemeCategoriesRss(CategoriesRss):
             return self.title
 
 
-class FeaturedRss(AddonFeedMixin, Feed):
+class FeaturedRss(AddonFeedMixin, NonAtomicFeed):
 
     request = None
 
@@ -143,7 +143,7 @@ class FeaturedRss(AddonFeedMixin, Feed):
         return Addon.objects.featured(self.app)[:20]
 
 
-class SearchToolsRss(AddonFeedMixin, Feed):
+class SearchToolsRss(AddonFeedMixin, NonAtomicFeed):
 
     category = None
     request = None

--- a/apps/browse/views.py
+++ b/apps/browse/views.py
@@ -1,6 +1,7 @@
 import collections
 
 from django.conf import settings
+from django.db.transaction import non_atomic_requests
 from django.http import (Http404, HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
 from django.shortcuts import get_object_or_404, redirect, render
@@ -128,6 +129,7 @@ def _get_locales(addons):
 
 # We never use the category, but this makes it
 # uniform with the other type listings.
+@non_atomic_requests
 def language_tools(request, category=None):
     types = (amo.ADDON_DICT, amo.ADDON_LPAPP)
     addons = (Addon.objects.public()
@@ -143,6 +145,7 @@ def language_tools(request, category=None):
                    'search_cat': '%s,0' % amo.ADDON_DICT})
 
 
+@non_atomic_requests
 def themes(request, category=None):
     TYPE = amo.ADDON_THEME
     if category is not None:
@@ -166,6 +169,7 @@ def themes(request, category=None):
 
 
 @mobile_template('browse/{mobile/}extensions.html')
+@non_atomic_requests
 def extensions(request, category=None, template=None):
     TYPE = amo.ADDON_EXTENSION
 
@@ -195,6 +199,7 @@ def extensions(request, category=None, template=None):
 
 
 @mobile_template('browse/{mobile/}extensions.html')
+@non_atomic_requests
 def es_extensions(request, category=None, template=None):
     TYPE = amo.ADDON_EXTENSION
 
@@ -244,6 +249,7 @@ class CategoryLandingFilter(BaseFilter):
         return manual_order(qs, self.ids, pk_name='addons.id')
 
 
+@non_atomic_requests
 def category_landing(request, category, addon_type=amo.ADDON_EXTENSION,
                      Filter=CategoryLandingFilter):
     base = (Addon.objects.listed(request.APP)
@@ -257,6 +263,7 @@ def category_landing(request, category, addon_type=amo.ADDON_EXTENSION,
                    'search_cat': '%s,0' % category.type})
 
 
+@non_atomic_requests
 def creatured(request, category):
     TYPE = amo.ADDON_EXTENSION
     q = Category.objects.filter(application=request.APP.id, type=TYPE)
@@ -332,6 +339,7 @@ def personas_listing(request, category_slug=None):
 
 
 @mobile_template('browse/personas/{mobile/}')
+@non_atomic_requests
 def personas(request, category=None, template=None):
     listing = personas_listing(request, category)
 
@@ -379,6 +387,7 @@ def personas(request, category=None, template=None):
     return render(request, template, ctx)
 
 
+@non_atomic_requests
 def legacy_theme_redirects(request, category=None, category_name=None):
     url = None
 
@@ -407,6 +416,7 @@ def legacy_theme_redirects(request, category=None, category_name=None):
         raise Http404
 
 
+@non_atomic_requests
 def legacy_fulltheme_redirects(request, category=None):
     """Full Themes have already been renamed to Complete Themes!"""
     url = request.get_full_path().replace('/full-themes',
@@ -415,6 +425,7 @@ def legacy_fulltheme_redirects(request, category=None):
 
 
 @cache_page(60 * 60 * 24 * 365)
+@non_atomic_requests
 def legacy_creatured_redirect(request, category):
     category = get_object_or_404(Category.objects, slug=category,
                                  application=request.APP.id)
@@ -422,6 +433,7 @@ def legacy_creatured_redirect(request, category):
 
 
 @cache_page(60 * 60 * 24 * 365)
+@non_atomic_requests
 def legacy_redirects(request, type_, category=None, sort=None, format=None):
     type_slug = amo.ADDON_SLUGS.get(int(type_), 'extensions')
     if not category or category == 'all':
@@ -473,6 +485,7 @@ class SearchExtensionsFilter(AddonFilter):
             ('created', _lazy(u'Recently Added')),)
 
 
+@non_atomic_requests
 def search_tools(request, category=None):
     """View the search tools page."""
     APP, TYPE = request.APP, amo.ADDON_SEARCH
@@ -498,6 +511,7 @@ def search_tools(request, category=None):
                    'search_extensions_filter': sidebar_ext})
 
 
+@non_atomic_requests
 def moreinfo_redirect(request):
     try:
         addon_id = int(request.GET.get('id', ''))

--- a/apps/compat/views.py
+++ b/apps/compat/views.py
@@ -3,6 +3,7 @@ import re
 
 from django import http
 from django.db.models import Count
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import csrf_exempt
 
@@ -21,6 +22,7 @@ from .models import CompatReport, AppCompat, CompatTotals
 from .forms import AppVerForm, CompatForm
 
 
+@non_atomic_requests
 def index(request, version=None):
     template = 'compat/index.html'
     COMPAT = [v for v in amo.COMPAT if v['app'] == request.APP.id]
@@ -106,6 +108,7 @@ def usage_stats(request, compat, app, binary=None):
 
 @csrf_exempt
 @post_required
+@non_atomic_requests
 def incoming(request):
     # Turn camelCase into snake_case.
     def snake_case(s):
@@ -130,6 +133,7 @@ def incoming(request):
     return http.HttpResponse(status=204)
 
 
+@non_atomic_requests
 def reporter(request):
     query = request.GET.get('guid')
     if query:
@@ -153,6 +157,7 @@ def reporter(request):
                   dict(query=query, addons=addons))
 
 
+@non_atomic_requests
 def reporter_detail(request, guid):
     try:
         addon = Addon.with_unlisted.get(guid=guid)

--- a/apps/discovery/urls.py
+++ b/apps/discovery/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, patterns, url
 from django.core.urlresolvers import reverse
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import redirect
 
 from addons.urls import ADDON_ID
@@ -18,6 +19,7 @@ browser_re = '(?P<version>[^/]+)/(?P<platform>[^/]+)'
 compat_mode_re = '(?:/(?P<compat_mode>strict|normal|ignore))?'
 
 
+@non_atomic_requests
 def pane_redirect(req, **kw):
     kw['compat_mode'] = views.get_compat_mode(kw.get('version'))
     return redirect(reverse('discovery.pane', kwargs=kw), permanent=False)

--- a/apps/discovery/views.py
+++ b/apps/discovery/views.py
@@ -1,6 +1,7 @@
 import json
 
 from django import http
+from django.db.transaction import non_atomic_requests
 from django.forms.models import modelformset_factory
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.csrf import csrf_exempt
@@ -41,6 +42,7 @@ def get_compat_mode(version):
     return 'ignore' if vint >= version_int('10.0') else 'strict'
 
 
+@non_atomic_requests
 def pane(request, version, platform, compat_mode=None):
 
     if not compat_mode:
@@ -60,6 +62,7 @@ def pane(request, version, platform, compat_mode=None):
                    'promovideo': promovideo, 'compat_mode': compat_mode})
 
 
+@non_atomic_requests
 def pane_account(request):
     try:
         qs = GlobalStat.objects.filter(name='addon_total_downloads')
@@ -71,6 +74,7 @@ def pane_account(request):
                   {'addon_downloads': addon_downloads})
 
 
+@non_atomic_requests
 def promos(request, context, version, platform, compat_mode='strict'):
     platform = amo.PLATFORM_DICT.get(version.lower(), amo.PLATFORM_ALL)
     modules = get_modules(request, platform.api_name, version)
@@ -78,6 +82,7 @@ def promos(request, context, version, platform, compat_mode='strict'):
                   {'modules': modules, 'module_context': context})
 
 
+@non_atomic_requests
 def pane_promos(request, version, platform, compat_mode=None):
     if not compat_mode:
         compat_mode = get_compat_mode(version)
@@ -85,6 +90,7 @@ def pane_promos(request, version, platform, compat_mode=None):
     return promos(request, 'discovery', version, platform, compat_mode)
 
 
+@non_atomic_requests
 def pane_more_addons(request, section, version, platform, compat_mode=None):
 
     if not compat_mode:
@@ -123,6 +129,7 @@ def get_featured_personas(request, category=None, num_personas=6):
     return manual_order(base, ids, 'addons.id')[:num_personas]
 
 
+@non_atomic_requests
 def api_view(request, platform, version, list_type, api_version=1.5,
              format='json', content_type='application/json',
              compat_mode='strict'):
@@ -136,6 +143,7 @@ def api_view(request, platform, version, list_type, api_version=1.5,
 
 
 @admin_required
+@non_atomic_requests
 def module_admin(request):
     APP = request.APP
     # Custom sorting to drop ordering=NULL objects to the bottom.
@@ -171,6 +179,7 @@ def _sync_db_and_registry(qs, app_id):
 
 @csrf_exempt
 @post_required
+@non_atomic_requests
 def recommendations(request, version, platform, limit=9, compat_mode=None):
     """
     Figure out recommended add-ons for an anonymous user based on POSTed guids.
@@ -218,6 +227,7 @@ def get_addon_ids(guids):
 
 
 @addon_view
+@non_atomic_requests
 def addon_detail(request, addon):
     reviews = Review.objects.valid().filter(addon=addon, is_latest=True)
     src = request.GET.get('src', 'discovery-details')
@@ -227,6 +237,7 @@ def addon_detail(request, addon):
 
 
 @addon_view
+@non_atomic_requests
 def addon_eula(request, addon, file_id):
     if not addon.eula:
         return http.HttpResponseRedirect(reverse('discovery.addons.detail',

--- a/apps/files/views.py
+++ b/apps/files/views.py
@@ -1,4 +1,5 @@
 from django import http, shortcuts
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -63,6 +64,7 @@ def setup_viewer(request, file_obj):
 @never_cache
 @json_view
 @file_view
+@non_atomic_requests
 def poll(request, viewer):
     return {'status': viewer.is_extracted(),
             'msg': [Message('file-viewer:%s' % viewer).get(delete=True)]}
@@ -85,6 +87,7 @@ def check_compare_form(request, form):
 @csrf_exempt
 @file_view
 @condition(etag_func=etag, last_modified_func=last_modified)
+@non_atomic_requests
 def browse(request, viewer, key=None, type='file'):
     form = forms.FileCompareForm(request.POST or None, addon=viewer.addon,
                                  initial={'left': viewer.file})
@@ -122,6 +125,7 @@ def browse(request, viewer, key=None, type='file'):
 @never_cache
 @compare_file_view
 @json_view
+@non_atomic_requests
 def compare_poll(request, diff):
     msgs = []
     for f in (diff.left, diff.right):
@@ -134,6 +138,7 @@ def compare_poll(request, diff):
 @csrf_exempt
 @compare_file_view
 @condition(etag_func=etag, last_modified_func=last_modified)
+@non_atomic_requests
 def compare(request, diff, key=None, type='file'):
     form = forms.FileCompareForm(request.POST or None, addon=diff.addon,
                                  initial={'left': diff.left.file,
@@ -176,6 +181,7 @@ def compare(request, diff, key=None, type='file'):
 
 
 @file_view
+@non_atomic_requests
 def redirect(request, viewer, key):
     new = Token(data=[viewer.file.id, key])
     new.save()
@@ -185,6 +191,7 @@ def redirect(request, viewer, key):
 
 
 @file_view_token
+@non_atomic_requests
 def serve(request, viewer, key):
     """
     This is to serve files off of st.a.m.o, not standard a.m.o. For this we

--- a/apps/localizers/views.py
+++ b/apps/localizers/views.py
@@ -2,6 +2,7 @@ from itertools import groupby
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import redirect, render
 
 import commonware.log
@@ -58,6 +59,7 @@ def set_motd(request):
     return data
 
 
+@non_atomic_requests
 def summary(request):
     """global L10n dashboard"""
 
@@ -73,6 +75,7 @@ def summary(request):
 
 @locale_switcher
 @valid_locale
+@non_atomic_requests
 def locale_dashboard(request, locale_code):
     """per-locale dashboard"""
     data = {

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -1,12 +1,14 @@
 from collections import defaultdict
 
 from django.conf import settings
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import render
 
 from devhub.models import ActivityLog
 from users.models import UserProfile
 
 
+@non_atomic_requests
 def credits(request):
 
     developers = (UserProfile.objects

--- a/apps/reviews/feeds.py
+++ b/apps/reviews/feeds.py
@@ -1,16 +1,16 @@
-from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 
 from tower import ugettext as _
 
 from amo import helpers
+from amo.feeds import NonAtomicFeed
 
 from addons.models import Addon, Review
 
 import urllib
 
 
-class ReviewsRss(Feed):
+class ReviewsRss(NonAtomicFeed):
 
     addon = None
 

--- a/apps/reviews/views.py
+++ b/apps/reviews/views.py
@@ -1,6 +1,7 @@
 from django import http
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import Context, loader
 from django.utils.http import urlquote
@@ -41,6 +42,7 @@ def send_mail(template, subject, emails, context, perm_setting):
 
 @addon_view
 @mobile_template('reviews/{mobile/}review_list.html')
+@non_atomic_requests
 def review_list(request, addon, review_id=None, user_id=None, template=None):
     q = (Review.objects.valid().filter(addon=addon)
          .order_by('-created'))
@@ -106,6 +108,7 @@ def _retrieve_translation(text, language):
 
 @addon_view
 @waffle_switch('reviews-translate')
+@non_atomic_requests
 def translate(request, addon, review_id, language):
     """
     Use the Google Translate API for ajax, redirect to Google Translate for

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -1,6 +1,7 @@
 from django import http
 from django.conf import settings
 from django.db.models import Q
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import render
 from django.utils import translation
 from django.utils.encoding import smart_str
@@ -219,6 +220,7 @@ class PersonaSuggestionsAjax(SearchSuggestionsAjax):
 
 
 @json_view
+@non_atomic_requests
 def ajax_search(request):
     """This is currently used only to return add-ons for populating a
     new collection. Themes (formerly Personas) are included by default, so
@@ -231,6 +233,7 @@ def ajax_search(request):
 
 
 @json_view
+@non_atomic_requests
 def ajax_search_suggestions(request):
     cat = request.GET.get('cat', 'all')
     suggesterClass = {
@@ -394,6 +397,7 @@ def _filter_search(request, qs, query, filters, sorting,
 
 @mobile_template('search/{mobile/}results.html')
 @vary_on_headers('X-PJAX')
+@non_atomic_requests
 def search(request, tag_name=None, template=None):
     APP = request.APP
     types = (amo.ADDON_EXTENSION, amo.ADDON_THEME, amo.ADDON_DICT,

--- a/apps/stats/views.py
+++ b/apps/stats/views.py
@@ -13,6 +13,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection
 from django.db.models import Avg, Count, Q, Sum
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, render
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.utils.datastructures import SortedDict
@@ -53,6 +54,7 @@ GLOBAL_SERIES = ('addons_in_use', 'addons_updated', 'addons_downloaded',
 addon_view_with_unlisted = addon_view_factory(qs=Addon.with_unlisted.all)
 
 
+@non_atomic_requests
 def dashboard(request):
     stats_base_url = reverse('stats.dashboard')
     view = get_report_view(request)
@@ -145,6 +147,7 @@ def extract(dicts):
 
 
 @addon_view_with_unlisted
+@non_atomic_requests
 def overview_series(request, addon, group, start, end, format):
     """Combines downloads_series and updates_series into one payload."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -190,6 +193,7 @@ def zip_overview(downloads, updates):
 
 
 @addon_view_with_unlisted
+@non_atomic_requests
 def downloads_series(request, addon, group, start, end, format):
     """Generate download counts grouped by ``group`` in ``format``."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -204,6 +208,7 @@ def downloads_series(request, addon, group, start, end, format):
 
 
 @addon_view_with_unlisted
+@non_atomic_requests
 def sources_series(request, addon, group, start, end, format):
     """Generate download source breakdown."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -221,6 +226,7 @@ def sources_series(request, addon, group, start, end, format):
 
 
 @addon_view_with_unlisted
+@non_atomic_requests
 def usage_series(request, addon, group, start, end, format):
     """Generate ADU counts grouped by ``group`` in ``format``."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -237,6 +243,7 @@ def usage_series(request, addon, group, start, end, format):
 
 
 @addon_view_with_unlisted
+@non_atomic_requests
 def usage_breakdown_series(request, addon, group,
                            start, end, format, field):
     """Generate ADU breakdown of ``field``."""
@@ -335,6 +342,7 @@ def check_stats_permission(request, addon, for_contributions=False):
 
 
 @addon_view_factory(qs=Addon.with_unlisted.valid)
+@non_atomic_requests
 def stats_report(request, addon, report):
     check_stats_permission(request, addon,
                            for_contributions=(report == 'contributions'))
@@ -345,6 +353,7 @@ def stats_report(request, addon, report):
                    'stats_base_url': stats_base_url})
 
 
+@non_atomic_requests
 def site_stats_report(request, report):
     stats_base_url = reverse('stats.dashboard')
     view = get_report_view(request)
@@ -391,6 +400,7 @@ def get_daterange_or_404(start, end):
 
 
 @json_view
+@non_atomic_requests
 def site_events(request, start, end):
     """Return site events in the given timeframe."""
     start, end = get_daterange_or_404(start, end)
@@ -427,6 +437,7 @@ def site_event_format(request, events):
 
 
 @addon_view_with_unlisted
+@non_atomic_requests
 def contributions_series(request, addon, group, start, end, format):
     """Generate summarized contributions grouped by ``group`` in ``format``."""
     date_range = check_series_params_or_404(group, start, end, format)
@@ -454,6 +465,7 @@ def contributions_series(request, addon, group, start, end, format):
 
 # TODO: (dspasovski) - remove this once we know the indexed stats return JSON
 @json_view
+@non_atomic_requests
 def fake_collection_stats(request, username, slug, group, start, end, format):
     from time import strftime
     from math import sin, floor
@@ -525,6 +537,7 @@ def _site_query(period, start, end, field=None, request=None):
     return result.values(), _CACHED_KEYS
 
 
+@non_atomic_requests
 def site(request, format, group, start=None, end=None):
     """Site data from the global_stats table."""
     if not start and not end:
@@ -544,6 +557,7 @@ def site(request, format, group, start=None, end=None):
 
 
 @login_required
+@non_atomic_requests
 def collection_report(request, username, slug, report):
     c = get_collection(request, username, slug)
     stats_base_url = c.stats_url()
@@ -554,6 +568,7 @@ def collection_report(request, username, slug, report):
                    'slug': slug, 'stats_base_url': stats_base_url})
 
 
+@non_atomic_requests
 def site_series(request, format, group, start, end, field):
     """Pull a single field from the site_query data"""
     start, end = get_daterange_or_404(start, end)
@@ -577,6 +592,7 @@ def site_series(request, format, group, start, end, field):
     return render_json(request, None, series)
 
 
+@non_atomic_requests
 def collection_series(request, username, slug, format, group, start, end,
                       field):
     """Pull a single field from the collection_query data"""
@@ -594,6 +610,7 @@ def collection_series(request, username, slug, format, group, start, end,
     return render_json(request, None, series)
 
 
+@non_atomic_requests
 def collection_stats(request, username, slug, group, start, end, format):
     c = get_collection(request, username, slug)
     start, end = get_daterange_or_404(start, end)
@@ -620,6 +637,7 @@ def _collection_query(request, collection, start=None, end=None):
     return series
 
 
+@non_atomic_requests
 def collection(request, uuid, format, start=None, end=None):
     collection = get_object_or_404(Collection, uuid=uuid)
     series = _collection_query(request, collection, start, end)
@@ -670,6 +688,7 @@ class UnicodeCSVDictWriter(csv.DictWriter):
 
 
 @allow_cross_site_request
+@non_atomic_requests
 def render_csv(request, addon, stats, fields,
                title=None, show_disclaimer=None):
     """Render a stats series in CSV."""
@@ -690,6 +709,7 @@ def render_csv(request, addon, stats, fields,
 
 
 @allow_cross_site_request
+@non_atomic_requests
 def render_json(request, addon, stats):
     """Render a stats series in JSON."""
     response = http.HttpResponse(content_type='text/json')

--- a/apps/tags/views.py
+++ b/apps/tags/views.py
@@ -1,8 +1,10 @@
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import render
 
 from tags.models import Tag
 
 
+@non_atomic_requests
 def top_cloud(request, num_tags=100):
     """Display 100 (or so) most used tags"""
     """TODO (skeen) Need to take request.APP.id into account, first

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.tokens import default_token_generator
 from django.db import IntegrityError
 from django.db.models import Q, Sum
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import (get_list_or_404, get_object_or_404, redirect,
                               render)
 from django.template import Context, loader
@@ -72,6 +73,7 @@ def user_view(f):
 
 @login_required(redirect=False)
 @json_view
+@non_atomic_requests
 def ajax(request):
     """Query for a user matching a given email."""
 
@@ -487,6 +489,7 @@ def logout(request):
 
 
 @user_view
+@non_atomic_requests
 def profile(request, user):
     # Get user's own and favorite collections, if they allowed that.
     own_coll = fav_coll = []
@@ -533,6 +536,7 @@ def profile(request, user):
 
 
 @user_view
+@non_atomic_requests
 def themes(request, user, category=None):
     cats = Category.objects.filter(type=amo.ADDON_PERSONA)
 

--- a/apps/versions/feeds.py
+++ b/apps/versions/feeds.py
@@ -1,4 +1,3 @@
-from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import DefaultFeed
 from jingo.helpers import datetime
@@ -6,6 +5,7 @@ from jingo.helpers import datetime
 from tower import ugettext as _
 
 import amo
+from amo.feeds import NonAtomicFeed
 from amo.urlresolvers import reverse
 from amo.helpers import absolutify, url
 from amo.utils import urlparams
@@ -40,7 +40,7 @@ class PagedFeed(DefaultFeed):
         self.add_page_relation(handler, 'last', self.page.paginator.num_pages)
 
 
-class VersionsRss(Feed):
+class VersionsRss(NonAtomicFeed):
 
     feed_type = PagedFeed
     addon = None

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -2,6 +2,7 @@ import os
 import posixpath
 
 from django import http
+from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, redirect, render
 
 import caching.base as caching
@@ -28,6 +29,7 @@ log = commonware.log.getLogger('z.versions')
 
 @addon_view
 @mobile_template('versions/{mobile/}version_list.html')
+@non_atomic_requests
 def version_list(request, addon, template, beta=False):
     status_list = (amo.STATUS_BETA,) if beta else amo.VALID_STATUSES
     qs = (addon.versions.filter(files__status__in=status_list)
@@ -40,6 +42,7 @@ def version_list(request, addon, template, beta=False):
 
 
 @addon_view
+@non_atomic_requests
 def version_detail(request, addon, version_num):
     qs = (addon.versions.filter(files__status__in=amo.VALID_STATUSES)
           .distinct().order_by('-created'))
@@ -63,6 +66,7 @@ def _find_version_page(qs, addon, version_num):
 
 
 @addon_view
+@non_atomic_requests
 def update_info(request, addon, version_num):
     qs = addon.versions.filter(version=version_num,
                                files__status__in=amo.VALID_STATUSES)
@@ -75,6 +79,7 @@ def update_info(request, addon, version_num):
                   content_type='application/xhtml+xml')
 
 
+@non_atomic_requests
 def update_info_redirect(request, version_id):
     version = get_object_or_404(Version, pk=version_id)
     return redirect(reverse('addons.versions.update_info',
@@ -83,6 +88,7 @@ def update_info_redirect(request, version_id):
 
 
 # Should accept junk at the end for filename goodness.
+@non_atomic_requests
 def download_file(request, file_id, type=None):
     file = get_object_or_404(File.objects, pk=file_id)
     addon = get_object_or_404(Addon.with_unlisted, pk=file.version.addon_id)
@@ -118,6 +124,7 @@ def guard():
 
 
 @addon_view_factory(guard)
+@non_atomic_requests
 def download_latest(request, addon, beta=False, type='xpi', platform=None):
     platforms = [amo.PLATFORM_ALL.id]
     if platform is not None and int(platform) in amo.PLATFORMS:
@@ -142,6 +149,7 @@ def download_latest(request, addon, beta=False, type='xpi', platform=None):
     return http.HttpResponseRedirect(url)
 
 
+@non_atomic_requests
 def download_source(request, version_id):
     version = get_object_or_404(Version, pk=version_id)
 

--- a/apps/zadmin/tasks.py
+++ b/apps/zadmin/tasks.py
@@ -103,9 +103,9 @@ def bulk_validate_file(result_id, **kw):
                                    compat=True)
     except:
         task_error = sys.exc_info()
-        log.error(u"bulk_validate_file exception on file %s (%s): %s: %s"
-                  % (res.file, file_base,
-                     task_error[0], task_error[1]), exc_info=False)
+        log.exception(
+            u'bulk_validate_file exception on file {} ({})'
+            .format(res.file, file_base))
 
     res.completed = datetime.now()
     if task_error:
@@ -117,10 +117,6 @@ def bulk_validate_file(result_id, **kw):
         tally_validation_results.delay(res.validation_job.id, validation)
     res.save()
     tally_job_results(res.validation_job.id)
-
-    if task_error:
-        etype, val, tb = task_error
-        raise etype, val, tb
 
 
 @task

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -79,6 +79,8 @@ DATABASES = {'default': dj_database_url.parse(DATABASE_URL)}
 DATABASES['default']['OPTIONS'] = {'sql_mode': 'STRICT_ALL_TABLES'}
 DATABASES['default']['TEST_CHARSET'] = 'utf8'
 DATABASES['default']['TEST_COLLATION'] = 'utf8_general_ci'
+# Run all views in a transaction unless they are decorated not to.
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 # A database to be used by the services scripts, which does not use Django.
 # The settings can be copied from DATABASES, but since its not a full Django

--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -50,8 +50,12 @@ SYSLOG_CSP = "http_app_addons_dev_csp"
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'mysql_pool'
+# Run all views in a transaction (on master) unless they are decorated not to.
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
+# Do not open a transaction for every view on the slave DB.
+DATABASES['slave']['ATOMIC_REQUESTS'] = False
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
 DATABASES['slave']['sa_pool_key'] = 'slave'
 

--- a/sites/prod/settings.py
+++ b/sites/prod/settings.py
@@ -50,8 +50,12 @@ SYSLOG_CSP = "http_app_addons_csp"
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'mysql_pool'
+# Run all views in a transaction (on master) unless they are decorated not to.
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
+# Do not open a transaction for every view on the slave DB.
+DATABASES['slave']['ATOMIC_REQUESTS'] = False
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
 DATABASES['slave']['sa_pool_key'] = 'slave'
 

--- a/sites/stage/settings.py
+++ b/sites/stage/settings.py
@@ -49,8 +49,12 @@ SYSLOG_CSP = "http_app_addons_stage_csp"
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'mysql_pool'
+# Run all views in a transaction (on master) unless they are decorated not to.
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
+# Do not open a transaction for every view on the slave DB.
+DATABASES['slave']['ATOMIC_REQUESTS'] = False
 DATABASES['slave']['ENGINE'] = 'mysql_pool'
 DATABASES['slave']['sa_pool_key'] = 'slave'
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/olympia/issues/1154

For starters, this marks all consumer views to still run without transactions. These are the heaviest trafficked views so eventually we can try to run them in transactions. However, some of these views we know for sure are read-only.

The script in [this gist](https://gist.github.com/kumar303/3092982b49859b219a0b) was used to verify the views that need to be marked as non-atomic. It would be helpful to also get a quick review of that script since this diff may be harder to review.