### PR TITLE
Send better JWT error messages to API clients

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1592,8 +1592,7 @@ JWT_AUTH = {
     # longer expiration.
     'JWT_ALLOW_REFRESH': False,
 
-    # JWTs are only valid for one minute. Note that this setting only applies
-    # to token creation which we don't do (yet?).
+    # JWTs are only valid for one minute.
     'JWT_EXPIRATION_DELTA': datetime.timedelta(
         seconds=MAX_JWT_AUTH_TOKEN_LIFETIME),
 


### PR DESCRIPTION
Fixes #1071

With clock skew, a bad API request gets this response now:

````
< HTTP/1.1 401 UNAUTHORIZED
{"detail": "JWT iat (issued at time) is invalid. Make sure your system clock is synchronized with something like NTP."}
````

I also improved a lot of other error message which were showing generic, non-informative messages before.