### PR TITLE
Optimize theme-related statistics generation queries

### DIFF
--- a/apps/addons/cron.py
+++ b/apps/addons/cron.py
@@ -19,10 +19,10 @@ import amo
 from amo.celery import task
 from amo.decorators import write
 from amo.utils import chunked, walkfiles
-from addons.models import Addon, AppSupport, FrozenAddon, Persona
+from addons.models import Addon, AppSupport, FrozenAddon
 from files.models import File
 from lib.es.utils import raise_if_reindex_in_progress
-from stats.models import ThemeUserCount, UpdateCount
+from stats.models import UpdateCount
 
 log = logging.getLogger('z.cron')
 task_log = logging.getLogger('z.task')
@@ -134,35 +134,6 @@ def _update_addon_average_daily_users(data, **kw):
             addon.update(average_daily_users=addon.total_downloads)
         else:
             addon.update(average_daily_users=count)
-
-
-@cronjobs.register
-def update_daily_theme_user_counts():
-    """Store the day's theme popularity counts into ThemeUserCount."""
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
-    raise_if_reindex_in_progress('amo')
-    d = Persona.objects.values_list('addon', 'popularity').order_by('id')
-
-    date = datetime.now().strftime('%M-%d-%y')
-    ts = [_update_daily_theme_user_counts.subtask(args=[chunk],
-                                                  kwargs={'date': date})
-          for chunk in chunked(d, 250)]
-    TaskSet(ts).apply_async()
-
-
-@task
-def _update_daily_theme_user_counts(data, **kw):
-    task_log.info("[%s] Updating daily theme user counts for %s."
-                  % (len(data), kw['date']))
-
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
-    for pk, count in data:
-        ThemeUserCount.objects.create(addon_id=pk, count=count,
-                                      date=datetime.now())
 
 
 @cronjobs.register

--- a/apps/amo/celery.py
+++ b/apps/amo/celery.py
@@ -5,14 +5,16 @@ from __future__ import absolute_import
 
 import datetime
 
+from django.conf import settings
+from django.core.cache import cache
+
 import commonware.log
 from celery import Celery
 from celery.signals import task_failure, task_postrun, task_prerun
-from django.conf import settings
-from django.core.cache import cache
+from celery.task.sets import TaskSet
 from django_statsd.clients import statsd
 
-from amo.utils import utc_millesecs_from_epoch
+from amo.utils import chunked, utc_millesecs_from_epoch
 
 
 log = commonware.log.getLogger('z.task')
@@ -91,3 +93,13 @@ class TaskTimer(object):
 
     def cache_key(self, task_id):
         return 'task_start_time.{}'.format(task_id)
+
+
+def create_subtasks(task, qs, chunk_size, *args):
+    """
+    Splits a task depending on a queryset into a bunch of subtasks of the
+    specified chunk_size, passing a chunked queryset and optional additional
+    arguments to each."""
+    ts = [task.subtask(args=(chunk,) + args)
+          for chunk in chunked(qs, chunk_size)]
+    TaskSet(ts).apply_async()

--- a/apps/stats/management/commands/update_theme_popularity_movers.py
+++ b/apps/stats/management/commands/update_theme_popularity_movers.py
@@ -5,8 +5,7 @@ from django.db import connection
 
 import commonware.log
 
-from addons.models import Persona
-from stats.models import ThemeUpdateCount, ThemeUpdateCountBulk
+from stats.models import ThemeUpdateCount, ThemeUpdateCountBulk, ThemeUserCount
 
 
 log = commonware.log.getLogger('adi.themepopularitymovers')
@@ -31,43 +30,55 @@ class Command(BaseCommand):
         start = datetime.datetime.now()  # Measure the time it takes to run.
         # The theme_update_counts_from_* gather data for the day before, at
         # best.
-        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+        today = datetime.date.today()
+        yesterday = today - datetime.timedelta(days=1)
 
-        # Average number of users over the last 7 days (0 to 6 days ago).
+        # Average number of users over the last 7 days (0 to 6 days ago), in
+        # a list of tuples (addon_id, persona_id, count)
         last_week_avgs = ThemeUpdateCount.objects.get_range_days_avg(
-            start=yesterday - datetime.timedelta(days=6), end=yesterday)
+            yesterday - datetime.timedelta(days=6),
+            yesterday,
+            'addon__persona__id')
 
         # Average number of users over the three weeks before last week
-        # (7 to 27 days ago).
-        prev_3_weeks_avgs = ThemeUpdateCount.objects.get_range_days_avg(
-            start=yesterday - datetime.timedelta(days=27),
-            end=yesterday - datetime.timedelta(days=7))
-
-        # Perf: memoize the addon to persona relation.
-        addon_to_persona = dict(Persona.objects.values_list('addon_id', 'id'))
+        # (7 to 27 days ago), in dictionary form ({addon_id: count}).
+        prev_3_weeks_avgs = dict(ThemeUpdateCount.objects.get_range_days_avg(
+            yesterday - datetime.timedelta(days=27),
+            yesterday - datetime.timedelta(days=7)))
 
         temp_update_counts = []
+        theme_user_counts = []
 
-        for addon_id, popularity in last_week_avgs.iteritems():
-            if addon_id not in addon_to_persona:
+        for addon_id, persona_id, popularity in last_week_avgs:
+            if not persona_id or not addon_id:
                 continue
             # Create the temporary ThemeUpdateCountBulk for later bulk create.
             prev_3_weeks_avg = prev_3_weeks_avgs.get(addon_id, 0)
-            tucb = ThemeUpdateCountBulk(
-                persona_id=addon_to_persona[addon_id],
+            theme_update_count_bulk = ThemeUpdateCountBulk(
+                persona_id=persona_id,
                 popularity=popularity,
                 movers=0)
             # Set movers to 0 if values aren't high enough.
             if popularity > 100 and prev_3_weeks_avg > 1:
-                tucb.movers = (
+                theme_update_count_bulk.movers = (
                     popularity - prev_3_weeks_avg) / prev_3_weeks_avg
-            temp_update_counts.append(tucb)
+
+            theme_user_count = ThemeUserCount(
+                addon_id=addon_id,
+                count=popularity,
+                date=today  # ThemeUserCount date is the processing date.
+            )
+
+            temp_update_counts.append(theme_update_count_bulk)
+            theme_user_counts.append(theme_user_count)
 
         # Create in bulk: this is much faster.
         ThemeUpdateCountBulk.objects.all().delete()  # Clean slate first.
         ThemeUpdateCountBulk.objects.bulk_create(temp_update_counts, 100)
+        ThemeUserCount.objects.bulk_create(theme_user_counts, 100)
 
-        # Update in bulk from the above temp table: again, much faster.
+        # Update Personas table in bulk from the above temp table: again, much
+        # faster.
         raw_query = """
             UPDATE personas p, theme_update_counts_bulk t
             SET p.popularity=t.popularity,

--- a/apps/stats/models.py
+++ b/apps/stats/models.py
@@ -88,17 +88,16 @@ class UpdateCount(StatsSearchMixin, models.Model):
 
 class ThemeUpdateCountManager(models.Manager):
 
-    def get_range_days_avg(self, start, end):
-        """Return a a dict of the average number of users (count) over the
-        given range of days, per addons."""
-        averages = (self.values('addon_id')
-                        .filter(date__range=[start, end])
-                        .annotate(avg=models.Avg('count')))
-        # Transform the queryset from a list of dicts
-        #   [{'addon_id': id1, 'count__avg': avg1], {'addon_id': id2, ...
-        # to a dict
-        #   {id1: avg1, id2: avg2, ...}
-        return dict((d['addon_id'], d['avg']) for d in averages)
+    def get_range_days_avg(self, start, end, *extra_fields):
+        """Return a a ValuesListQuerySet containing the addon_id and popularity
+        for each theme where popularity is the average number of users (count)
+        over the given range of days passed as start / end arguments.
+
+        If extra_fields are passed, then the list of fields is returned in the
+        queryset, inserted after addon_id but before popularity."""
+        return (self.values_list('addon_id', *extra_fields)
+                    .filter(date__range=[start, end])
+                    .annotate(avg=models.Avg('count')))
 
 
 class ThemeUpdateCount(StatsSearchMixin, models.Model):

--- a/apps/stats/search.py
+++ b/apps/stats/search.py
@@ -11,6 +11,14 @@ from stats.models import (CollectionCount, DownloadCount, StatsSearchMixin,
                           UpdateCount)
 
 
+# Number of elements to index at once in ES. The size of a dict to send to ES
+# should be less than 1000 bytes, and the max size of messages to send to ES
+# can be retrieved with the following command (look for
+# "max_content_length_in_bytes"):
+#  curl http://HOST:PORT/_nodes/?pretty
+CHUNK_SIZE = 10000
+
+
 def es_dict(items):
     if not items:
         return {}

--- a/apps/stats/tests/test_commands.py
+++ b/apps/stats/tests/test_commands.py
@@ -13,7 +13,8 @@ import amo.tests
 from addons.models import Addon, Persona
 from stats.management.commands.download_counts_from_file import is_valid_source
 from stats.management.commands.update_counts_from_file import Command
-from stats.models import DownloadCount, ThemeUpdateCount, UpdateCount
+from stats.models import (DownloadCount, ThemeUpdateCount, ThemeUserCount,
+                          UpdateCount)
 from zadmin.models import DownloadSource
 
 
@@ -192,7 +193,8 @@ class TestADICommand(FixturesFolderMixin, amo.tests.TestCase):
         # 15663 and the persona 575 with addon_id 15679 for the last 28 days.
         # We start from the previous day, as the theme_update_counts_from_*
         # scripts are gathering data for the day before.
-        yesterday = date.today() - timedelta(days=1)
+        today = date.today()
+        yesterday = today - timedelta(days=1)
         for i in range(28):
             d = yesterday - timedelta(days=i)
             ThemeUpdateCount.objects.create(addon_id=15663, count=i, date=d)
@@ -200,6 +202,7 @@ class TestADICommand(FixturesFolderMixin, amo.tests.TestCase):
                                             count=i * 100, date=d)
         # Compute the popularity and movers.
         management.call_command('update_theme_popularity_movers')
+
         p1 = Persona.objects.get(pk=559)
         p2 = Persona.objects.get(pk=575)
 
@@ -208,6 +211,15 @@ class TestADICommand(FixturesFolderMixin, amo.tests.TestCase):
         # calculation is "sum(range(7)) / 7" (or "sum(range(7)) * 100 / 7").
         eq_(p1.popularity, 3)  # sum(range(7)) / 7
         eq_(p2.popularity, 300)  # sum(range(7)) * 100 / 7
+
+        # A ThemeUserCount row should have been created for each Persona with
+        # today's date and the Persona popularity.
+        t1 = ThemeUserCount.objects.get(addon_id=15663)
+        t2 = ThemeUserCount.objects.get(addon_id=15679)
+        eq_(t1.date, today)
+        eq_(t1.count, p1.popularity)
+        eq_(t2.date, today)
+        eq_(t2.count, p2.popularity)
 
         # Three weeks avg (sum(range(21)) / 21) = 10 so (3 - 10) / 10.
         # The movers is computed with the following formula:

--- a/apps/stats/tests/test_cron.py
+++ b/apps/stats/tests/test_cron.py
@@ -81,7 +81,7 @@ class TestTotalContributions(amo.tests.TestCase):
         eq_(float(a.total_contributions), 19.99)
 
 
-@mock.patch('stats.management.commands.index_stats.create_tasks')
+@mock.patch('stats.management.commands.index_stats.create_subtasks')
 class TestIndexStats(amo.tests.TestCase):
     fixtures = ['stats/test_models']
 

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -53,7 +53,6 @@ HOME=/tmp
 00 18 * * * %(z_cron)s update_addon_average_daily_users
 30 18 * * * %(z_cron)s index_latest_stats
 45 18 * * * %(z_cron)s update_addons_collections_downloads
-50 18 * * * %(z_cron)s update_daily_theme_user_counts
 
 # Once per week
 45 7 * * 4 %(z_cron)s unconfirmed


### PR DESCRIPTION
I made this while trying to understand how stats were processed. This gets rid of a task that spawned a bunch of subtasks, and optimizes insertions of `ThemeUserCount`. We no longer need to re-fetch all the themes and generate a bunch of tasks just to copy their popularity values as a result.

I would have liked to also index at the same time but since I'm using `bulk_create()` I don't have the ids of the `ThemeUserCount` rows I'm creating (there is a django pull request to do that, but it'd be limited to postgresql) so I didn't see much value in merging with `index_stats`.

I did clean up `index_stats` however, `--fixup` was broken so I removed it, and I started refactoring the create subtask pattern we're using everywhere.