### PR TITLE
Revert "Enforce CSP on prod + stage"

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1255,7 +1255,7 @@ PROD_CDN_HOST = 'https://addons.cdn.mozilla.net'
 ANALYTICS_HOST = 'https://ssl.google-analytics.com'
 
 CSP_REPORT_URI = '/__cspreport__'
-CSP_REPORT_ONLY = False
+CSP_REPORT_ONLY = True
 CSP_EXCLUDE_URL_PREFIXES = ()
 
 # NOTE: CSP_DEFAULT_SRC MUST be set otherwise things not set

--- a/settings.py
+++ b/settings.py
@@ -101,6 +101,7 @@ FXA_CONFIG = {
 }
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
+CSP_REPORT_ONLY = False
 CSP_REPORT_URI = '/csp-report'
 
 # Allow GA over http + www subdomain in local development.

--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -10,6 +10,7 @@ env = environ.Env()
 
 # Allow addons-dev CDN for CSP.
 DEV_CDN_HOST = 'https://addons-dev-cdn.allizom.org'
+CSP_REPORT_ONLY = False
 CSP_FONT_SRC += (DEV_CDN_HOST,)
 CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
 CSP_IMG_SRC += (DEV_CDN_HOST,)


### PR DESCRIPTION
Reverts mozilla/olympia#1550

Due to CSP related bugs that are not easily worked-around going to leave Prod in report-only for another week.