### PR TITLE
Send user to FxA to change password when migrated #1002

### DIFF
--- a/apps/users/helpers.py
+++ b/apps/users/helpers.py
@@ -1,5 +1,6 @@
 import random
 
+from django.conf import settings
 from django.utils.encoding import smart_unicode
 
 import jinja2
@@ -7,6 +8,7 @@ from jingo import register, env
 from tower import ugettext as _
 
 import amo
+from amo.utils import urlparams
 
 
 @register.function
@@ -115,3 +117,13 @@ def user_data(user):
         email = user.email
 
     return {'anonymous': anonymous, 'currency': currency, 'email': email}
+
+
+@register.function
+@jinja2.contextfunction
+def manage_fxa_link(context):
+    user = context['user']
+    base_url = '{host}/settings'.format(
+        host=settings.FXA_CONFIG['content_host'])
+    return urlparams(
+        base_url, uid=user.fxa_id, email=user.email, entrypoint='addons')

--- a/apps/users/templates/users/edit.html
+++ b/apps/users/templates/users/edit.html
@@ -17,6 +17,7 @@ data-default-locale="{{ request.LANG|lower }}"
 <div id="user_edit" class="primary prettyform grid" role="main">
   <form method="post" class="user-input island"
         enctype="multipart/form-data">
+    {% set is_fxa_user = switch_is_active('fxa-auth') and user.source == 'fxa' %}
     {{ csrf() }}
     <div id="user-edit" class="tab-wrapper">
       <div id="user-account" class="tab-panel">
@@ -39,40 +40,48 @@ data-default-locale="{{ request.LANG|lower }}"
               {{ form.email.errors }}
             </li>
             <li>
-              <a href="#acct-password" id="change-acct-password">
-                {{ _('Change Password') }}</a>
+              {% if is_fxa_user %}
+                <a href="{{ manage_fxa_link() }}" target="_blank">
+                  {{ _('Manage Firefox Account...') }}</a>
+              {% else %}
+                <a href="#acct-password" id="change-acct-password">
+                  {{ _('Change Password') }}</a>
+              {% endif %}
             </li>
           </ul>
         </fieldset>
 
-        <fieldset id="acct-password">
-          <legend>{{ _('Password') }}</legend>
-          <p class="sub_legend">
-            {% trans reset_url=url('password_reset_form') -%}
-            Change your password.  If you forgot your password, you can <a href="{{ reset_url }}">use the reset form</a>.
-            {%- endtrans %}
-          </p>
-          <ol class="formfields">
-            <li>
-              <label for="id_oldpassword">{{ _('Old Password') }}</label>
-              {{ form.oldpassword }}
-              {{ form.oldpassword.errors }}
-            </li>
-            <li>
-              {% with form_user=form.instance %}{% include "users/tougher_password.html" %}{% endwith %}
-            </li>
-            <li>
-              <label for="id_password">{{ _('New Password') }}</label>
-              {{ form.password }}
-              {{ form.password.errors }}
-            </li>
-            <li>
-              <label for="id_password2">{{ _('Confirm Password') }}</label>
-              {{ form.password2 }}
-              {{ form.password2.errors }}
-            </li>
-          </ol>
-        </fieldset>
+        {% if not is_fxa_user %}
+          <fieldset id="acct-password">
+            <legend>{{ _('Password') }}</legend>
+            <p class="sub_legend">
+              {% trans reset_url=url('password_reset_form') -%}
+              Change your password.  If you forgot your password, you can <a href="{{ reset_url }}">use the reset form</a>.
+              {%- endtrans %}
+            </p>
+            <ol class="formfields">
+              <li>
+                <label for="id_oldpassword">{{ _('Old Password') }}</label>
+                {{ form.oldpassword }}
+                {{ form.oldpassword.errors }}
+              </li>
+              <li>
+                {% with form_user=form.instance %}{% include "users/tougher_password.html" %}{% endwith %}
+              </li>
+              <li>
+                <label for="id_password">{{ _('New Password') }}</label>
+                {{ form.password }}
+                {{ form.password.errors }}
+              </li>
+              <li>
+                <label for="id_password2">{{ _('Confirm Password') }}</label>
+                {{ form.password2 }}
+                {{ form.password2.errors }}
+              </li>
+            </ol>
+          </fieldset>
+        {% endif %}
+
         <fieldset id="profile-personal">
           <legend>{{ _('Profile') }}</legend>
           <p class="sub_legend">


### PR DESCRIPTION
Fixes #1002. It changes the link to go to FxA in a new tab instead of showing the change password form.

Excitement to follow in video form.

![fxa-change-password mov](https://cloud.githubusercontent.com/assets/211578/12430827/89d1d382-beb7-11e5-99ba-68f64b25dcae.gif)