### PR TITLE
Remove 2nd datepicker

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -844,7 +844,6 @@ MINIFY_BUNDLES = {
             'js/common/ratingwidget.js',
         ),
         'zamboni/stats': (
-            'js/lib/jquery-datepicker.js',
             'js/lib/highcharts.src.js',
             'js/impala/stats/csv_keys.js',
             'js/impala/stats/helpers.js',


### PR DESCRIPTION
Fixes #1265 

![network_-_http___addons_dev_en-gb_firefox_addon_tasty-gyro_statistics__last_30](https://cloud.githubusercontent.com/assets/1514/12230731/2f856812-b84a-11e5-85ce-118ba8d0b48d.png)
