### PR TITLE
Add modal to body following jqmodal update

### DIFF
--- a/static/js/zamboni/contributions.js
+++ b/static/js/zamboni/contributions.js
@@ -248,14 +248,18 @@ var contributions = {
                     if ($.browser.opera) {
                         this.inputs = $(':input:visible').css('visibility', 'hidden');
                     }
+
                     // clean up, then show box
                     hash.w.find('.error').hide();
+                    // If overlay is not disabled, prepend to body
+                    if(hash.c.overlay > 0) {
+                        hash.o.prependTo('body');
+                    }
                     hash.w
                         .find('input:text').val('').end()
                         .find('textarea').val('').keyup().end()
                         .find('input:radio:first').prop('checked', true).end()
                         .fadeIn();
-
                 },
                 onHide: function(hash) {
                     if ($.browser.opera) {


### PR DESCRIPTION
Fixes #1301 

The update to jqModal means that if you override onShow you need to prepend the overlay yourself too.