### PR TITLE
Update amo-validator to 1.10.9

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 -r compiled.txt
-amo-validator==1.10.8
+amo-validator==1.10.9
 amqp==1.4.6
 anyjson==0.3.3
 argparse==1.2.1


### PR DESCRIPTION
This is putting back in the whitelisting for the SDK: https://github.com/mozilla/amo-validator/commit/bf52d011c5afa770d42cb2307621ae860bee6a93