### PR TITLE
Changing support.mozilla.com links to support.mozilla.org

### DIFF
--- a/apps/blocklist/templates/blocklist/blocked_detail.html
+++ b/apps/blocklist/templates/blocklist/blocked_detail.html
@@ -32,7 +32,7 @@
 
     {% trans app = APP.pretty,
              criteria = "http://wiki.mozilla.org/Blocklisting",
-             support = "http://support.mozilla.com/kb/Add-ons Blocklist" %}
+             support = "http://support.mozilla.org/kb/add-ons-cause-issues-are-on-blocklist" %}
     When Mozilla becomes aware of add-ons, plugins, or other third-party
     software that seriously compromises {{ app }} security, stability, or
     performance and meets <a href="{{ criteria }}">certain criteria</a>, the

--- a/templates/mobile/header.html
+++ b/templates/mobile/header.html
@@ -4,7 +4,7 @@
     <li><a href="http://www.mozilla.com/firefox/features/">{{ _('Features') }}</a></li>
     <li><a href="http://mozilla.com/firefox/">{{ _('Desktop') }}</a></li>
     <li><a href="http://addons.mozilla.org/">{{ _('Add-Ons') }}</a></li>
-    <li><a href="http://support.mozilla.com/">{{ _('Support') }}</a></li>
+    <li><a href="http://support.mozilla.org/">{{ _('Support') }}</a></li>
     <li><a href="http://mozilla.org/">{{ _('Visit Mozilla') }}</a></li>
   </ul>
   <div class="tab"><a href="#">{# L10n: a link #}{{ _('menu') }}</a></div>


### PR DESCRIPTION
#1397 