### PR TITLE
Get .srcElement from originalEvent in syntaxhighlither/shCore.js

### DIFF
--- a/static/js/lib/syntaxhighlighter/shCore.js
+++ b/static/js/lib/syntaxhighlighter/shCore.js
@@ -620,7 +620,7 @@ function attachEvent(obj, type, func, scope)
 
 		if (!e.target)
 		{
-			e.target = e.srcElement;
+			e.target = e.originalEvent.srcElement;
 			e.preventDefault = function()
 			{
 				this.returnValue = false;


### PR DESCRIPTION
Fixes #1273