### PR TITLE
Fix NETAPP_STORAGE_ROOT override in stats related cron tasks

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -46,15 +46,7 @@ HOME=/tmp
 # Collect visitor stats from Google Analytics once per day.
 50 10 * * * %(z_cron)s update_google_analytics
 
-# Update ADI metrics from HIVE.
-# Once per day after 1000 UTC (after hive queries + transfer is done)
-00 16 * * * NETAPP_STORAGE_ROOT='/var/tmp' %(django)s update_counts_from_file
-30 16 * * * NETAPP_STORAGE_ROOT='/var/tmp' %(django)s download_counts_from_file
-35 16 * * * NETAPP_STORAGE_ROOT='/var/tmp' %(django)s theme_update_counts_from_hive
-00 17 * * * NETAPP_STORAGE_ROOT='/var/tmp' %(django)s theme_update_counts_from_file
-00 18 * * * NETAPP_STORAGE_ROOT='/var/tmp' %(django)s update_theme_popularity_movers
-
-# Once per day after metrics is done (see above)
+# Once per day after metrics import is done
 00 17 * * * %(z_cron)s update_addon_download_totals
 05 17 * * * %(z_cron)s weekly_downloads
 55 17 * * * %(z_cron)s update_global_totals
@@ -65,5 +57,15 @@ HOME=/tmp
 
 # Once per week
 45 7 * * 4 %(z_cron)s unconfirmed
+
+# Update ADI metrics from HIVE.
+# Once per day after 1000 UTC (after hive queries + transfer is done)
+NETAPP_STORAGE_ROOT='/var/tmp'
+00 16 * * * %(django)s update_counts_from_file
+30 16 * * * %(django)s download_counts_from_file
+00 17 * * * %(django)s theme_update_counts_from_file
+00 18 * * * %(django)s update_theme_popularity_movers
+
+# Do not put crons below this line
 
 MAILTO=root


### PR DESCRIPTION
I foolishly put NETAPP_STORAGE_ROOT inline which doesn't work the way as expected since gen-cron.py populates this template. I also removed theme_update_counts_from_hive since this actually no longer needs to run since we are doing a push from HIVE.