### PR TITLE
Don't send real emails on -dev/stage other than user confirmation

### DIFF
--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -426,7 +426,7 @@ def ownership(request, addon_id, addon):
         send_mail(title,
                   t.render(Context({'author': author, 'addon': addon,
                                     'site_url': settings.SITE_URL})),
-                  None, recipients, use_blacklist=False, real_email=True)
+                  None, recipients, use_blacklist=False)
 
     if request.method == 'POST' and all([form.is_valid() for form in fs]):
         # Authors.

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -398,7 +398,7 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase,
         t = loader.get_template('users/email/restricted.ltxt')
         send_mail(_('Your account has been restricted'),
                   t.render(Context({})), None, [self.email],
-                  use_blacklist=False, real_email=True)
+                  use_blacklist=False)
 
     def unrestrict(self):
         log.info(u'User (%s: <%s>) is being unrestricted.' % (self,


### PR DESCRIPTION
Fixes [bug 1237899](https://bugzilla.mozilla.org/show_bug.cgi?id=1237899)

This makes sure that no email is ever sent for real on -dev/stage/local, other
than the two emails that require user confirmation:
- registering
- changing email address