### PR TITLE
Always treat blank fxa_id as unmigrated (fixes #1533)

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -103,7 +103,7 @@ def with_user(fn):
                              'request.user: {}, identity_user: {}'.format(
                                  request.user.pk, identity_user.pk))
                     return Response({'error': 'User mismatch.'}, status=422)
-                elif request.user.fxa_id is not None:
+                elif request.user.fxa_migrated():
                     log.info('User already migrated. '
                              'request.user: {}, identity_user: {}'.format(
                                  request.user, identity_user))

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -107,7 +107,7 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
         email = self.cleaned_data['email']
         self.users_cache = UserProfile.objects.filter(email__iexact=email)
         try:
-            if self.users_cache.get().fxa_id:
+            if self.users_cache.get().fxa_migrated():
                 raise forms.ValidationError(
                     _('You must recover your password through Firefox '
                       'Accounts. Try logging in instead.'))

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -335,10 +335,15 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase,
     def source(self):
         if not self.pk:
             return None
-        elif self.fxa_id:
+        elif self.fxa_migrated():
             return 'fxa'
         else:
             return 'amo'
+
+    def fxa_migrated(self):
+        """Return whether the user has a Firefox Accounts id set or not. When
+        this is True the user must log in through Firefox Accounts."""
+        return bool(self.fxa_id)
 
     @property
     def name(self):

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -266,6 +266,18 @@ class TestUserProfile(amo.tests.TestCase):
         assert tuple(user.watching) == (watched_collection1.pk,
                                         watched_collection2.pk)
 
+    def test_fxa_migrated_not_migrated(self):
+        user = UserProfile(fxa_id=None)
+        assert user.fxa_migrated() is False
+
+    def test_fxa_migrated_not_migrated_empty_string(self):
+        user = UserProfile(fxa_id='')
+        assert user.fxa_migrated() is False
+
+    def test_fxa_migrated_migrated(self):
+        user = UserProfile(fxa_id='db27f8')
+        assert user.fxa_migrated() is True
+
 
 class TestPasswords(amo.tests.TestCase):
     utf = u'\u0627\u0644\u062a\u0637\u0628'

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -684,7 +684,7 @@ def password_reset_confirm(request, uidb64=None, token=None):
     except (ValueError, UserProfile.DoesNotExist, TypeError):
         pass
 
-    if (user is not None and user.fxa_id
+    if (user is not None and user.fxa_migrated()
             and waffle.switch_is_active('fxa-auth')):
         migrated = True
         validlink = False
@@ -755,7 +755,7 @@ def migrate(request):
     next_path = request.GET.get('to')
     if not next_path or not is_safe_url(next_path):
         next_path = reverse('home')
-    if not request.user.is_authenticated() or request.user.fxa_id:
+    if not request.user.is_authenticated() or request.user.fxa_migrated():
         return redirect(next_path)
     else:
         return render(request, 'users/fxa_migration.html', {'to': next_path})


### PR DESCRIPTION
Most places were checking `fxa_id` on its own so empty strings were treated as not migrated but it was checking against `None` when the user came back from FxA so that wasn't great. This fixes the `User already migrated` error that would happen and switches all the checks on `fxa_id` to use `fxa_migrated()`.