### PR TITLE
Generate anonymous usernames for FxA (fixes #1000)

### DIFF
--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -340,7 +340,7 @@ class TestRegisterUser(TestCase):
         views.register_user(self.request, self.identity)
         assert user_qs.exists()
         user = user_qs.get()
-        assert user.username == 'me@yeahoo.com'
+        assert user.username.startswith('anonymous-')
         assert user.fxa_id == '9005'
         assert not user.has_usable_password()
         self.login.assert_called_with(self.request, user)
@@ -353,8 +353,7 @@ class TestRegisterUser(TestCase):
         views.register_user(self.request, self.identity)
         assert user_qs.exists()
         user = user_qs.get()
-        assert user.username.startswith('me@yeahoo.com')
-        assert user.username != 'me@yeahoo.com'
+        assert user.username.startswith('anonymous-')
         assert user.fxa_id == '9005'
         assert not user.has_usable_password()
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -133,9 +133,9 @@ class UserManager(BaseUserManager, amo.models.ManagerBase):
     def create_user(self, username, email, password=None, fxa_id=None):
         # We'll send username=None when registering through FxA to try and
         # generate a username from the email.
-        if username is None:
-            username = self._generate_username(email)
         user = self.model(username=username, email=email, fxa_id=fxa_id)
+        if username is None:
+            user.anonymize_username()
         # FxA won't set a password so don't let a user log in with one.
         if password is None:
             user.set_unusable_password()
@@ -154,25 +154,6 @@ class UserManager(BaseUserManager, amo.models.ManagerBase):
         admins = Group.objects.get(name='Admins')
         GroupUser.objects.create(user=user, group=admins)
         return user
-
-    def _generate_username(self, seed):
-        """Generate a username from a seed which is intended to be an email
-        address. If the username is taken a single attempt will be made to
-        append a random number to it and get a unique username.
-        """
-        log.info('Generating username for {}'.format(seed))
-        if self.model.objects.filter(username=seed).exists():
-            # Only make one attempt at generating a new username. This isn't
-            # meant to be exhaustive but to make it difficult to maliciously
-            # prevent someone from signing up. See #967 for more discussion.
-            username = '{seed}-{num}'.format(
-                seed=seed, num=random.randint(1000, 9999))
-            log.warning('Username taken for {} trying {}'.format(
-                seed, username))
-            return username
-        else:
-            log.info('Using seeded username for {}'.format(seed))
-            return seed
 
 
 AbstractBaseUser._meta.get_field('password').max_length = 255
@@ -361,9 +342,26 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase,
 
     @property
     def name(self):
-        return smart_unicode(self.display_name or self.username)
+        if self.display_name:
+            return smart_unicode(self.display_name)
+        elif self.has_anonymous_username():
+            return _('Anonymous')
+        else:
+            return smart_unicode(self.username)
 
     welcome_name = name
+
+    def anonymize_username(self):
+        """Set an anonymous username."""
+        if self.pk:
+            log.info('Anonymizing username for {}'.format(self.pk))
+        else:
+            log.info('Generating username for {}'.format(self.email))
+        self.username = 'anonymous-{}'.format(os.urandom(16).encode('hex'))
+        return self.username
+
+    def has_anonymous_username(self):
+        return re.match('^anonymous-[0-9a-f]{32}$', self.username)
 
     @amo.cached_property
     def reviews(self):

--- a/apps/users/templates/users/edit.html
+++ b/apps/users/templates/users/edit.html
@@ -30,7 +30,7 @@ data-default-locale="{{ request.LANG|lower }}"
           </p>
           <ul class="formfields">
             <li{% if form.username.errors %} class="error"{% endif %}>
-              <label for="id_username">{{ _('Username') }} {{ required() }}</label>
+              <label for="id_username">{{ _('Username') }}</label>
               {{ form.username }}
               {{ form.username.errors }}
             </li>

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -66,6 +66,16 @@ class TestUserProfile(amo.tests.TestCase):
         eq_(u2.welcome_name, 'Sarah Connor')
         eq_(u3.welcome_name, '')
 
+    def test_welcome_name_anonymous(self):
+        user = UserProfile()
+        user.anonymize_username()
+        assert user.welcome_name == 'Anonymous'
+
+    def test_welcome_name_anonymous_with_display(self):
+        user = UserProfile(
+            username='anonymous-foo', display_name='John Connor')
+        assert user.welcome_name == 'John Connor'
+
     def test_add_admin_powers(self):
         u = UserProfile.objects.get(username='jbalogh')
 


### PR DESCRIPTION
This changes how usernames are generated to be `anonymous-{random-data}`. When a `username` matches this pattern and there is no `display_name` the `welcome_name` is set to `_('Anonymous')`.

The demo includes changes from #1173.

![fxa-register-three mov](https://cloud.githubusercontent.com/assets/211578/12098697/7a9764ce-b2e9-11e5-96f1-d19f85bddcca.gif)

This fixes #1000.