### PR TITLE
Make it easier to enable the Django Debug Toolbar, and make it work with CSP

### DIFF
--- a/djdt_settings.py
+++ b/djdt_settings.py
@@ -1,0 +1,32 @@
+# To enable the Django Debug Toolbar for local dev add the following line to
+# your local_settings.py file:
+# from djdt_settings import *
+
+from settings import *  # noqa
+
+INSTALLED_APPS += (
+    'debug_toolbar',
+)
+DEBUG_TOOLBAR_PATCH_SETTINGS = False  # Prevent DDT from patching the settings.
+
+MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+
+
+def debug_toolbar_enabled(request):
+    """Callback used by the Django Debug Toolbar to decide when to display."""
+    # We want to make sure to have the DEBUG value at runtime, not the one we
+    # have in this specific settings file.
+    from django.conf import settings
+    return settings.DEBUG
+
+
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': 'settings.debug_toolbar_enabled',
+    'JQUERY_URL': '',  # Use the jquery that's already on the page.
+}
+
+
+# Disable CSP by setting it as report only. We can't enable it because it uses
+# "data:" for its logo, and it uses "unsafe eval" for some panels like the
+# templates or SQL ones.
+CSP_REPORT_ONLY = True

--- a/docs/topics/development/debugging.rst
+++ b/docs/topics/development/debugging.rst
@@ -77,9 +77,7 @@ templates rendered and their context...
 To enable it add the following setting to your ``local_settings.py`` file (you
 may need to create it)::
 
-    DEBUG_TOOLBAR_CONFIG = {
-        "SHOW_TOOLBAR_CALLBACK": "settings.debug_toolbar_enabled",
-    }
+    from djdt_settings import *
 
 All being well it should look like this at the top-right of any web page on
 olympia:
@@ -89,6 +87,13 @@ olympia:
 If clicked, it looks like:
 
 .. image:: /screenshots/django-debug-toolbar-expanded.png
+
+You must know that using the Django Debug Toolbar will slow the website quite a
+lot. You can mitigate this by deselecting the checkbox next to the ``SQL``
+panel.
+
+Also, please note that you should only use the Django Debug Toolbar if you need
+it, as it makes CSP report only for your local dev.
 
 .. _ipdb: https://pypi.python.org/pypi/ipdb
 .. _docker-utils: https://pypi.python.org/pypi/docker-utils

--- a/settings.py
+++ b/settings.py
@@ -82,31 +82,6 @@ TASK_USER_ID = 10968
 # Set to True if we're allowed to use X-SENDFILE.
 XSENDFILE = False
 
-# Enable the Django Debug Toolbar for local dev.
-INSTALLED_APPS += (
-    'debug_toolbar',
-)
-DEBUG_TOOLBAR_PATCH_SETTINGS = False  # Prevent DDT from patching the settings.
-
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
-
-
-def debug_toolbar_disabled(request):
-    """Callback used by the Django Debug Toolbar to decide when to display."""
-    return False
-
-
-def debug_toolbar_enabled(request):
-    """Callback used by the Django Debug Toolbar to decide when to display."""
-    # We want to make sure to have the DEBUG value at runtime, not the one we
-    # have in this specific settings file.
-    from django.conf import settings
-    return settings.DEBUG
-
-
-DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": "settings.debug_toolbar_disabled",
-}
 
 AES_KEYS = {
     'api_key:secret': os.path.join(ROOT, 'apps', 'api', 'tests', 'assets',


### PR DESCRIPTION
Relates to #995 

Fixes #1345
