### PR TITLE
CSP: Allow GA on www subdomain over http for local dev

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1233,15 +1233,17 @@ CEF_PRODUCT = "amo"
 CSP_REPORT_URI = '/services/csp/report'
 CSP_REPORT_ONLY = True
 
-CSP_DEFAULT_SRC = ("*", "data:")
-CSP_SCRIPT_SRC = ("'self'",
-                  "https://www.google.com",  # Recaptcha
-                  "https://www.paypalobjects.com",
-                  "https://ssl.google-analytics.com",
-                  )
-CSP_STYLE_SRC = ("*", "'unsafe-inline'")
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_SCRIPT_SRC = (
+    "'self'",
+    "https://www.google.com",  # Recaptcha
+    "https://www.paypalobjects.com",
+    "https://ssl.google-analytics.com",
+)
+CSP_IMG_SRC = ("'self'", "https://ssl.google-analytics.com")
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'",)
 CSP_OBJECT_SRC = ("'none'",)
-CSP_FRAME_SRC = ("https://ssl.google-analytics.com",)
+CSP_CHILD_SRC = ("https://ssl.google-analytics.com",)
 
 
 # Should robots.txt deny everything or disallow a calculated list of URLs we

--- a/settings.py
+++ b/settings.py
@@ -128,6 +128,11 @@ FXA_CONFIG = {
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'
 
+# Allow GA over http + www subdomain in local development.
+HTTP_GA_SRC = 'http://www.google-analytics.com'
+CSP_SCRIPT_SRC += (HTTP_GA_SRC,)
+CSP_IMG_SRC += (HTTP_GA_SRC,)
+
 # If you have settings you want to overload, put them in a local_settings.py.
 try:
     from local_settings import *  # noqa


### PR DESCRIPTION
Fixes #1314 - because of this conditional line: https://github.com/mozilla/olympia/blob/master/static/js/zamboni/analytics.js#L11

Includes other settings changes to fix up CSP warnings.

:bomb: Do not merge yet. :bomb: - will land after the tag