### PR TITLE
Fixed line height on header to prevent overlap

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -433,7 +433,6 @@ button.search-button {
         h2, h3 {
             font-size: 36px;
             font-weight: 100;
-            line-height: 1.3em;
             color: #fff;
         }
         h2 {


### PR DESCRIPTION
Was:
<img width="1288" alt="screen shot 2016-01-22 at 1 39 46 pm" src="https://cloud.githubusercontent.com/assets/2600677/12519583/b5744b7a-c10d-11e5-9113-68192616b956.png">
Now is:
<img width="1286" alt="screen shot 2016-01-22 at 1 40 08 pm" src="https://cloud.githubusercontent.com/assets/2600677/12519608/d1327b20-c10d-11e5-91cd-18486221e078.png">
