### PR TITLE
Update SERVICES_URL for -dev and stage

### DIFF
--- a/sites/dev/settings.py
+++ b/sites/dev/settings.py
@@ -47,7 +47,7 @@ REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY')
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-SERVICES_URL = SITE_URL
+SERVICES_URL = 'https://addons-dev-services.allizom.org'
 STATIC_URL = 'https://addons-dev-cdn.allizom.org/static/'
 MEDIA_URL = 'https://addons-dev-cdn.allizom.org/user-media/'
 

--- a/sites/stage/settings.py
+++ b/sites/stage/settings.py
@@ -44,7 +44,7 @@ REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY')
 DOMAIN = env('DOMAIN', default='addons.allizom.org')
 SERVER_EMAIL = 'zstage@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-SERVICES_URL = SITE_URL
+SERVICES_URL = 'https://addons-services.allizom.org'
 STATIC_URL = 'https://addons-stage-cdn.allizom.org/static/'
 MEDIA_URL = 'https://addons-stage-cdn.allizom.org/user-media/'
 


### PR DESCRIPTION
https://github.com/mozilla/olympia/issues/1555

We have dedicated services endpoints for -dev and stage but they were not configured in SERVICES_URL. This change will make the settings align with prod.

r?