### PR TITLE
Update message tests/format for FxA migration success

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1,5 +1,7 @@
 import base64
 
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.urlresolvers import resolve, reverse
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
@@ -59,37 +61,39 @@ class TestLoginUser(TestCase):
 
     def setUp(self):
         self.request = RequestFactory().get('/login')
+        setattr(self.request, 'session', 'session')
+        messages = FallbackStorage(self.request)
+        setattr(self.request, '_messages', messages)
         self.user = UserProfile.objects.create(
             email='real@yeahoo.com', fxa_id='9001')
         self.identity = {'email': 'real@yeahoo.com', 'uid': '9001'}
         patcher = mock.patch('olympia.accounts.views.login')
         self.login = patcher.start()
         self.addCleanup(patcher.stop)
-        patcher = mock.patch('olympia.accounts.views.messages')
-        self.messages = patcher.start()
-        self.addCleanup(patcher.stop)
 
     def test_user_gets_logged_in(self):
+        assert len(get_messages(self.request)) == 0
         views.login_user(self.request, self.user, self.identity)
         self.login.assert_called_with(self.request, self.user)
-        assert not self.messages.success.called
+        assert len(get_messages(self.request)) == 0
 
     def test_fxa_data_gets_set(self):
+        assert len(get_messages(self.request)) == 0
         self.user.update(fxa_id=None)
         views.login_user(self.request, self.user, self.identity)
         user = self.user.reload()
         assert user.fxa_id == '9001'
         assert not user.has_usable_password()
-        self.messages.success.assert_called_with(
-            self.request, mock.ANY, extra_tags='fxa')
+        assert len(get_messages(self.request)) == 1
 
     def test_email_address_can_change(self):
+        assert len(get_messages(self.request)) == 0
         self.user.update(email='different@yeahoo.com')
         views.login_user(self.request, self.user, self.identity)
         user = self.user.reload()
         assert user.fxa_id == '9001'
         assert user.email == 'real@yeahoo.com'
-        assert not self.messages.success.called
+        assert len(get_messages(self.request)) == 0
 
 
 class TestFindUser(TestCase):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -74,8 +74,8 @@ def login_user(request, user, identity):
         if not user.fxa_migrated():
             messages.success(
                 request,
-                _(u'Great job! You can now log in to Add-ons with your '
-                  'Firefox Account.'),
+                _(u'Great job!'),
+                _(u'You can now log in to Add-ons with your Firefox Account.'),
                 extra_tags='fxa')
         user.update(fxa_id=identity['uid'], email=identity['email'])
     log.info('Logging in user {} from FxA'.format(user))

--- a/static/css/impala/fxa-migration.less
+++ b/static/css/impala/fxa-migration.less
@@ -17,9 +17,16 @@
 .notification-box.fxa {
     background: lighten(@button-green-light, 7.5%);
     border-color: @button-green-light;
+    color: white;
 
     h2 {
         color: white;
         font-family: @head-sans;
+        text-shadow: 0px 0px 2px rgba(0, 0, 0, 0.5);
+    }
+
+    p {
+        font-size: 14px;
+        text-shadow: 0px 0px 2px rgba(0, 0, 0, 0.5);
     }
 }


### PR DESCRIPTION
This updates the tests for the FxA migration success message to use a real message instead of a mock. It also flips it to use the title and message format which is closer to the mocks. I added a slight `text-shadow` so that the text is a bit easier to read.

![screenshot 2016-02-05 09 33 14](https://cloud.githubusercontent.com/assets/211578/12850678/87db8ece-cbeb-11e5-8ac6-4e2d8745059e.png)
> Mock

![screenshot 2016-02-04 13 11 51](https://cloud.githubusercontent.com/assets/211578/12850676/87d62b8c-cbeb-11e5-942e-b7fda7e596c1.png)
> Before

![screenshot 2016-02-05 09 30 37](https://cloud.githubusercontent.com/assets/211578/12850677/87d8fec0-cbeb-11e5-864b-79cc195eb329.png)
> After