### PR TITLE
Replace .attr() with .prop() and .val()

### DIFF
--- a/static/js/common/fxa-login.js
+++ b/static/js/common/fxa-login.js
@@ -57,7 +57,7 @@
     function showLoginForm($form) {
         $form.removeClass('login-source-form')
              .addClass('login-form');
-        $form.find('[name="password"]').attr('required', true);
+        $form.find('[name="password"]').prop('required', true);
     }
 
     function showLoginSourceForm($form) {

--- a/static/js/common/ratingwidget.js
+++ b/static/js/common/ratingwidget.js
@@ -33,11 +33,11 @@ $.fn.ratingwidget = function(classes) {
         $widget.click(function(evt) {
             var t = $(evt.target);
             if (t.is('input[type=radio]')) {
-                showStars(rating = t.attr('value'));
+                showStars(rating = t.val());
                 if (!t.val()) {
                     // If the user caused a radio button to become unchecked,
                     // re-check it because that shouldn't happen.
-                    t.attr('checked', true);
+                    t.prop('checked', true);
                 }
             }
         }).mouseover(function(evt) {

--- a/static/js/common/upload-base.js
+++ b/static/js/common/upload-base.js
@@ -44,10 +44,10 @@
                 $upload_field.trigger("upload_start", [file]);
 
                 /* Disable uploading while something is uploading */
-                $upload_field.attr('disabled', true);
+                $upload_field.prop('disabled', true);
                 $upload_field.parent().find('a').addClass("disabled");
                 $upload_field.bind("reenable_uploader", function() {
-                    $upload_field.attr('disabled', false);
+                    $upload_field.prop('disabled', false);
                     $upload_field.parent().find('a').removeClass("disabled");
                 });
 

--- a/static/js/impala/formset.js
+++ b/static/js/impala/formset.js
@@ -111,7 +111,7 @@ $.zAutoFormset = function(o) {
         }
         var $visible = $forms.find(formSelector + ':visible').length;
         if ($visible >= maxItems) {
-            $input.attr('disabled', true).slideUp();
+            $input.prop('disabled', true).slideUp();
             $('.ui-autocomplete').hide();
         } else if ($visible < maxItems) {
             $input.filter(':disabled').removeAttr('disabled').slideDown();
@@ -156,7 +156,7 @@ $.zAutoFormset = function(o) {
     function removed(el) {
         el.slideUp(toggleInput);
         // Mark as deleted.
-        el.find('input[name$=-DELETE]').attr('checked', true);
+        el.find('input[name$=-DELETE]').prop('checked', true);
 
         if (removedCB) {
             removedCB(el);

--- a/static/js/impala/global.js
+++ b/static/js/impala/global.js
@@ -186,7 +186,7 @@ $(function() {
           $parent = $form.is('.ajax-submit') ? $form : $form.closest('.ajax-submit'),
           params = $form.serializeArray();
 
-      $form.find('.submit, button[type=submit], submit').attr('disabled', true).addClass('loading-submit');
+      $form.find('.submit, button[type=submit], submit').prop('disabled', true).addClass('loading-submit');
       $.post($form.attr('action'), params, function(d) {
           var $replacement = $(d);
           $parent.replaceWith($replacement);

--- a/static/js/impala/users.js
+++ b/static/js/impala/users.js
@@ -10,7 +10,7 @@ $(function() {
     if($('#user_edit').exists()) {
         $('.more-all, .more-none').click(_pd(function() {
             var $this = $(this);
-            $this.closest('li').find('input:not([disabled]').attr('checked', $this.hasClass('more-all'));
+            $this.closest('li').find('input:not([disabled]').prop('checked', $this.hasClass('more-all'));
         }));
     }
 
@@ -64,7 +64,7 @@ $(function() {
         var validate_required_fields = function() {
             var valid = _.every($(required, $form),
                                 function (e) { return $.trim(e.value) });
-            $submit.attr('disabled', !valid || null);
+            $submit.prop('disabled', !valid || null);
         }
 
         var $form = $('#t-shirt-order-form');
@@ -76,7 +76,7 @@ $(function() {
         validate_required_fields();
 
         $form.submit(function (e) {
-            $submit.attr('disabled', true);
+            $submit.prop('disabled', true);
 
             $.ajax({
                 url: location.href,

--- a/static/js/zamboni/admin_features.js
+++ b/static/js/zamboni/admin_features.js
@@ -30,11 +30,11 @@ $(document).ready(function(){
             $tr = $this.closest('tr'),
             val = $this.val();
         $tr.attr('data-app', val);
-        $tr.find('.collection-ac').attr('disabled', !val);
+        $tr.find('.collection-ac').prop('disabled', !val);
     });
     $('#features').delegate('.remove', 'click', _pd(function() {
         $(this).closest('tr').hide();
-        $(this).closest('td').find('input').attr('checked', true);
+        $(this).closest('td').find('input').prop('checked', true);
     }));
     $('#features').delegate('.replace', 'click', _pd(function() {
         var $td = $(this).closest('td');

--- a/static/js/zamboni/collections.js
+++ b/static/js/zamboni/collections.js
@@ -255,7 +255,7 @@ collections.hijack_favorite_button = function() {
         /* We don't want the button to shrink when the contents
         * inside change. */
         fav_button.css('min-width', fav_button.outerWidth());
-        fav_button.addClass('loading-fav').attr('disabled', 'disabled');
+        fav_button.addClass('loading-fav').prop('disabled', true);
         button(is_fav ? 'removing' : 'adding');
         fav_button.css('min-width', fav_button.outerWidth());
 
@@ -279,7 +279,7 @@ collections.hijack_favorite_button = function() {
                 fav_button.html(previous);
             },
             complete: function(){
-                fav_button.attr('disabled', '');
+                fav_button.prop('disabled', false);
                 fav_button.removeClass('loading-fav');
             }
         });

--- a/static/js/zamboni/contributions.js
+++ b/static/js/zamboni/contributions.js
@@ -172,11 +172,11 @@ var contributions = {
         var contrib_limit = parseFloat($('#contrib-too-much').attr('data-max-amount'));
         cb.find('li label').click(function(e) {
             e.preventDefault();
-            $(this).siblings(':radio').attr('checked', 'checked');
+            $(this).siblings(':radio').prop('checked', true);
             $(this).children('input:text').focus();
         }).end()
         .find('input:text').keypress(function() {
-            $(this).parent().siblings(':radio').attr('checked', 'checked');
+            $(this).parent().siblings(':radio').prop('checked', true);
         }).end()
         .find('textarea').keyup(function() {
             var txt = $(this).val(),
@@ -253,7 +253,7 @@ var contributions = {
                     hash.w
                         .find('input:text').val('').end()
                         .find('textarea').val('').keyup().end()
-                        .find('input:radio:first').attr('checked', 'checked').end()
+                        .find('input:radio:first').prop('checked', true).end()
                         .fadeIn();
 
                 },

--- a/static/js/zamboni/files.js
+++ b/static/js/zamboni/files.js
@@ -1071,17 +1071,17 @@ $(document).ready(function() {
     var $left = $('#id_left'),
         $right = $('#id_right');
 
-    $left.find('option:not([value])').attr('disabled', true);
+    $left.find('option:not([value])').prop('disabled', true);
 
     var $left_options = $left.find('option:not([disabled])'),
         $right_options = $right.find('option:not([disabled])');
 
     $right.change(function(event) {
         var right = $right.val();
-        $left_options.attr('disabled', function() { return this.value == right; });
+        $left_options.prop('disabled', function() { return this.value == right; });
     }).change();
     $left.change(function(event) {
         var left = $left.val();
-        $right_options.attr('disabled', function() { return this.value == left; });
+        $right_options.prop('disabled', function() { return this.value == left; });
     }).change();
 });

--- a/static/js/zamboni/init.js
+++ b/static/js/zamboni/init.js
@@ -26,7 +26,7 @@ $(document).ready(function(){
     if (z.readonly) {
         $('form[method=post]')
             .before(gettext('This feature is temporarily disabled while we perform website maintenance. Please check back a little later.'))
-            .find('input, button, select').attr('disabled', true).addClass('disabled');
+            .find('input, button, select').prop('disabled', true).addClass('disabled');
     }
 });
 

--- a/static/js/zamboni/password-strength.js
+++ b/static/js/zamboni/password-strength.js
@@ -29,7 +29,7 @@ function initStrength(nodes) {
                 $count.hide();
             }
             var val = (complexity($el.val()) / 5) * 100;
-            $strength.children('progress').attr('value', val).text(format('{0}%', val));
+            $strength.children('progress').val(val).text(format('{0}%', val));
         });
     });
 }

--- a/static/js/zamboni/reviews.js
+++ b/static/js/zamboni/reviews.js
@@ -107,5 +107,5 @@ $(document).ready(function() {
 
     $("select[name='rating']").ratingwidget();
 
-    $('.review-flagged.disabled input:not([type=hidden])').attr('disabled', true);
+    $('.review-flagged.disabled input:not([type=hidden])').prop('disabled', true);
 });


### PR DESCRIPTION
Fixes #1245

Replaces `.attr()` used for boolean values with `.prop()`. Also replaces `.attr('value')` with `.val()`.