### PR TITLE
Allow admins to view signing API results

### DIFF
--- a/apps/signing/tests/test_views.py
+++ b/apps/signing/tests/test_views.py
@@ -8,6 +8,7 @@ import mock
 from rest_framework.response import Response
 
 import amo
+from access.models import Group, GroupUser
 from addons.models import Addon, AddonUser
 from api.tests.utils import APIAuthTestCase
 from devhub import tasks
@@ -61,6 +62,10 @@ class BaseUploadVersionCase(SigningAPITestCase):
             return self.client.put(url, {'upload': upload},
                                    HTTP_AUTHORIZATION=self.authorization())
 
+    def make_admin(self, user):
+        admin_group = Group.objects.create(name='Admin', rules='*:*')
+        GroupUser.objects.create(group=admin_group, user=user)
+
 
 class TestUploadVersion(BaseUploadVersionCase):
 
@@ -93,6 +98,15 @@ class TestUploadVersion(BaseUploadVersionCase):
         self.user = UserProfile.objects.create(
             read_dev_agreement=datetime.now())
         self.api_key = self.create_api_key(self.user, 'bar')
+        response = self.put(self.url(self.guid, '3.0'))
+        assert response.status_code == 403
+        assert response.data['error'] == 'You do not own this addon.'
+
+    def test_admin_does_not_own_addon(self):
+        self.user = UserProfile.objects.create(
+            read_dev_agreement=datetime.now())
+        self.api_key = self.create_api_key(self.user, 'bar')
+        self.make_admin(self.user)
         response = self.put(self.url(self.guid, '3.0'))
         assert response.status_code == 403
         assert response.data['error'] == 'You do not own this addon.'
@@ -202,12 +216,23 @@ class TestCheckVersion(BaseUploadVersionCase):
         assert response.data['error'] == 'Could not find add-on with id "foo".'
 
     def test_user_does_not_own_addon(self):
+        self.create_version('3.0')
         self.user = UserProfile.objects.create(
             read_dev_agreement=datetime.now())
         self.api_key = self.create_api_key(self.user, 'bar')
         response = self.get(self.url(self.guid, '3.0'))
         assert response.status_code == 403
         assert response.data['error'] == 'You do not own this addon.'
+
+    def test_admin_can_view(self):
+        self.create_version('3.0')
+        self.user = UserProfile.objects.create(
+            read_dev_agreement=datetime.now())
+        self.make_admin(self.user)
+        self.api_key = self.create_api_key(self.user, 'bar')
+        response = self.get(self.url(self.guid, '3.0'))
+        assert response.status_code == 200
+        assert 'processed' in response.data
 
     def test_version_does_not_exist(self):
         response = self.get(self.url(self.guid, '2.5'))


### PR DESCRIPTION
This lets admin users view the results of a signing API upload but does not allow them to upload files for add-ons they do not own.