### PR TITLE
Update review email templates (fixes #1316)

### DIFF
--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -742,7 +742,7 @@ class ReviewAddon(ReviewBase):
 
         self.log_action(amo.LOG.REJECT_VERSION)
         template = u'%s_to_sandbox' % self.review_type
-        subject = u'Mozilla Add-ons: %s %s Rejected'
+        subject = u'Mozilla Add-ons: %s %s didn\'t pass review'
         if not self.addon.is_listed:
             template = u'unlisted_to_sandbox'
             subject = u'Mozilla Add-ons: %s %s didn\'t pass review'
@@ -850,7 +850,7 @@ class ReviewFiles(ReviewBase):
 
         self.log_action(amo.LOG.REJECT_VERSION)
         template = u'%s_to_sandbox' % self.review_type
-        subject = u'Mozilla Add-ons: %s %s Rejected'
+        subject = u'Mozilla Add-ons: %s %s didn\'t pass review'
         if not self.addon.is_listed:
             template = u'unlisted_to_sandbox'
             subject = u'Mozilla Add-ons: %s %s didn\'t pass review'

--- a/apps/editors/templates/editors/emails/author_super_review.ltxt
+++ b/apps/editors/templates/editors/emails/author_super_review.ltxt
@@ -1,5 +1,10 @@
-Your add-on, {{ name }} {{ number }}, has been flagged for Admin Review by an editor.
+Hello,
+
+Your add-on, {{ name }} {{ number }}, has been flagged for Admin Review.
 
 Your add-on is still in our review queue, but it will need to be checked by one of our admin reviewers. This means that your review will probably take longer than usual.
 
-If you have any questions or comments, please reply to this email or join #amo-editors on irc.mozilla.org.
+If you have any questions or comments, you can reply to this email or join #amo-editors on irc.mozilla.org. To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
+
+Mozilla Add-ons Team
+{{ SITE_URL }}

--- a/apps/editors/templates/editors/emails/base.ltxt
+++ b/apps/editors/templates/editors/emails/base.ltxt
@@ -1,5 +1,7 @@
+Hello,
+
 {% block content %}{% endblock %}
-If you have any questions or comments on this review, please reply to this email or join #amo-editors on irc.mozilla.org
+If you want to respond to this review, or have any questions about it, please reply to this email or join #amo-editors on irc.mozilla.org. To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
 --
-Mozilla Add-ons
+Mozilla Add-ons Team
 {{ SITE_URL }}

--- a/apps/editors/templates/editors/emails/info.ltxt
+++ b/apps/editors/templates/editors/emails/info.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-A Mozilla Add-ons Editor requested further information from you regarding version {{ number }} of your add-on {{ name }}.
+A reviewer requested further information from you regarding version {{ number }} of your add-on {{ name }}.
 
 {{ reviewer }} wrote:
 

--- a/apps/editors/templates/editors/emails/nominated_to_nominated.ltxt
+++ b/apps/editors/templates/editors/emails/nominated_to_nominated.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been reviewed by an editor and did not meet the criteria for full review. However, your add-on has been granted preliminary review and is now available for download in our gallery at {{ addon_url }}
+Your add-on, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for full review. However, it has been granted preliminary review and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,4 @@ Comments:
 
 {{ tested }}
 
-To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
 {% endblock %}

--- a/apps/editors/templates/editors/emails/nominated_to_preliminary.ltxt
+++ b/apps/editors/templates/editors/emails/nominated_to_preliminary.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been reviewed by an editor and did not meet the criteria for full review. However, your add-on has been granted preliminary review and is now available for download in our gallery at {{ addon_url }}
+Your add-on, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for full review. However, it has been granted preliminary review and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 
 Reviewer:
@@ -10,5 +10,5 @@ Comments:
 
 {{ tested }}
 
-Your add-on will now appear in search results and categories with some limitations. You may re-request full review by addressing the editor's comments and uploading a new version. To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
+Your add-on will now appear in search results and categories with some limitations. You may re-request full review by addressing the reviewer's comments and uploading a new version.
 {% endblock %}

--- a/apps/editors/templates/editors/emails/nominated_to_public.ltxt
+++ b/apps/editors/templates/editors/emails/nominated_to_public.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been fully reviewed by an editor and is now available for download in our gallery at {{ addon_url}}
+Your add-on, {{ name }} {{ number }}, has been fully reviewed and is now available for download in our gallery at {{ addon_url}}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-Your add-on will no longer display warnings and can make full use of features such as contributions and beta channels.  To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
+Your add-on will no longer display warnings and can make full use of features such as contributions and beta channels.
 {% endblock %}

--- a/apps/editors/templates/editors/emails/nominated_to_sandbox.ltxt
+++ b/apps/editors/templates/editors/emails/nominated_to_sandbox.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been reviewed by an editor and did not meet the criteria for being hosted in our gallery.
+Your add-on, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for being hosted in our gallery.
 
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your add-on has been disabled. You may re-request review by addressing the editor's comments and uploading a new version. To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
+This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version.
 {% endblock %}

--- a/apps/editors/templates/editors/emails/notify_update.ltxt
+++ b/apps/editors/templates/editors/emails/notify_update.ltxt
@@ -1,6 +1,6 @@
-Dear editor,
+Dear reviewer,
 
-An add-on you previously reviewed was just updated.
+You're looking great today! Also, an add-on you previously reviewed was just updated.
 
 Add-on Information:
 

--- a/apps/editors/templates/editors/emails/pending_to_preliminary.ltxt
+++ b/apps/editors/templates/editors/emails/pending_to_preliminary.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been preliminarily reviewed by an editor and is now available for download in our gallery at {{ addon_url }}
+Your add-on, {{ name }} {{ number }}, has been preliminarily reviewed and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,4 @@ Comments:
 
 {{ tested }}
 
-To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
 {% endblock %}

--- a/apps/editors/templates/editors/emails/pending_to_public.ltxt
+++ b/apps/editors/templates/editors/emails/pending_to_public.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your {{ addon_type }}, {{ name }} {{ number }}, has been fully reviewed by an editor and is now available for download in our gallery at {{ addon_url }}
+Your {{ addon_type }}, {{ name }} {{ number }}, has been fully reviewed and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,4 @@ Comments:
 
 {{ tested }}
 
-To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
 {% endblock %}

--- a/apps/editors/templates/editors/emails/pending_to_sandbox.ltxt
+++ b/apps/editors/templates/editors/emails/pending_to_sandbox.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your {{ addon_type }}, {{ name }} {{ number }}, has been reviewed by an editor and did not meet the criteria for being hosted in our gallery.
+Your {{ addon_type }}, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for being hosted in our gallery.
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your {{ addon_type }} has been disabled. You may re-request review by addressing the editor's comments and uploading a new version. To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
+This version of your {{ addon_type }} has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version.
 {% endblock %}

--- a/apps/editors/templates/editors/emails/preliminary_to_preliminary.ltxt
+++ b/apps/editors/templates/editors/emails/preliminary_to_preliminary.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }}, {{ number }}, has been preliminarily reviewed by an editor and is now available for download in our gallery at {{ addon_url }}
+Your add-on, {{ name }}, {{ number }}, has been preliminarily reviewed and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-Your add-on will now appear in search results and categories with some limitations. After 10 days you may request full review to remove these limitations and enable additional features. To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
+Your add-on will now appear in search results and categories with some limitations. You may request full review to remove these limitations.
 {% endblock %}

--- a/apps/editors/templates/editors/emails/preliminary_to_sandbox.ltxt
+++ b/apps/editors/templates/editors/emails/preliminary_to_sandbox.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been reviewed by an editor and did not meet the criteria for being hosted in our gallery.
+Your add-on, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for being hosted in our gallery.
 
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your add-on has been disabled. You may re-request review by addressing the editor's comments and uploading a new version. To learn more about the review process, please visit https://addons.mozilla.org/developers/docs/policies/reviews
+This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version.
 {% endblock %}

--- a/apps/editors/templates/editors/emails/super_review.ltxt
+++ b/apps/editors/templates/editors/emails/super_review.ltxt
@@ -1,7 +1,7 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
 Dear Superheroes,
 
-An editor has requested super-review of the following add-on due to security, copyright, or other administrative concerns.
+A reviewer has requested super-review of the following add-on due to security, copyright, or other administrative concerns.
 
 Please open your plethora of knowledge and wield your mighty administrative sword of decision making in the general vicinity of:
 

--- a/apps/editors/tests/test_helpers.py
+++ b/apps/editors/tests/test_helpers.py
@@ -592,7 +592,8 @@ class TestReviewHelper(amo.tests.TestCase):
                 amo.STATUS_DISABLED)
 
             assert len(mail.outbox) == 1
-            assert mail.outbox[0].subject == '%s Rejected' % self.preamble
+            assert mail.outbox[0].subject == (
+                '%s didn\'t pass review' % self.preamble)
             assert 'did not meet the criteria' in mail.outbox[0].body
 
             assert not sign_mock.called
@@ -727,7 +728,8 @@ class TestReviewHelper(amo.tests.TestCase):
                 assert file.status == amo.STATUS_DISABLED
 
             assert len(mail.outbox) == 1
-            assert mail.outbox[0].subject == '%s Rejected' % self.preamble
+            assert mail.outbox[0].subject == (
+                '%s didn\'t pass review' % self.preamble)
             assert 'did not meet the criteria' in mail.outbox[0].body
 
             assert not sign_mock.called
@@ -858,7 +860,8 @@ class TestReviewHelper(amo.tests.TestCase):
                 assert file.status == amo.STATUS_DISABLED
 
             assert len(mail.outbox) == 1
-            assert mail.outbox[0].subject == '%s Rejected' % self.preamble
+            assert mail.outbox[0].subject == (
+                '%s didn\'t pass review' % self.preamble)
             assert 'did not meet the criteria' in mail.outbox[0].body
 
             assert not sign_mock.called


### PR DESCRIPTION
Moved a couple of lines to the base template for consistency, removed
references to editors, and tried to soften the language in a couple of
places. Also updated the review policy URL.

Second try after having lots of fun times with git.