### PR TITLE
Fix for prefetching causing CSP violations

### DIFF
--- a/apps/amo/tests/test_csp_headers.py
+++ b/apps/amo/tests/test_csp_headers.py
@@ -11,8 +11,8 @@ class TestCSPHeaders(amo.tests.TestCase):
         """Test that required settings are provided as headers."""
         response = self.client.get('/en-US/firefox/')
         assert response.status_code == 200
-        # Make sure a default-src is locked down.
-        assert "default-src 'none'" in response['content-security-policy']
+        # Make sure a default-src is set.
+        assert "default-src 'self'" in response['content-security-policy']
         # Make sure a object-src is locked down.
         assert "object-src 'none'" in response['content-security-policy']
         # The report-uri should be set.

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1261,7 +1261,7 @@ CSP_EXCLUDE_URL_PREFIXES = ()
 # NOTE: CSP_DEFAULT_SRC MUST be set otherwise things not set
 # will default to being open to anything.
 CSP_DEFAULT_SRC = (
-    "'none'",
+    "'self'",
 )
 CSP_CONNECT_SRC = (
     "'self'",


### PR DESCRIPTION
Fixes #1577

Since the "prefetch" requests made by replaceState don't understand content in context of CSP they fall-back to use the `default-src` directive. Setting default-src to be 'self' fixes that.