### PR TITLE
Prevent password reset for migrated users  (fixes #1080)

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -106,6 +106,13 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
     def clean_email(self):
         email = self.cleaned_data['email']
         self.users_cache = UserProfile.objects.filter(email__iexact=email)
+        try:
+            if self.users_cache.get().fxa_id:
+                raise forms.ValidationError(
+                    _('You must recover your password through Firefox '
+                      'Accounts. Try logging in instead.'))
+        except UserProfile.DoesNotExist:
+            pass
         return email
 
     def save(self, **kw):

--- a/apps/users/templates/users/pwreset_confirm.html
+++ b/apps/users/templates/users/pwreset_confirm.html
@@ -8,7 +8,12 @@
 {% block content %}
 <div class="primary" role="main">
 
-  {% if validlink %}
+  {% if migrated %}
+    <div class="notification-box error">
+      <h2>{{ _('Password reset unsuccessful') }}</h2>
+      <div>{{ _('You have migrated to Firefox Accounts. You can no longer change your password here.') }}</div>
+    </div>
+  {% elif validlink %}
     <div class="primary island hero">
       <h1>{{ _('Password Reset') }}</h1>
       <form method="post" class="object-lead user-input prettyform grid">

--- a/apps/users/tests/test_forms.py
+++ b/apps/users/tests/test_forms.py
@@ -107,6 +107,17 @@ class TestPasswordResetForm(UserFormBase):
         assert mail.outbox[0].subject.find('Password reset') == 0
         assert mail.outbox[0].body.find('pwreset/%s' % self.uidb64) > 0
 
+    def test_request_success_migrated(self):
+        self.user.update(fxa_id='555')
+        response = self.client.post(
+            reverse('password_reset_form'),
+            {'email': self.user.email})
+
+        assert len(mail.outbox) == 0
+        assert response.status_code == 200
+        assert ('You must recover your password through Firefox Accounts' in
+                response.content)
+
     def test_request_success_getpersona_password(self):
         """Email is sent even if the user has no password and the profile has
         an "unusable" password according to django's AbstractBaseUser."""


### PR DESCRIPTION
![pwreset-migrated mov](https://cloud.githubusercontent.com/assets/211578/12694229/aab0e6b0-c6eb-11e5-9e44-c490516d427e.gif)
> Migrated user

![pwreset-unmigrated mov](https://cloud.githubusercontent.com/assets/211578/12694230/aac202c4-c6eb-11e5-8c36-4a0938f860cb.gif)
> Unmigrated user