### PR TITLE
Add disco pane settings for -dev and stage

### DIFF
--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -14,7 +14,11 @@ CSP_REPORT_ONLY = False
 CSP_FONT_SRC += (DEV_CDN_HOST,)
 CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
 CSP_IMG_SRC += (DEV_CDN_HOST,)
-CSP_SCRIPT_SRC += (DEV_CDN_HOST,)
+CSP_SCRIPT_SRC += (
+    # Fix for discovery pane when using services subdomain.
+    'https://addons-dev.allizom.org',
+    DEV_CDN_HOST,
+)
 CSP_STYLE_SRC += (DEV_CDN_HOST,)
 
 ENGAGE_ROBOTS = False

--- a/sites/stage/settings.py
+++ b/sites/stage/settings.py
@@ -12,7 +12,11 @@ STAGE_CDN_HOST = 'https://addons-stage-cdn.allizom.org'
 CSP_FONT_SRC += (STAGE_CDN_HOST,)
 CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
 CSP_IMG_SRC += (STAGE_CDN_HOST,)
-CSP_SCRIPT_SRC += (STAGE_CDN_HOST,)
+CSP_SCRIPT_SRC += (
+    # Fix for discovery pane when using services subdomain.
+    'https://addons.allizom.org',
+    STAGE_CDN_HOST,
+)
 CSP_STYLE_SRC += (STAGE_CDN_HOST,)
 
 ENGAGE_ROBOTS = False


### PR DESCRIPTION
Relates to #995

I'm wanting to test CSP for the discovery pane on -dev and stage. I've filed a separate bug to enable services hosts but for now I can fake the services subdomain using charles proxy. This means I can double check that the fixes for #1579 are good without waiting for it to hit production. 

Also this means that if we do add services.addons-dev.a.o and services.addons.a.o we'll be covered.