### PR TITLE
Use '*' as the default strict_max_version for WebExtension

### DIFF
--- a/apps/files/tests/test_utils_.py
+++ b/apps/files/tests/test_utils_.py
@@ -378,7 +378,7 @@ class TestManifestJSONExtractor(amo.tests.TestCase):
         firefox_min_version = self.create_appversion('firefox', '30.0')
         firefox_max_version = self.create_appversion('firefox', '30.*')
         self.create_appversion('firefox', '42.0')  # Default AppVersions.
-        self.create_appversion('firefox', '42.*')
+        self.create_appversion('firefox', '*')
         data = {
             'applications': {
                 'gecko': {
@@ -395,7 +395,7 @@ class TestManifestJSONExtractor(amo.tests.TestCase):
         """Use the default min and max versions if none provided."""
         # Default AppVersions.
         firefox_min_version = self.create_appversion('firefox', '42.0')
-        firefox_max_version = self.create_appversion('firefox', '42.*')
+        firefox_max_version = self.create_appversion('firefox', '*')
         data = {'applications': {'gecko': {'id': 'some-id'}}}
         apps = self.parse(data)['apps']
         assert len(apps) == 1  # Only Firefox for now.

--- a/apps/files/utils.py
+++ b/apps/files/utils.py
@@ -297,7 +297,7 @@ class ManifestJSONExtractor(JSONExtractor):
             get_simple_version(self.gecko.get('strict_min_version')) or '42.0')
         strict_max_version = (
             # Not sure what we should default to here.
-            get_simple_version(self.gecko.get('strict_max_version')) or '42.*')
+            get_simple_version(self.gecko.get('strict_max_version')) or '*')
         try:
             min_appver, max_appver = get_appversions(
                 app, strict_min_version, strict_max_version)

--- a/migrations/860-add-appversion-firefox-star.sql
+++ b/migrations/860-add-appversion-firefox-star.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO `appversions`
+SET `created`=NOW(),
+    `modified`=NOW(),
+    `application_id`=1,
+    `version`='*',
+    `version_int`='99000000200100';

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 -r compiled.txt
-amo-validator==1.10.16
+amo-validator==1.10.17
 amqp==1.4.6
 anyjson==0.3.3
 argparse==1.2.1


### PR DESCRIPTION
Fixes #1339

Needs https://github.com/mozilla/amo-validator/pull/391

**/!\ DO NOT MERGE before bumping the amo-validator and fixing the requirements**