### PR TITLE
Queue tasks when a request is started, only fire them when it's finished (fix #1449)

### DIFF
--- a/apps/amo/celery.py
+++ b/apps/amo/celery.py
@@ -15,12 +15,13 @@ from celery.task.sets import TaskSet
 from django_statsd.clients import statsd
 
 from amo.utils import chunked, utc_millesecs_from_epoch
+from post_request_task.task import PostRequestTask
 
 
 log = commonware.log.getLogger('z.task')
 
 
-app = Celery('olympia')
+app = Celery('olympia', task_cls=PostRequestTask)
 task = app.task
 
 app.config_from_object('django.conf:settings')

--- a/apps/amo/tests/test_celery.py
+++ b/apps/amo/tests/test_celery.py
@@ -2,15 +2,20 @@ import datetime
 import unittest
 from datetime import timedelta
 
+from django.core.signals import request_finished, request_started
+
 import mock
 
 from amo.celery import task
 from amo.utils import utc_millesecs_from_epoch
 
 
+fake_task_func = mock.Mock()
+
+
 @task
 def fake_task(**kw):
-    pass
+    fake_task_func()
 
 
 class TestTaskTiming(unittest.TestCase):
@@ -51,3 +56,34 @@ class TestTaskTiming(unittest.TestCase):
         self.cache.get.return_value = None  # cache miss
         fake_task.delay()
         assert not self.statsd.timing.called
+
+
+class TestTaskQueued(unittest.TestCase):
+    """Test that our celery tasks are queued to be triggered only when the
+    request is finished, thanks to django-post-request-task."""
+    def setUp(self):
+        fake_task_func.reset_mock()
+
+    def test_not_queued_outside_request_response_cycle(self):
+        fake_task.delay()
+        assert fake_task_func.call_count == 1
+
+    def test_queued_inside_request_response_cycle(self):
+        request_started.send(sender=self)
+        fake_task.delay()
+        assert fake_task_func.call_count == 0
+        request_finished.send_robust(sender=self)
+        assert fake_task_func.call_count == 1
+
+    def test_no_dedupe_outside_request_response_cycle(self):
+        fake_task.delay()
+        fake_task.delay()
+        assert fake_task_func.call_count == 2
+
+    def test_dedupe_inside_request_response_cycle(self):
+        request_started.send(sender=self)
+        fake_task.delay()
+        fake_task.delay()
+        assert fake_task_func.call_count == 0
+        request_finished.send_robust(sender=self)
+        assert fake_task_func.call_count == 1

--- a/apps/amo/tests/test_send_mail.py
+++ b/apps/amo/tests/test_send_mail.py
@@ -268,10 +268,10 @@ class TestSendMail(BaseTestCase):
             send_mail('test subject',
                       'test body',
                       recipient_list=['somebody@mozilla.org'])
-        assert send_mail('test subject',
-                         'test body',
-                         async=True,
-                         recipient_list=['somebody@mozilla.org'])
+        send_mail('test subject',
+                  'test body',
+                  async=True,
+                  recipient_list=['somebody@mozilla.org'])
 
     @mock.patch('amo.tasks.EmailMessage')
     def test_async_will_stop_retrying(self, backend):

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -28,6 +28,7 @@ django-extensions==1.2.5
 django-filter==0.7
 django-multidb-router==0.5.1
 django-mysql-pymysql==0.1
+django-post-request-task==0.0.2
 django-quieter-formset==0.4
 django-raven-heka==0.3
 djangorestframework==2.3.12


### PR DESCRIPTION
`request_finished()` is sent only after the view has completed and its transaction
that was started because of `ATOMIC_REQUESTS` has been committed.

The implementation is borrowed from mozilla/zamboni.