### PR TITLE
Use the csp-report endpoint in addons-nginx

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -125,6 +125,9 @@ FXA_CONFIG = {
     'scope': 'profile',
 }
 
+# CSP report endpoint which returns a 204 from addons-nginx in local dev.
+CSP_REPORT_URI = '/csp-report'
+
 # If you have settings you want to overload, put them in a local_settings.py.
 try:
     from local_settings import *  # noqa


### PR DESCRIPTION
:bomb: Don't land until addons-nginx PR has landed and is built on the docker hub. :bomb:

See also https://github.com/mozilla/addons-nginx/pull/1

Fixes #1304