### PR TITLE
Fix erroneous conversion of object to string

### DIFF
--- a/static/js/impala/stats/stats.js
+++ b/static/js/impala/stats/stats.js
@@ -41,7 +41,21 @@
         // Restore any session view information from sessionStorage.
         if (z.capabilities.localStorage && sessionStorage.getItem('stats_view')) {
             var ssView = JSON.parse(sessionStorage.getItem('stats_view'));
-            initView.range = _.escape(ssView.range || initView.range);
+
+            // The stored range is either a string or an object.
+            if (ssView.range && typeof ssView.range === 'object') {
+                var objRange = ssView.range;
+                Object.keys(objRange).forEach(function(key) {
+                    var val = objRange[key];
+                    if (typeof val === 'string') {
+                      objRange[key] = _.escape(val);
+                    }
+                });
+                initView.range = objRange;
+            } else {
+                initView.range = _.escape(ssView.range || initView.range);
+            }
+
             initView.group = _.escape(ssView.group || initView.group);
         }
 


### PR DESCRIPTION
Fixes #1290

To test look at a stats page and change the dates in the datepicker. When you refresh the dates should be restored from session storage and as the error is gone - the data is displayed as expected.