### PR TITLE
Shift the homepage add-on box shadow a bit

### DIFF
--- a/static/css/impala/hovercards.less
+++ b/static/css/impala/hovercards.less
@@ -93,7 +93,7 @@
         z-index: 25;
         background: #fff;
         border-color: #ccc;
-        .box-shadow(0 0 4px rgba(0,0,0,.4));
+        .box-shadow(2px 2px 6px -2px rgba(0,0,0,.4));
         .more {
             background: #fff;
             display: block;
@@ -197,7 +197,7 @@
             z-index: 25;
             background: #fff;
             border-color: #ccc;
-            .box-shadow(0 0 4px rgba(0,0,0,.4));
+            .box-shadow(2px 2px 6px -2px rgba(0,0,0,.4));
             .summary {
                 background: white;
                 z-index: 26;
@@ -210,7 +210,7 @@
                 z-index: 27;
             }
             &:before {
-                .box-shadow(0 0 4px rgba(0,0,0,.4));
+                .box-shadow(2px 2px 6px -2px rgba(0,0,0,.4));
             }
         }
     }


### PR DESCRIPTION
The box shadow is currently evenly spaced around the "hovercard". But that's not how shadows work and for some reason it bothered me today. I toned it down a bit, perhaps it looks better?

<img width="549" alt="screenshot 2016-01-19 14 39 53" src="https://cloud.githubusercontent.com/assets/211578/12431348/a339b3c8-beba-11e5-9a03-4972c866a78f.png">
> Before

<img width="548" alt="screenshot 2016-01-19 14 54 08" src="https://cloud.githubusercontent.com/assets/211578/12431700/868d6e16-bebc-11e5-8cbb-47997883275e.png">
> After