### PR TITLE
Add X-Content-Type-Options and X-XSS-Protection headers

### DIFF
--- a/apps/amo/tests/test_secure_headers.py
+++ b/apps/amo/tests/test_secure_headers.py
@@ -1,0 +1,12 @@
+import amo.tests
+
+
+class TestSecurityHeaders(amo.tests.TestCase):
+
+    def test_for_security_headers(self):
+        """Test that security headers are set."""
+        response = self.client.get('/en-US/firefox/')
+        assert response.status_code == 200
+        assert response['x-xss-protection'] == '1; mode=block'
+        assert response['x-content-type-options'] == 'nosniff'
+        assert response['x-frame-options'] == 'DENY'

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -325,6 +325,8 @@ MIDDLEWARE_CLASSES = (
     'commonware.middleware.SetRemoteAddrFromForwardedFor',
 
     'commonware.middleware.FrameOptionsHeader',
+    'commonware.middleware.XSSProtectionHeader',
+    'commonware.middleware.ContentTypeOptionsHeader',
     'commonware.middleware.StrictTransportMiddleware',
     'multidb.middleware.PinningRouterMiddleware',
     'waffle.middleware.WaffleMiddleware',


### PR DESCRIPTION
Fixes #1511

Since we're using commonware for other headers and this covered what we wanted in #1511 I've used that.