### PR TITLE
Add font-src and remove default-src

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1246,8 +1246,17 @@ ANALYTICS_HOST = 'https://ssl.google-analytics.com'
 CSP_REPORT_URI = '/services/csp/report'
 CSP_REPORT_ONLY = True
 
-CSP_DEFAULT_SRC = ("'self'",)
-CSP_IFRAME_SRC = (
+# NOTE: CSP_DEFAULT_SRC MUST be set otherwise things not set
+# will default to being open to anything.
+CSP_DEFAULT_SRC = (
+    "'none'",
+)
+
+CSP_FONT_SRC = (
+    "'self'",
+    PROD_CDN_HOST,
+)
+CSP_FRAME_SRC = (
     "'self'",
     'https://www.paypal.com',
 )

--- a/settings.py
+++ b/settings.py
@@ -130,9 +130,9 @@ CSP_REPORT_URI = '/csp-report'
 
 # Allow GA over http + www subdomain in local development.
 HTTP_GA_SRC = 'http://www.google-analytics.com'
-CSP_SCRIPT_SRC += (HTTP_GA_SRC,)
+CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
 CSP_IMG_SRC += (HTTP_GA_SRC,)
-CSP_IFRAME_SRC += ('https://www.sandbox.paypal.com',)
+CSP_SCRIPT_SRC += (HTTP_GA_SRC,)
 
 # If you have settings you want to overload, put them in a local_settings.py.
 try:

--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -10,10 +10,11 @@ env = environ.Env()
 
 # Allow addons-dev CDN for CSP.
 DEV_CDN_HOST = 'https://addons-dev-cdn.allizom.org'
-CSP_SCRIPT_SRC += (DEV_CDN_HOST,)
+CSP_FONT_SRC += (DEV_CDN_HOST,)
+CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
 CSP_IMG_SRC += (DEV_CDN_HOST,)
+CSP_SCRIPT_SRC += (DEV_CDN_HOST,)
 CSP_STYLE_SRC += (DEV_CDN_HOST,)
-CSP_IFRAME_SRC += ('https://www.sandbox.paypal.com',)
 
 ENGAGE_ROBOTS = False
 

--- a/sites/stage/settings.py
+++ b/sites/stage/settings.py
@@ -9,10 +9,11 @@ environ.Env.read_env(env_file='/etc/olympia/settings.env')
 env = environ.Env()
 
 STAGE_CDN_HOST = 'https://addons-stage-cdn.allizom.org'
-CSP_SCRIPT_SRC += (STAGE_CDN_HOST,)
+CSP_FONT_SRC += (STAGE_CDN_HOST,)
+CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
 CSP_IMG_SRC += (STAGE_CDN_HOST,)
+CSP_SCRIPT_SRC += (STAGE_CDN_HOST,)
 CSP_STYLE_SRC += (STAGE_CDN_HOST,)
-CSP_IFRAME_SRC += ('https://www.sandbox.paypal.com',)
 
 ENGAGE_ROBOTS = False
 


### PR DESCRIPTION
Fixes #1377

Fixes default-src to be locked down via 'none' as leaving it out makes things not explicitly set be wide-open.

Also fixed `CSP_IFRAME_SRC` which should be `CSP_FRAME_SRC`