### PR TITLE
Change fix-disabled template to use STATIC_URL endpoint

### DIFF
--- a/apps/zadmin/templates/zadmin/fix-disabled.html
+++ b/apps/zadmin/templates/zadmin/fix-disabled.html
@@ -3,7 +3,7 @@
 {% block title %}{{ page_title("Let's Undisable Some Files!") }}{% endblock %}
 
 {% block content %}
-<img title="What Would Jorge Do?" src="https://static.addons.mozilla.net/img/uploads/userpics/0/4/4230.png?modified=1292626484" alt="">
+<img title="What Would Jorge Do?" src="{{ STATIC_URL }}img/uploads/userpics/0/4/4230.png?modified=1292626484" alt="">
 <p>Enter the id of the file you want to rescue from the disabled abyss.</p>
 <form method="post">
   {{ csrf() }}


### PR DESCRIPTION
static.addons.mozilla.net is our CDN origin, we should use STATIC_URL instead.

r?