### PR TITLE
Initial iframe CSP settings for PayPal

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1247,15 +1247,21 @@ CSP_REPORT_URI = '/services/csp/report'
 CSP_REPORT_ONLY = True
 
 CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = (
+CSP_IFRAME_SRC = (
     "'self'",
-    "https://www.google.com",  # Recaptcha
-    "https://www.paypalobjects.com",
-    ANALYTICS_HOST,
-    PROD_CDN_HOST,
+    'https://www.paypal.com',
 )
 CSP_IMG_SRC = (
     "'self'",
+    'https://www.paypal.com',
+    ANALYTICS_HOST,
+    PROD_CDN_HOST,
+)
+CSP_OBJECT_SRC = ("'none'",)
+CSP_SCRIPT_SRC = (
+    "'self'",
+    'https://www.google.com',  # Recaptcha
+    'https://www.paypalobjects.com',
     ANALYTICS_HOST,
     PROD_CDN_HOST,
 )
@@ -1264,7 +1270,6 @@ CSP_STYLE_SRC = (
     "'unsafe-inline'",
     PROD_CDN_HOST,
 )
-CSP_OBJECT_SRC = ("'none'",)
 
 # Should robots.txt deny everything or disallow a calculated list of URLs we
 # don't want to be crawled?  Default is true, allow everything, toggled to

--- a/settings.py
+++ b/settings.py
@@ -132,6 +132,7 @@ CSP_REPORT_URI = '/csp-report'
 HTTP_GA_SRC = 'http://www.google-analytics.com'
 CSP_SCRIPT_SRC += (HTTP_GA_SRC,)
 CSP_IMG_SRC += (HTTP_GA_SRC,)
+CSP_IFRAME_SRC += ('https://www.sandbox.paypal.com',)
 
 # If you have settings you want to overload, put them in a local_settings.py.
 try:

--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -13,6 +13,7 @@ DEV_CDN_HOST = 'https://addons-dev-cdn.allizom.org'
 CSP_SCRIPT_SRC += (DEV_CDN_HOST,)
 CSP_IMG_SRC += (DEV_CDN_HOST,)
 CSP_STYLE_SRC += (DEV_CDN_HOST,)
+CSP_IFRAME_SRC += ('https://www.sandbox.paypal.com',)
 
 ENGAGE_ROBOTS = False
 

--- a/sites/stage/settings.py
+++ b/sites/stage/settings.py
@@ -12,6 +12,7 @@ STAGE_CDN_HOST = 'https://addons-stage-cdn.allizom.org'
 CSP_SCRIPT_SRC += (STAGE_CDN_HOST,)
 CSP_IMG_SRC += (STAGE_CDN_HOST,)
 CSP_STYLE_SRC += (STAGE_CDN_HOST,)
+CSP_IFRAME_SRC += ('https://www.sandbox.paypal.com',)
 
 ENGAGE_ROBOTS = False
 


### PR DESCRIPTION
Relates to #1335

* Add initial paypal iframe-src settings
* Switch " for ' where possible.
* Re-jig order of rules.