### PR TITLE
Remove old @commit_on_success decorators

### DIFF
--- a/apps/addons/cron.py
+++ b/apps/addons/cron.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.db import connections, transaction
+from django.db import connections
 from django.db.models import Q, F, Avg
 
 import cronjobs
@@ -86,7 +86,6 @@ def _update_addons_current_version(data, **kw):
         except Addon.DoesNotExist:
             m = "Failed to update current_version. Missing add-on: %d" % (pk)
             task_log.debug(m)
-    transaction.commit_unless_managed()
 
 
 @cronjobs.register

--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -403,7 +403,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
             return
         clean_slug(self, slug_field)
 
-    @transaction.commit_on_success
+    @transaction.atomic
     def delete(self, msg='', reason=''):
         # To avoid a circular import.
         from . import tasks

--- a/apps/amo/cron.py
+++ b/apps/amo/cron.py
@@ -4,7 +4,7 @@ from subprocess import Popen, PIPE
 
 from django.conf import settings
 from django.utils import translation
-from django.db import connection, transaction
+from django.db import connection
 
 import cronjobs
 import commonware.log
@@ -130,7 +130,6 @@ def category_totals():
     AS j ON (t.id = j.category_id)
     SET t.count = j.ct
     """ % (p, p), VALID_STATUSES * 2)
-    transaction.commit_unless_managed()
 
 
 @cronjobs.register
@@ -164,7 +163,6 @@ def collection_subscribers():
         SET c.weekly_subscribers = weekly.count,
             c.monthly_subscribers = monthly.count
     """)
-    transaction.commit_unless_managed()
 
 
 @cronjobs.register
@@ -187,7 +185,6 @@ def unconfirmed():
         AND addons_collections.user_id IS NULL
         AND collections_users.user_id IS NULL
     """)
-    transaction.commit_unless_managed()
 
 
 @cronjobs.register
@@ -205,7 +202,6 @@ def share_count_totals():
                  GROUP BY addon_id, service)
             """ % ','.join(['%s'] * len(SERVICES_LIST)),
                    [s.shortname for s in SERVICES_LIST])
-    transaction.commit_unless_managed()
 
 
 @cronjobs.register
@@ -243,4 +239,3 @@ def weekly_downloads():
             ON addons.id = tmp_wd.addon_id
         SET weeklydownloads = tmp_wd.count""")
     cursor.execute("DROP TABLE IF EXISTS tmp_wd")
-    transaction.commit_unless_managed()

--- a/apps/amo/models.py
+++ b/apps/amo/models.py
@@ -146,7 +146,7 @@ class UncachedManagerBase(models.Manager):
         gets fixed. It's probably fine, but this makes me happy for the moment
         and solved a get_or_create we've had in the past.
         """
-        with transaction.commit_on_success():
+        with transaction.atomic():
             try:
                 return self.get(**kw), False
             except self.model.DoesNotExist:

--- a/apps/api/handlers.py
+++ b/apps/api/handlers.py
@@ -100,7 +100,7 @@ class AddonsHandler(BaseHandler):
         return addon.name.localized_string if addon.name else ''
 
     # We need multiple validation, so don't use @validate decorators.
-    @transaction.commit_on_success
+    @transaction.atomic
     def create(self, request):
         new_file_form = XPIForm(request, request.POST, request.FILES)
 

--- a/apps/bandwagon/cron.py
+++ b/apps/bandwagon/cron.py
@@ -1,7 +1,7 @@
 from datetime import date
 import itertools
 
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import Count
 
 import commonware.log
@@ -107,7 +107,7 @@ def drop_collection_recs():
 
 
 @task(rate_limit='1/m')
-@transaction.commit_on_success
+@transaction.atomic
 def _drop_collection_recs(**kw):
     task_log.info("[300@%s] Dropping recommended collections." % (
                   _drop_collection_recs.rate_limit))

--- a/apps/bandwagon/cron.py
+++ b/apps/bandwagon/cron.py
@@ -1,7 +1,7 @@
 from datetime import date
 import itertools
 
-from django.db import connection, transaction
+from django.db import connection
 from django.db.models import Count
 
 import commonware.log
@@ -42,7 +42,6 @@ def _update_collections_subscribers(data, **kw):
                     (%s, %s, %s, %s)"""
         p = [today, 'new_subscribers', var['collection_id'], var['count']]
         cursor.execute(q, p)
-    transaction.commit_unless_managed()
 
 
 @cronjobs.register
@@ -79,7 +78,6 @@ def _update_collections_votes(data, stat, **kw):
         p = [date.today(), stat,
              var['collection_id'], var['count']]
         cursor.execute(q, p)
-    transaction.commit_unless_managed()
 
 
 # TODO: remove this once zamboni enforces slugs.

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -1173,7 +1173,7 @@ def _get_file_history(version):
 
 @dev_required
 @post_required
-@transaction.commit_on_success
+@transaction.atomic
 def version_delete(request, addon_id, addon):
     version_id = request.POST.get('version_id')
     version = get_object_or_404(Version, pk=version_id, addon=addon)
@@ -1404,7 +1404,7 @@ def submit(request, step):
 
 @login_required
 @submit_step(2)
-@transaction.commit_on_success
+@transaction.atomic
 def submit_addon(request, step):
     if request.user.read_dev_agreement is None:
         return redirect(_step_url(1))
@@ -1762,7 +1762,7 @@ def render_agreement(request, template, next_step, step=None):
 
 @login_required
 @waffle_switch('signing-api')
-@transaction.commit_on_success
+@transaction.atomic
 def api_key(request):
     if request.user.read_dev_agreement is None:
         return redirect(reverse('devhub.api_key_agreement'))

--- a/apps/stats/tasks.py
+++ b/apps/stats/tasks.py
@@ -3,7 +3,7 @@ import httplib2
 import itertools
 
 from django.conf import settings
-from django.db import connection, transaction
+from django.db import connection
 from django.db.models import Sum, Max
 
 import commonware.log
@@ -54,7 +54,6 @@ def update_addons_collections_downloads(data, **kw):
                    list(itertools.chain.from_iterable(
                        [var['sum'], var['addon'], var['collection']]
                        for var in data)))
-    transaction.commit_unless_managed()
 
 
 @task
@@ -131,7 +130,6 @@ def update_google_analytics(date, **kw):
         cursor = connection.cursor()
         cursor.execute('REPLACE INTO global_stats (name, count, date) '
                        'values (%s, %s, %s)', p)
-        transaction.commit_unless_managed()
     except Exception, e:
         log.critical('Failed to update global stats: (%s): %s' % (p, e))
         return
@@ -156,7 +154,6 @@ def update_global_totals(job, date, **kw):
     try:
         cursor = connection.cursor()
         cursor.execute(q, p)
-        transaction.commit_unless_managed()
     except Exception, e:
         log.critical('Failed to update global stats: (%s): %s' % (p, e))
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -385,7 +385,7 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase,
         self.picture_type = ""
         self.save()
 
-    @transaction.commit_on_success
+    @transaction.atomic
     def restrict(self):
         from amo.utils import send_mail
         log.info(u'User (%s: <%s>) is being restricted and '


### PR DESCRIPTION
These can't be used when transactions are managed globally (ATOMIC=True).

This is a follow-up to https://github.com/mozilla/olympia/pull/1243