### PR TITLE
Fix moz_header CSS refs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ nginx:
     - "80:80"
   volumes:
     - ./static:/srv/static
+    - ./site-static:/srv/site-static
   links:
     - web:web
 


### PR DESCRIPTION
Adds site-static so that we can serve the header/footer.css for moz_header from there. See also https://github.com/mozilla/addons-nginx/pull/2